### PR TITLE
change GraphQLRequest property names to camelCase

### DIFF
--- a/GraphQL/Common/Request/GraphQLRequest.cs
+++ b/GraphQL/Common/Request/GraphQLRequest.cs
@@ -9,17 +9,17 @@ namespace GraphQL.Common.Request {
 		/// <summary>
 		/// The Query
 		/// </summary>
-		public string Query { get; set; }
+		public string query { get; set; }
 
 		/// <summary>
 		/// If the provided <see cref="Query"/> contains multiple named operations, this specifies which operation should be executed.
 		/// </summary>
-		public string OperationName { get; set; }
+		public string operationName { get; set; }
 
 		/// <summary>
 		/// The Variables
 		/// </summary>
-		public dynamic Variables { get; set; }
+		public dynamic variables { get; set; }
 
 	}
 }


### PR DESCRIPTION
GraphQL documentation for a POST request specs the variables in camel case - "query", "operationName", and "variables". Serializing the GraphQL object as it exists will return an error from case sensitive GraphQL APIs.  (https://graphql.org/learn/serving-over-http/)