### PR TITLE
Add Refresh option to system tray menu

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -154,10 +154,11 @@ public class MainService : ReactiveModel, IMainService
         await _notify.AddMenuAsync(-1, "Start","Icon/Start", StartAsync);
         await _notify.AddMenuAsync(-1, "Stop","Icon/Stop", () =>
         {
-            MonitorsLayout.Options.Enabled = false; 
+            MonitorsLayout.Options.Enabled = false;
             MonitorsLayout.SaveEnabled();
             return _littleBigMouseClientService.StopAsync();
         });
+        await _notify.AddMenuAsync(-1, "Refresh", "Icon/lbm_on", RefreshAsync);
         await _notify.AddMenuAsync(-1, "Exit", "Icon/sys/Close", QuitAsync);
 
         await _notify.SetIconAsync("Icon/lbm_off",128);
@@ -180,6 +181,15 @@ public class MainService : ReactiveModel, IMainService
     }
 
     Task StartAsync() => _littleBigMouseClientService.StartAsync(MonitorsLayout.ComputeZones());
+
+    async Task RefreshAsync()
+    {
+        UpdateLayout();
+        if (MonitorsLayout.Options.Enabled)
+        {
+            await StartAsync();
+        }
+    }
 
     bool _justConnected = false;
     async Task DaemonEventReceived(object? sender, LittleBigMouseServiceEventArgs args)


### PR DESCRIPTION
## Summary
- Adds a "Refresh" option to the system tray context menu
- Allows users to manually refresh the monitor layout without opening the UI

## Motivation
When switching between monitor setups (e.g., docking/undocking laptop), LBM doesn't always auto-detect the change. Users currently have to open the UI, toggle a setting, and press play to force a refresh. This adds a quick one-click refresh from the tray.

## Test plan
- [ ] Right-click tray icon → verify "Refresh" appears between Stop and Exit
- [ ] Click Refresh → verify monitor layout updates
- [ ] If LBM was running, verify it restarts with new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)