### PR TITLE
Switch donations from PayPal to GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Enables GitHub's native "Sponsor" button at the top of the repository.
+github: mgth

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Little Big Mouse (LBM) is an open-source software designed to enhance the multi-
 
 If you find Little Big Mouse helpful, consider supporting the project with a donation. Your contribution helps us maintain and improve the software.
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YLGYPSHWTQ5UW&lc=FR&item_name=LittleBigMouse&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-mgth-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/mgth)
 
 ## Presentation Video
 


### PR DESCRIPTION
PayPal closed donations for individual accounts, so the existing PayPal donate badge no longer works.

- Replace the PayPal donate badge in the README with a GitHub Sponsors badge linking to https://github.com/sponsors/mgth
- Add `.github/FUNDING.yml` (`github: mgth`) to enable GitHub's native "Sponsor" button at the top of the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)