### PR TITLE
Fix issues with games that capture mouse during freelook

### DIFF
--- a/LittleBigMouse.Hook/Engine/MouseEngine.cpp
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.cpp
@@ -488,14 +488,63 @@ void MouseEngine::Reset()
 	_onMouseMoveFunc = &MouseEngine::OnMouseMoveExtFirst;
 }
 
+bool MouseEngine::IsFreelookActive() const
+{
+	// Signal 1: cursor hidden — game called ShowCursor(FALSE), show-count < 0
+	CURSORINFO ci{};
+	ci.cbSize = sizeof(CURSORINFO);
+	GetCursorInfo(&ci);
+	if (!(ci.flags & CURSOR_SHOWING)) return true;
+
+	// Signal 2: cursor clipped to a sub-virtual-desktop rect
+	// Skip this check when LBM itself set the clip (_oldClipRect not empty means
+	// LBM saved the original clip and is managing cursor confinement itself).
+	if (_oldClipRect.IsEmpty())
+	{
+		RECT clip;
+		GetClipCursor(&clip);
+		const int vsLeft   = GetSystemMetrics(SM_XVIRTUALSCREEN);
+		const int vsTop    = GetSystemMetrics(SM_YVIRTUALSCREEN);
+		const int vsRight  = vsLeft + GetSystemMetrics(SM_CXVIRTUALSCREEN);
+		const int vsBottom = vsTop  + GetSystemMetrics(SM_CYVIRTUALSCREEN);
+		if (clip.left > vsLeft || clip.top > vsTop ||
+		    clip.right < vsRight || clip.bottom < vsBottom)
+			return true;
+	}
+
+	return false;
+}
+
 void MouseEngine::OnMouseMove(MouseEventArg& e)
 {
-	//LOG_TRACE(e.Point);
-
-	if(_lock.try_lock())
+	if (_lock.try_lock())
 	{
-		if(_onMouseMoveFunc)
-			(this->*_onMouseMoveFunc)(e);
+		const bool freelook = IsFreelookActive();
+
+		if (freelook)
+		{
+			if (!_wasFreelook)
+			{
+				// Entering freelook: restore any clip LBM had set so the game
+				// gets a clean cursor environment.
+				ResetClip();
+				Reset();
+				_wasFreelook = true;
+				LOG_TRACE("<engine:freelook enter>");
+			}
+			e.Handled = false;
+		}
+		else
+		{
+			if (_wasFreelook)
+			{
+				// Leaving freelook: reinitialise position tracking.
+				_wasFreelook = false;
+				LOG_TRACE("<engine:freelook exit>");
+			}
+			if (_onMouseMoveFunc)
+				(this->*_onMouseMoveFunc)(e);
+		}
 
 		_lock.unlock();
 	}

--- a/LittleBigMouse.Hook/Engine/MouseEngine.h
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.h
@@ -55,6 +55,9 @@ class MouseEngine
 	double _borderResistance = 0;
 	long _borderResistancePixel = 0;
 
+	bool _wasFreelook = false;
+	bool IsFreelookActive() const;
+
 public:
 	SIGNAL<void(std::string&)> OnMessage;
 


### PR DESCRIPTION
Fixes an issue where LBM interferes with games that capture the cursor during freelook. Currently it sometimes allows the cursor to leave the screen, this fixes it by pausing LBM while it detects freelook.

Inspired by #459

Detects when a game hides the cursor or clips it to a sub-screen rect (both common freelook signals) and passes mouse events through unmodified. Uses GetCursorInfo and GetClipCursor; guards against false positives from LBM's own ClipCursor calls via the existing _oldClipRect sentinel.

I tested it in a bunch of different games where I have been having this issue and so far this has completely fixed it for me. There might be some games that capture the mouse in an obscure way that this does not account for but those should be rare.


Closes #439 #438 #411 #388 #363 #355 #327 #321 #302 #255 #221 #207 #195 #184 #163 #125 #97 #61

I had trouble building the whole project so I found I could just build LittleBigMouse.Hook.exe on its own from LittleBigMouse.Hook.vcxproj

For anyone who wants to test without building, a compiled exe is available here: https://github.com/funnything1/LittleBigMouseGameFix/releases/download/v1.0-freelook-fix/LittleBigMouse.Hook.exe

Download LittleBigMouse.Hook.exe and paste it into your LBM installation folder replacing the old file then relaunch LBM