### PR TITLE
Fix cursor plane lock: 4 engine bugs (from PR #460)

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
@@ -46,8 +46,6 @@ public static class ZonesLayoutFactory
             }
         }
 
-        zones.Init();
-
         zones.MaxTravelDistance = layout.Options.MaxTravelDistance;
 
         zones.AdjustPointer = layout.Options.AdjustPointer;
@@ -59,6 +57,11 @@ public static class ZonesLayoutFactory
 
         zones.LoopX = layout.Options.LoopX;
         zones.LoopY = layout.Options.LoopY;
+
+        // Init() computes zone links via ComputeLinks(), which reads MaxTravelDistance:
+        // it must run after the options above are set, otherwise links are built with
+        // default values (cursor stuck at some edges, wrong travel distance).
+        zones.Init();
 
         return zones;
     }

--- a/LittleBigMouse.Hook/Engine/Zone.cpp
+++ b/LittleBigMouse.Hook/Engine/Zone.cpp
@@ -62,7 +62,7 @@ bool Zone::Contains(const geo::Point<double>& mm) const
 geo::Point<long> Zone::InsidePixelsBounds(const geo::Point<long> px) const
 {
     auto x = px.X();
-    auto y = px.X();
+    auto y = px.Y();
 
     if (x < _pixelsBounds.Left()) x = _pixelsBounds.Left();
     else if (x > _pixelsBounds.Right() - 1) x = _pixelsBounds.Right() - 1;
@@ -155,7 +155,7 @@ std::vector<geo::Rect<long>> Reachable(const geo::Rect<long>& source, const geo:
 
 	if(top >= bottom) 
 	{
-        auto start = geo::Rect<long>(left, source.Top(), right, source.Height());
+        auto start = geo::Rect<long>(left, source.Top(), right - left, source.Height());
         auto dest  = geo::Rect<long>(left, target.Top(), right - left, target.Height());
 		return {start,dest};
 	}

--- a/LittleBigMouse.Hook/Engine/ZoneLink.h
+++ b/LittleBigMouse.Hook/Engine/ZoneLink.h
@@ -18,7 +18,7 @@ public:
 	long TargetToPixel;
 
 	double BorderResistance;
-	long BorderResistancePixel;
+	long BorderResistancePixel = 0;
 
 	//long SourceLengthPixel;
 	//long TargetLengthPixel;


### PR DESCRIPTION
Cherry-picks the four engine fixes identified in #460 by @thomcuddihy, rebased onto current master (the original PR predates the net10/Avalonia 12 upgrade and its `LaunchDaemon` changes were superseded by 5eb0100).

## Fixes

- **`Zone::InsidePixelsBounds`** (`Zone.cpp`): took Y from `px.X()` (copy-paste bug), so the clamp corrupted the Y coordinate — cursor locked on a horizontal plane at some edges until Alt+Tab. Root cause of the "cursor stuck / plane lock" reports.
- **`Reachable()`** (`Zone.cpp`): passed `right` as the *width* of the start rect instead of `right - left`, producing oversized transition rects.
- **`ZoneLink::BorderResistancePixel`** (`ZoneLink.h`): left uninitialized when `BorderResistance <= 0` (the ctor only assigns it in the `else` branch) — random border resistance (#389).
- **`ComputeZones()`** (`ZonesLayoutFactory.cs`): called `zones.Init()` before assigning layout options; `ComputeLinks()` reads `MaxTravelDistance`, so links were computed with the default 200.0 instead of the configured value.

## Related issues

Likely addresses #456, #440, #325, #300, #421, #434, #352 (cursor stuck at edges) and #389 (border resistance always active).

Credit to @thomcuddihy for the investigation and original fix (#460).

Built and smoke-tested: hook (MSBuild VS2022 Release x64) + UI (net10 Release x64), daemon launches and connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
