### PR TITLE
Gate freelook detection out of the mouse move hot path

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
@@ -47,6 +47,7 @@ public static class ZonesLayoutFactory
         }
 
         zones.MaxTravelDistance = layout.Options.MaxTravelDistance;
+        zones.FreelookCheckInterval = layout.Options.FreelookCheckInterval;
 
         zones.AdjustPointer = layout.Options.AdjustPointer;
         zones.AdjustSpeed = layout.Options.AdjustSpeed;

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -27,6 +27,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool LoopX { get; set; } = false;
       public bool LoopY { get; set; } = false;
       public double MaxTravelDistance { get; set; } = 200;
+      public double FreelookCheckInterval { get; set; } = 100;
       public bool AdjustPointer { get; set; } = false;
       public bool AdjustSpeed { get; set; } = false;
       public string Algorithm { get; set; } = "Strait";
@@ -93,6 +94,12 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// Helps to prevent cursor to reach monitor too far
    /// </summary>
    double MaxTravelDistance { get; set; }
+
+   /// <summary>
+   /// Interval (ms) between freelook re-checks while a game holds the cursor
+   /// (hidden or clipped). 0 = re-check on every mouse event.
+   /// </summary>
+   double FreelookCheckInterval { get; set; }
 
    /// <summary>
    /// Adjust pointer size with display pixel to dip ratio

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/ZonesLayout.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/ZonesLayout.cs
@@ -14,6 +14,7 @@ namespace LittleBigMouse.Zoning
 
         public string Algorithm { get; set; } = "strait";
         public double MaxTravelDistance { get; set; } = 200.0;
+        public double FreelookCheckInterval { get; set; } = 100.0;
 
         public Zone FromPixel(Point pixel) => MainZones.FirstOrDefault(zone => zone.ContainsPixel(pixel));
         public Zone FromPhysical(Point physical) => Zones.FirstOrDefault(zone => zone.ContainsMm(physical));
@@ -48,6 +49,7 @@ namespace LittleBigMouse.Zoning
                 e => e.PriorityUnhooked,
                 e => e.Algorithm,
                 e => e.MaxTravelDistance,
+                e => e.FreelookCheckInterval,
                 e => e.MainZones);
         }
     }

--- a/LittleBigMouse.Hook/Engine/MouseEngine.cpp
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.cpp
@@ -486,6 +486,9 @@ void MouseEngine::Reset()
 {
 	LOG_TRACE("<engine:Reset>");
 	_onMouseMoveFunc = &MouseEngine::OnMouseMoveExtFirst;
+	// The zone may not survive a layout reload; drop it so nothing
+	// dereferences a stale pointer before OnMouseMoveExtFirst reassigns it.
+	_oldZone = nullptr;
 }
 
 bool MouseEngine::IsFreelookActive() const
@@ -519,31 +522,65 @@ void MouseEngine::OnMouseMove(MouseEventArg& e)
 {
 	if (_lock.try_lock())
 	{
-		const bool freelook = IsFreelookActive();
+		// IsFreelookActive costs ~2µs (GetCursorInfo + GetClipCursor), too much to
+		// pay on every event of a high polling rate mouse. Freelook only matters
+		// when LBM is about to act, so gate the check:
+		// - steady state: only when the cursor touches the current zone border
+		//   (interior moves need pure arithmetic only);
+		// - while in freelook: re-check at the configured interval to detect exit.
+		bool checkFreelook;
 
-		if (freelook)
+		if (_wasFreelook)
 		{
-			if (!_wasFreelook)
-			{
-				// Entering freelook: restore any clip LBM had set so the game
-				// gets a clean cursor environment.
-				ResetClip();
-				Reset();
-				_wasFreelook = true;
-				LOG_TRACE("<engine:freelook enter>");
-			}
-			e.Handled = false;
+			checkFreelook = GetTickCount64() - _lastFreelookCheck
+				>= static_cast<ULONGLONG>(Layout.FreelookCheckIntervalMs);
+		}
+		else if (_onMouseMoveFunc == &MouseEngine::OnMouseMoveExtFirst || !_oldZone)
+		{
+			// Tracking not initialized yet: no zone to gate against.
+			checkFreelook = true;
 		}
 		else
 		{
-			if (_wasFreelook)
+			// Matches the widest acting conditions of both algorithms
+			// (Strait acts from x <= Left() / x >= Right()-1, Cross from !Contains).
+			const auto& bounds = _oldZone->PixelsBounds();
+			checkFreelook =
+				e.Point.X() <= bounds.Left() || e.Point.X() >= bounds.Right() - 1 ||
+				e.Point.Y() <= bounds.Top() || e.Point.Y() >= bounds.Bottom() - 1;
+		}
+
+		if (checkFreelook)
+		{
+			_lastFreelookCheck = GetTickCount64();
+			const bool freelook = IsFreelookActive();
+
+			if (freelook != _wasFreelook)
 			{
-				// Leaving freelook: reinitialise position tracking.
-				_wasFreelook = false;
-				LOG_TRACE("<engine:freelook exit>");
+				if (freelook)
+				{
+					// Entering freelook: restore any clip LBM had set so the game
+					// gets a clean cursor environment.
+					ResetClip();
+					Reset();
+					LOG_TRACE("<engine:freelook enter>");
+				}
+				else
+				{
+					// Leaving freelook: position tracking restarts at next event.
+					LOG_TRACE("<engine:freelook exit>");
+				}
+				_wasFreelook = freelook;
 			}
-			if (_onMouseMoveFunc)
-				(this->*_onMouseMoveFunc)(e);
+		}
+
+		if (_wasFreelook)
+		{
+			e.Handled = false;
+		}
+		else if (_onMouseMoveFunc)
+		{
+			(this->*_onMouseMoveFunc)(e);
 		}
 
 		_lock.unlock();

--- a/LittleBigMouse.Hook/Engine/MouseEngine.h
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.h
@@ -56,6 +56,7 @@ class MouseEngine
 	long _borderResistancePixel = 0;
 
 	bool _wasFreelook = false;
+	ULONGLONG _lastFreelookCheck = 0;
 	bool IsFreelookActive() const;
 
 public:

--- a/LittleBigMouse.Hook/Engine/ZonesLayout.cpp
+++ b/LittleBigMouse.Hook/Engine/ZonesLayout.cpp
@@ -88,6 +88,8 @@ void ZonesLayout::Load(tinyxml2::XMLElement* layoutElement)
 	Unload();
 
 	MaxTravelDistanceSquared = pow(XmlHelper::GetDouble(layoutElement,"MaxTravelDistance"),2);
+	// Missing attribute (older UI) -> 0 -> re-check every event, the pre-throttle behavior.
+	FreelookCheckIntervalMs = XmlHelper::GetLong(layoutElement,"FreelookCheckInterval");
 	AdjustPointer = XmlHelper::GetBool(layoutElement,"AdjustPointer");
 	AdjustSpeed = XmlHelper::GetBool(layoutElement,"AdjustSpeed");
 	LoopX = XmlHelper::GetBool(layoutElement,"LoopX");

--- a/LittleBigMouse.Hook/Engine/ZonesLayout.h
+++ b/LittleBigMouse.Hook/Engine/ZonesLayout.h
@@ -23,6 +23,10 @@ class ZonesLayout
 public:
 	double MaxTravelDistanceSquared = pow(200.0,2.0);
 
+	// Interval (ms) between freelook re-checks while a game holds the cursor
+	// (hidden or clipped). 0 = re-check on every mouse event.
+	long FreelookCheckIntervalMs = 100;
+
 	bool AdjustPointer = false;
 	bool AdjustSpeed = false;
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -148,6 +148,14 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     double _maxTravelDistance = 200.0;
 
     [DataMember]
+    public double FreelookCheckInterval
+    {
+        get => _freelookCheckInterval;
+        set => SetUnsavedValue(ref _freelookCheckInterval, value);
+    }
+    double _freelookCheckInterval = 100.0;
+
+    [DataMember]
     public double MinimalMaxTravelDistance
     {
         get => _minimalMaxTravelDistance;

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -176,6 +176,17 @@
 										ClipValueToMinMax="True"/>
 								</StackPanel>
 
+								<StackPanel Classes="Options">
+									<Label ToolTip.Tip="While a game captures the mouse (hidden or confined cursor), LBM pauses and re-checks the capture state at this interval. Lower values react faster, 0 checks on every mouse event.">Game detection interval (ms)</Label>
+
+									<NumericUpDown
+										Minimum="0"
+										Maximum="1000"
+										Increment="10"
+										Value="{Binding Model.FreelookCheckInterval, FallbackValue=100}"
+										ClipValueToMinMax="True"/>
+								</StackPanel>
+
 								<CheckBox
 									Content="Horizontal loop"
 									IsEnabled="{Binding Path=Model.LoopAllowed, FallbackValue=false}"

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
@@ -80,6 +80,7 @@ public static class PersistencyExtensions
 
         @this.Algorithm = key.GetOrSet("Algorithm", () => "Strait");
         @this.MaxTravelDistance = key.GetOrSet("MaxTravelDistance", () => 200.0);
+        @this.FreelookCheckInterval = key.GetOrSet("FreelookCheckInterval", () => 100.0);
         @this.LoopX = key.GetOrSet("LoopX", () => false);
         @this.LoopY = key.GetOrSet("LoopY", () => false);
 
@@ -165,6 +166,7 @@ public static class PersistencyExtensions
 
         key.SetKey("Algorithm", @this.Algorithm);
         key.SetKey("MaxTravelDistance", @this.MaxTravelDistance);
+        key.SetKey("FreelookCheckInterval", @this.FreelookCheckInterval);
         key.SetKey("LoopX", @this.LoopX);
         key.SetKey("LoopY", @this.LoopY);
 


### PR DESCRIPTION
Follow-up to #465: the freelook detection called `GetCursorInfo` + `GetClipCursor` on **every mouse event**.

## Measured cost (micro-benchmark, VM)

| Call | Cost |
|---|---|
| `GetCursorInfo` | 381 ns |
| `GetClipCursor` | 1 370 ns |
| `GetSystemMetrics` ×4 | 261 ns |
| **Full `IsFreelookActive()`** | **≈ 2.2 µs / event** |
| `GetTickCount64` | 1.5 ns |
| Border gate (pure arithmetic) | 0.5 ns |

At 8 kHz polling: ~1.8 % of a core and +2.2 µs of latency added synchronously in the low-level hook path — the events LBM delays are exactly the ones a hardcore gamer cares about.

## Change

Freelook only matters when LBM is about to act, so the check is now gated:

- **Steady state**: freelook is only consulted when the cursor touches the border of the current zone (pure arithmetic against cached bounds). Interior moves — virtually all events during normal use *and* raw-input gaming — pay **zero system calls** (~4 400× cheaper).
- **While in freelook**: re-check at a configurable interval to detect exit. New option **`FreelookCheckInterval`** (ms, default 100, 0 = every event) exposed in the layout options UI as *Game detection interval*, persisted to the registry and transmitted to the daemon in the `ZonesLayout` XML. A missing attribute (older UI) falls back to 0, i.e. the exact #465 behavior.

The gate matches the widest acting conditions of both algorithms (Strait acts from `x <= Left()` / `x >= Right()-1`, Cross from `!Contains`). `Reset()` now also clears `_oldZone` so the gate can never dereference a zone freed by a layout reload.

## Behavior notes

- A game clipping the cursor *inside* a zone (windowed) never triggers detection — correct, since LBM only acts at zone borders anyway.
- Fullscreen clip → clip edge == zone border → detection fires exactly when needed (#363 scenario).
- Exit from freelook is detected within the configured interval at the next mouse event.

## Testing

- Hook (MSBuild VS2022 Release x64) + UI (net10 Release x64) build clean.
- 3 clip/unclip cycles: engine enters/exits freelook, daemon and UI stable.
- `FreelookCheckInterval` round-trips: registry → options → XML → C++ parse (verified default 100 written to the layout registry key on load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
