### PR TITLE
Rebuild CI: working build pipeline + draft releases on tags

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,115 +1,75 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# Build LittleBigMouse: managed UI (net10 / Avalonia) + native C++ hook (x64).
+# - Push / PR on master: build everything, upload a portable artifact.
+# - Tag v*: additionally compile the InnoSetup installer and attach it to a
+#   draft GitHub release for manual review before publishing.
 
-# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
-# built on .NET Core.
-# To learn how to migrate your existing application to .NET Core,
-# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
-#
-# To configure this workflow:
-#
-# 1. Configure environment variables
-# GitHub sets default environment variables for every workflow run.
-# Replace the variables relative to your project in the "env" section below.
-#
-# 2. Signing
-# Generate a signing certificate in the Windows Application
-# Packaging Project or add an existing signing certificate to the project.
-# Next, use PowerShell to encode the .pfx file using Base64 encoding
-# by running the following Powershell script to generate the output string:
-#
-# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
-# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
-#
-# Open the output file, SigningCertificate_Encoded.txt, and copy the
-# string inside. Then, add the string to the repo as a GitHub secret
-# and name it "Base64_Encoded_Pfx."
-# For more information on how to configure your signing certificate for
-# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
-#
-# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
-# See "Build the Windows Application Packaging project" below to see how the secret is used.
-#
-# For more information on GitHub Actions, refer to https://github.com/features/actions
-# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
-# refer to https://github.com/microsoft/github-actions-for-desktop-apps
-
-name: .NET Core Desktop
+name: Build
 
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  UI_PROJECT: LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\LittleBigMouse.Ui.Avalonia.csproj
+  HOOK_PROJECT: LittleBigMouse.Hook\LittleBigMouse.Hook.vcxproj
+  UI_OUTPUT: LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0
 
 jobs:
-
   build:
-
-    strategy:
-      matrix:
-        configuration: [Debug, Release]
-
-    runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-
-    env:
-      Solution_Name: LittleBigMouse                                        # Replace with your solution name, i.e. MyWpfApp.sln.
-      # Test_Project_Path: LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia      # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      Wap_Project_Directory: LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia  # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
-      Wap_Project_Path: LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\LittleBigMouse.Ui.Avalonia.csproj       # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
+    runs-on: windows-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - name: Checkout (with submodules)
+      uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        submodules: recursive
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
+    - name: Install .NET SDK
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
 
-    # Execute all unit tests in the solution
-    # - name: Execute unit tests
-    #   run: dotnet test
+    - name: Build UI (net10, x64 Release)
+      run: dotnet build $env:UI_PROJECT -c Release -p:Platform=x64
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
+    - name: Build hook (C++, x64 Release)
+      run: msbuild $env:HOOK_PROJECT /m /p:Configuration=Release /p:Platform=x64
 
-    # Decode the base 64 encoded pfx and save the Signing_Certificate
-    - name: Decode the pfx
+    - name: Stage hook next to UI output
+      run: Copy-Item LittleBigMouse.Hook\bin\x64\Release\LittleBigMouse.Hook.exe $env:UI_OUTPUT\
+
+    - name: Upload portable artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: LittleBigMouse-portable
+        path: |
+          ${{ env.UI_OUTPUT }}
+          !${{ env.UI_OUTPUT }}\runtimes\linux*\**
+          !${{ env.UI_OUTPUT }}\runtimes\osx*\**
+
+    - name: Compile installer (InnoSetup)
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        $pfx_cert_byte = [System.Convert]::FromBase64String("${{ secrets.Base64_Encoded_Pfx }}")
-        $certificatePath = Join-Path -Path $env:Wap_Project_Directory -ChildPath GitHubActionsWorkflow.pfx
-        [IO.File]::WriteAllBytes("$certificatePath", $pfx_cert_byte)
+        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" LittleBigMouse.Setup\LittleBigMouse.iss
 
-    # Create the app package by building and packaging the Windows Application Packaging project
-    - name: Create the app package
-      run: msbuild $env:Wap_Project_Path /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:Appx_Package_Build_Mode /p:AppxBundle=$env:Appx_Bundle /p:PackageCertificateKeyFile=GitHubActionsWorkflow.pfx /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
-      env:
-        Appx_Bundle: Always
-        Appx_Bundle_Platforms: x86|x64
-        Appx_Package_Build_Mode: StoreUpload
-        Configuration: ${{ matrix.configuration }}
-
-    # Remove the pfx
-    - name: Remove the pfx
-      run: Remove-Item -path $env:Wap_Project_Directory\GitHubActionsWorkflow.pfx
-
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+    - name: Upload installer artifact
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/upload-artifact@v4
       with:
-        name: MSIX Package
-        path: ${{ env.Wap_Project_Directory }}\AppPackages
+        name: LittleBigMouse-installer
+        path: LittleBigMouse.Setup\LittleBigMouse_*.exe
+
+    - name: Create draft release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: true
+        files: LittleBigMouse.Setup\LittleBigMouse_*.exe
+        generate_release_notes: true

--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -1,5 +1,5 @@
-; -- LittleBigMouse.iss --
-#define AppVer GetVersionNumbersString('..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net8.0\LittleBigMouse.Ui.Avalonia.exe')
+﻿; -- LittleBigMouse.iss --
+#define AppVer GetVersionNumbersString('..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\LittleBigMouse.Ui.Avalonia.exe')
 ;#define AppVer '5.0.0'
 
 [Setup]
@@ -15,15 +15,15 @@ ArchitecturesInstallIn64BitMode=x64
 OutputBaseFilename=LittleBigMouse_{#AppVer}
 
 [Files]
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net8.0\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
+Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
 Source: "..\LittleBigMouse.Hook\bin\x64\Release\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net8.0\*.dll"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net8.0\*.xml"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net8.0\*.json"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
+Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.dll"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
+Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.xml"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
+Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.json"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
 
-;Source: "..\bin\x86\Release\net8.0\*.exe"; DestDir: "{app}"; Check: not Is64BitInstallMode
-;Source: "..\bin\x86\Release\net8.0\*.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
-;Source: "..\bin\x86\Release\net8.0\*.xml"; DestDir: "{app}"; Check: not Is64BitInstallMode; Flags: recursesubdirs
+;Source: "..\bin\x86\Release\net10.0\*.exe"; DestDir: "{app}"; Check: not Is64BitInstallMode
+;Source: "..\bin\x86\Release\net10.0\*.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
+;Source: "..\bin\x86\Release\net10.0\*.xml"; DestDir: "{app}"; Check: not Is64BitInstallMode; Flags: recursesubdirs
 
 [Icons]
 Name: "{group}\Little Big Mouse"; Filename: "{app}\LittleBigMouse.Ui.Avalonia.exe"
@@ -35,3 +35,4 @@ Filename: {app}\LittleBigMouse.Ui.Avalonia.exe; Description: Run Application; Fl
 ;Filename: "{cmd}"; Parameters: "/C ""taskkill /im LittleBigMouse.Ui.Avalonia.exe /f /t"
 ;Filename: "{cmd}"; Parameters: "/C ""taskkill /im LittleBigMouse.Hook.exe /f /t"
 ;Filename: "{app}\LittleBigMouse_Daemon.exe"; Parameters: "--unschedule --exit"
+


### PR DESCRIPTION
Rebuild CI: actually build the app, produce artifacts and draft releases

The previous workflow was the stock WPF/MSIX template, never adapted to
this project: no submodule checkout (build could not even restore), dotnet
8, a WAP packaging project that does not exist, and MSIX signing secrets
that were never configured. Every run failed.

New pipeline (windows-latest):
- checkout with recursive submodules (HLab.Core / HLab.Avalonia)
- dotnet 10 build of the Avalonia UI (x64 Release)
- MSBuild of the C++ hook (x64 Release, v143 toolset)
- hook staged next to the UI output so FindHookPath resolves it deployed
- portable artifact uploaded on every push/PR (linux/osx runtimes pruned)
- on v* tags: compiles the InnoSetup installer (preinstalled on runners)
  and attaches it to a DRAFT GitHub release for manual review

LittleBigMouse.iss updated from the stale net8.0 output paths to net10.0.
Installer compile verified locally (InnoSetup 6): LittleBigMouse_5.3.0.0.exe.

Credit to @mezotaken: the submodule + msbuild CI skeleton idea comes from
PR #459.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
