### PR TITLE
Redesign the settings panel and toolbar (Windows 11 style)

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -2,16 +2,96 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:main="clr-namespace:LittleBigMouse.Ui.Avalonia.Main"
              xmlns:icons="clr-namespace:HLab.Icons.Avalonia.Icons;assembly=HLab.Icons.Avalonia"
+             xmlns:controls="clr-namespace:LittleBigMouse.Ui.Avalonia.Controls"
              x:Class="LittleBigMouse.Ui.Avalonia.App"
              RequestedThemeVariant="Default"
 			 x:DataType="main:TrayIconViewModel"
              >
 	<!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+	<!-- Lbm.* brushes live in Application.Resources (not in a Styles include) so that
+	     ThemeDictionaries variant switching notifies DynamicResource subscribers. -->
+	<Application.Resources>
+		<ResourceDictionary>
+
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="{x:Static ThemeVariant.Dark}">
+					<SolidColorBrush x:Key="Lbm.Brushes.Pane.Background" Color="#FF17171C"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Background" Color="#12FFFFFF"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Border" Color="#1EFFFFFF"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Separator" Color="#14FFFFFF"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Text.Primary" Color="#EDEDF0"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Text.Secondary" Color="#9EA0A8"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Badge.Success.Background" Color="#1E3A26"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Badge.Success.Foreground" Color="#7BD08A"/>
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="{x:Static ThemeVariant.Light}">
+					<SolidColorBrush x:Key="Lbm.Brushes.Pane.Background" Color="#FFF2F2F5"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Background" Color="#B3FFFFFF"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Border" Color="#17000000"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Card.Separator" Color="#11000000"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Text.Primary" Color="#1B1B1F"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Text.Secondary" Color="#5F6368"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Badge.Success.Background" Color="#E4F5E9"/>
+					<SolidColorBrush x:Key="Lbm.Brushes.Badge.Success.Foreground" Color="#1B7F3B"/>
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+
+			<SolidColorBrush x:Key="Lbm.Brushes.Accent" Color="{DynamicResource SystemAccentColor}"/>
+			<SolidColorBrush x:Key="Lbm.Brushes.Accent.Faint" Color="{DynamicResource SystemAccentColor}" Opacity="0.22"/>
+
+			<StreamGeometry x:Key="Lbm.Icon.Update">M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Startup">M8,5.14V19.14L19,12.14L8,5.14Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Shield">M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Priority">M17,17H7V7H17M21,11V9H19V7C19,5.89 18.1,5 17,5H15V3H13V5H11V3H9V5H7C5.89,5 5,5.89 5,7V9H3V11H5V13H3V15H5V17C5,18.1 5.89,19 7,19H9V21H11V19H13V21H15V19H17A2,2 0 0,0 19,17V15H21V13H19V11M13,13H11V11H13M15,9H9V15H15V9Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Algorithm">M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Ruler">M1.39,18.36L3.16,16.6L4.58,18L5.64,16.95L4.22,15.54L5.64,14.12L8.11,16.6L9.17,15.54L6.7,13.06L8.11,11.65L9.53,13.06L10.59,12L9.17,10.59L10.59,9.17L13.06,11.65L14.12,10.59L11.65,8.11L13.06,6.7L14.47,8.11L15.54,7.05L14.12,5.64L15.54,4.22L18,6.7L19.07,5.64L16.6,3.16L18.36,1.39L22.61,5.64L5.64,22.61L1.39,18.36Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Gamepad">M7.97,16L5,19C4.67,19.3 4.23,19.5 3.75,19.5A1.75,1.75 0 0,1 2,17.75V17.5L3,10.12C3.21,7.81 5.14,6 7.5,6H16.5C18.86,6 20.79,7.81 21,10.12L22,17.5V17.75A1.75,1.75 0 0,1 20.25,19.5C19.77,19.5 19.33,19.3 19,19L16.03,16H7.97M7,8V10H5V11H7V13H8V11H10V10H8V8H7M16.5,8A0.75,0.75 0 0,0 15.75,8.75A0.75,0.75 0 0,0 16.5,9.5A0.75,0.75 0 0,0 17.25,8.75A0.75,0.75 0 0,0 16.5,8M14.75,9.75A0.75,0.75 0 0,0 14,10.5A0.75,0.75 0 0,0 14.75,11.25A0.75,0.75 0 0,0 15.5,10.5A0.75,0.75 0 0,0 14.75,9.75M18.25,9.75A0.75,0.75 0 0,0 17.5,10.5A0.75,0.75 0 0,0 18.25,11.25A0.75,0.75 0 0,0 19,10.5A0.75,0.75 0 0,0 18.25,9.75M16.5,11.5A0.75,0.75 0 0,0 15.75,12.25A0.75,0.75 0 0,0 16.5,13A0.75,0.75 0 0,0 17.25,12.25A0.75,0.75 0 0,0 16.5,11.5Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.LoopH">M17,17H7V14L3,18L7,22V19H19V13H17M7,7H17V10L21,6L17,2V5H5V11H7V7Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.LoopV">M9,3L5,7H8V14H10V7H13M16,17V10H14V17H11L15,21L19,17H16Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Mouse">M11,1.07C7.05,1.56 4,4.92 4,9H11M4,15A8,8 0 0,0 12,23A8,8 0 0,0 20,15V11H4M13,1.07V9H20C20,4.92 16.94,1.56 13,1.07Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Pointer">M13.64,21.97C13.14,22.21 12.54,22 12.31,21.5L10.13,16.76L7.62,18.78C7.45,18.92 7.24,19 7,19A1,1 0 0,1 6,18V3A1,1 0 0,1 7,2C7.24,2 7.47,2.09 7.64,2.23L7.65,2.22L19.14,11.86C19.57,12.22 19.62,12.85 19.27,13.27C19.12,13.45 18.91,13.57 18.7,13.61L15.54,14.23L17.74,18.96C18,19.46 17.76,20.05 17.26,20.28L13.64,21.97Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Overlap">M22,16A2,2 0 0,1 20,18H8C6.89,18 6,17.1 6,16V4C6,2.89 6.89,2 8,2H20A2,2 0 0,1 22,4V16M16,20V22H4A2,2 0 0,1 2,20V7H4V20H16Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Gap">M18,16V13H15V22H13V2H15V11H18V8L22,12L18,16M2,12L6,16V13H9V22H11V2H9V11H6V8L2,12Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Excluded">M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4C10.1,4 8.4,4.6 7.1,5.7L18.3,16.9C19.3,15.5 20,13.8 20,12A8,8 0 0,0 12,4M5.7,7.1C4.6,8.4 4,10.1 4,12A8,8 0 0,0 12,20C13.9,20 15.6,19.4 16.9,18.3L5.7,7.1Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Trash">M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z</StreamGeometry>
+
+			<ControlTheme x:Key="{x:Type controls:SettingRow}" TargetType="controls:SettingRow">
+				<Setter Property="Padding" Value="14,10"/>
+				<Setter Property="HorizontalAlignment" Value="Stretch"/>
+				<Setter Property="Template">
+					<ControlTemplate>
+						<Grid ColumnDefinitions="Auto,*,Auto" Margin="{TemplateBinding Padding}">
+							<Path Data="{TemplateBinding Icon}"
+							      Fill="{DynamicResource Lbm.Brushes.Text.Secondary}"
+							      Width="18" Height="18" Stretch="Uniform"
+							      VerticalAlignment="Center"
+							      IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"/>
+							<StackPanel Grid.Column="1" Margin="12,0" VerticalAlignment="Center" Spacing="1">
+								<TextBlock Text="{TemplateBinding Header}"
+								           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+								           FontSize="13" TextWrapping="Wrap"/>
+								<TextBlock Text="{TemplateBinding Description}"
+								           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+								           FontSize="12" TextWrapping="Wrap"
+								           IsVisible="{TemplateBinding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+							</StackPanel>
+							<ContentPresenter Grid.Column="2"
+							                  Content="{TemplateBinding Content}"
+							                  ContentTemplate="{TemplateBinding ContentTemplate}"
+							                  VerticalAlignment="Center"/>
+						</Grid>
+					</ControlTemplate>
+				</Setter>
+			</ControlTheme>
+
+		</ResourceDictionary>
+	</Application.Resources>
+
 	<Application.Styles>
 		<FluentTheme DensityStyle="Normal"/>
 		<StyleInclude Source="avares://HLab.Base.Avalonia/Controls/DoubleBox.axaml" />
+		<StyleInclude Source="/Styles/LbmStyles.axaml" />
 	</Application.Styles>
-
-
 
 </Application>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
@@ -14,100 +14,57 @@
 		<controls:LocationControlViewModelDesign/>
 	</Design.DataContext>
 
-	<UserControl.Styles>
-
-		<Style Selector="ListBox.RadioButtonListBox">
-			<Setter Property="BorderBrush" Value="Transparent"/>
-		</Style>
-
-		<Style Selector="ListBox.RadioButtonListBox ListBoxItem">
-			<Setter Property="Padding" Value="6,3,6,4" />
-			<Setter Property="BorderBrush" Value="Transparent" />
-
-			<Style Selector="^:selected">
-				<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-					<Setter Property="Background" Value="Transparent" />
-				</Style>
-			</Style>
-			<Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-				<Setter Property="Background" Value="Transparent" />
-			</Style>
-		</Style>
-
-		<Style Selector="Button.Command">
-			<Setter Property="MinWidth" Value="50"/>
-			<Setter Property="Margin" Value="5,0,0,0" />
-		</Style>
-
-		<Style Selector="Button.Command:disabled /template/ ContentPresenter">
-			<Setter Property="Background" Value="Transparent"/>
-			<Setter Property="Opacity" Value="0.25"/>
-			<Setter Property="OpacityMask" Value="Black"/>
-		</Style>
-		<Style Selector="StackPanel.Options">
-			<Setter Property="Orientation" Value="Vertical"/>
-			<Setter Property="Margin" Value="5,0,0,0"/>
-			<Setter Property="VerticalAlignment" Value="Top"/>
-		</Style>
-	</UserControl.Styles>
-
-	<Grid Margin="20,5">
+	<Grid Margin="14,0">
 		<StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left" Opacity="0.051" OpacityMask="Gray">
 			<icons:IconView
                 Foreground="Black"
-				IconMaxHeight="50"
+				IconMaxHeight="40"
                 Path="icon/lbm_logo"
             />
-			<Label FontSize="40" Foreground="{DynamicResource ThemeForegroundBrush}">Little Big Mouse</Label>
+			<Label FontSize="30" Foreground="{DynamicResource ThemeForegroundBrush}">Little Big Mouse</Label>
 		</StackPanel>
 
+		<StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
 
-		<!--<ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Disabled">-->
-		<!---->
-		<WrapPanel Margin="5" HorizontalAlignment="Right" Orientation="Horizontal">
-			<!--<StackPanel Orientation="Vertical" Margin="5,0,0,0" VerticalAlignment="Center">
-                    <CheckBox  Content="Home Cinema" IsChecked="{Binding Path=Config.HomeCinema, Mode=TwoWay}" Foreground="LightGray"/>
-                </StackPanel>-->
-			<StackPanel Orientation="Horizontal">
+			<Button Classes="ToolbarButton"
+				Click="ImportJSon_Click">
+				<ToolTip.Tip>Import configuration for debugging purpose</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/Sys/LoadJson"/>
+			</Button>
 
-				<Button Classes="Command"
-					Click="ImportJSon_Click">
-					<ToolTip.Tip>Import configuration for debugging purpose</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/Sys/LoadJson"/>
-				</Button>
-				
-				<Button Classes="Command"
-					Click="ExportJSon_Click">
-					<ToolTip.Tip>Export configuration for debugging purpose</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/CopyConfig"/>
-				</Button>
+			<Button Classes="ToolbarButton"
+				Click="ExportJSon_Click">
+				<ToolTip.Tip>Export configuration for debugging purpose</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/CopyConfig"/>
+			</Button>
 
-				<Button Classes="Command"
-					Command="{Binding SaveCommand}">
-					<ToolTip.Tip>Save</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/Save"/>
-				</Button>
+			<Border Classes="ToolbarSeparator"/>
 
-				<Button Classes="Command"
-					Command="{Binding StartCommand}">
-					<ToolTip.Tip>Apply/Start</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/Start"/>
-				</Button>
+			<Button Classes="ToolbarButton"
+				Command="{Binding SaveCommand}">
+				<ToolTip.Tip>Save</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/Save"/>
+			</Button>
 
-				<Button Classes="Command"
-					Command="{Binding StopCommand}">
-					<ToolTip.Tip>Stop</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/Stop"/>
-				</Button>
+			<Button Classes="ToolbarButton"
+				Command="{Binding StartCommand}">
+				<ToolTip.Tip>Apply/Start</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/Start"/>
+			</Button>
 
-				<Button Classes="Command"
-					Command="{Binding UndoCommand}">
-					<ToolTip.Tip>Undo</ToolTip.Tip>
-					<icons:IconView Height="30" Path="Icon/Undo"/>
-				</Button>
+			<Button Classes="ToolbarButton"
+				Command="{Binding StopCommand}">
+				<ToolTip.Tip>Stop</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/Stop"/>
+			</Button>
 
-			</StackPanel>
-		</WrapPanel>
+			<Button Classes="ToolbarButton"
+				Command="{Binding UndoCommand}">
+				<ToolTip.Tip>Undo</ToolTip.Tip>
+				<icons:IconView Height="22" Width="22" Path="Icon/Undo"/>
+			</Button>
+
+		</StackPanel>
 
 	</Grid>
 </UserControl>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/SettingRow.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/SettingRow.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+/// <summary>
+/// A settings-panel row: optional icon, header with optional description,
+/// and a right-aligned control provided as Content.
+/// </summary>
+public class SettingRow : ContentControl
+{
+    public static readonly StyledProperty<Geometry?> IconProperty =
+        AvaloniaProperty.Register<SettingRow, Geometry?>(nameof(Icon));
+
+    public static readonly StyledProperty<string?> HeaderProperty =
+        AvaloniaProperty.Register<SettingRow, string?>(nameof(Header));
+
+    public static readonly StyledProperty<string?> DescriptionProperty =
+        AvaloniaProperty.Register<SettingRow, string?>(nameof(Description));
+
+    public Geometry? Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    public string? Header
+    {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    public string? Description
+    {
+        get => GetValue(DescriptionProperty);
+        set => SetValue(DescriptionProperty, value);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
@@ -40,7 +40,7 @@
 
         <main:PluginsControlsView/>
 
-		<SplitView OpenPaneLength="500" Grid.Row="1" IsPaneOpen="{Binding OptionsIsVisible, Mode = TwoWay}"  PaneBackground="Transparent" >
+		<SplitView OpenPaneLength="440" Grid.Row="1" IsPaneOpen="{Binding OptionsIsVisible, Mode = TwoWay}"  PaneBackground="Transparent" >
 			<SplitView.Pane>
 		        <mvvm:ViewLocator Model="{Binding Options}" />
 			</SplitView.Pane>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
@@ -20,31 +20,42 @@
 
 	</Control.Resources>
 
-	<!--<main:ResizeGrid>-->
-
-    <!-- 
-	    Row 0 : Buttons
-		Row 1 : Screens view panel
-		Row 2 : 
-		Row 3 :
-	-->
-	<Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="*">
-        <Grid.Background>
+	<!-- DockPanel: docked bars are measured first so the center view can never
+	     push the bottom control bar out of the window (a star Grid row would
+	     grow to its content's min height and overflow). -->
+	<DockPanel>
+        <DockPanel.Background>
             <LinearGradientBrush StartPoint="0,0.4" EndPoint="1,0.6">
                 <GradientStop Offset="0" Color="{DynamicResource ThemeBackgroundColor}"/>
                 <GradientStop Offset="0.5" Color="#80808080"/>
                 <GradientStop Offset="0.53" Color="#80606060"/>
                 <GradientStop Offset="1" Color="#40000000"/>
             </LinearGradientBrush>
-        </Grid.Background>
+        </DockPanel.Background>
 
-        <main:PluginsControlsView/>
+        <main:PluginsControlsView DockPanel.Dock="Top"/>
 
-		<SplitView OpenPaneLength="440" Grid.Row="1" IsPaneOpen="{Binding OptionsIsVisible, Mode = TwoWay}"  PaneBackground="Transparent" >
+        <!--Controls for the layout.
+            ZIndex keeps the bar above the presenter view, whose monitor frames
+            can overflow the SplitView cell (the fill child of a DockPanel is
+            declared last, hence painted on top by default).-->
+		<Border
+			DockPanel.Dock="Bottom"
+			ZIndex="1"
+			Classes="Toolbar Bottom">
+
+			<mvvm:ViewLocator
+				ViewClass="{x:Type plugins:IMonitorsLayoutControlViewClass}"
+				ViewMode="{x:Type annotations:DefaultViewMode}"
+				Model="{Binding MainService.MonitorsLayout}"
+					/>
+		</Border>
+
+		<SplitView OpenPaneLength="440" IsPaneOpen="{Binding OptionsIsVisible, Mode = TwoWay}"  PaneBackground="Transparent" ClipToBounds="True" >
 			<SplitView.Pane>
 		        <mvvm:ViewLocator Model="{Binding Options}" />
 			</SplitView.Pane>
-			
+
             <!--Graphical view for the layout-->
 		    <mvvm:ViewLocator
                   ViewClass="{x:Type plugins:IMonitorsLayoutPresenterViewClass}"
@@ -53,19 +64,6 @@
                   Model="{Binding MainService.MonitorsLayout}"
             />
 		</SplitView>
-		
-        <!--Controls for the layout-->
-		<Border
-			Grid.Row="2"
-			Grid.Column="0"
-			Classes="Toolbar Bottom">
-			
-			<mvvm:ViewLocator
-				ViewClass="{x:Type plugins:IMonitorsLayoutControlViewClass}"
-				ViewMode="{x:Type annotations:DefaultViewMode}"
-				Model="{Binding MainService.MonitorsLayout}"
-					/>
-		</Border>
-	</Grid>
+	</DockPanel>
 
 </UserControl>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml
@@ -55,10 +55,10 @@
 		</SplitView>
 		
         <!--Controls for the layout-->
-		<Border 
+		<Border
 			Grid.Row="2"
 			Grid.Column="0"
-			Background="{DynamicResource HLab.Brushes.Header.Active.Background}">
+			Classes="Toolbar Bottom">
 			
 			<mvvm:ViewLocator
 				ViewClass="{x:Type plugins:IMonitorsLayoutControlViewClass}"

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainView.axaml.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
   LittleBigMouse.Control.Core
   Copyright (c) 2021 Mathieu GRENET.  All right reserved.
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/PluginsControlsView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/PluginsControlsView.axaml
@@ -9,24 +9,18 @@
              x:Class="LittleBigMouse.Ui.Avalonia.Main.PluginsControlsView"
              x:DataType="main:MainViewModel"
              >
-	<Grid
-        Background="Transparent"
-        ClipToBounds="False"
-        HorizontalAlignment="Left"
-    >
+	<Border Classes="Toolbar" ClipToBounds="False">
 		<StackPanel Orientation="Horizontal">
-			
-            <ToggleButton IsChecked="{Binding  OptionsIsVisible}">
-                <icons:IconView Height="40"
-                                Width="40"
-                                Margin="5"
-                                Path="Icon/Options" 
-                                ToolTip.Tip="Options"/>
-            </ToggleButton>
 
-			
-			
-			<!--Background="{DynamicResource HLab.Brushes.Header.Active.Background}"-->
+			<ToggleButton Classes="ToolbarButton" IsChecked="{Binding  OptionsIsVisible}">
+				<icons:IconView Height="22"
+				                Width="22"
+				                Path="Icon/Options"
+				                ToolTip.Tip="Options"/>
+			</ToggleButton>
+
+			<Border Classes="ToolbarSeparator"/>
+
 			<ItemsControl
 				Foreground="{DynamicResource HLab.Brushes.Foreground}"
 				ItemsSource="{Binding Commands}"
@@ -45,18 +39,18 @@
 				</ItemsControl.ItemTemplate>
 
 			</ItemsControl>
-			
 
-			<ToggleButton IsChecked="{Binding ViewList}">
-                <icons:IconView Height="40"
-                                Width="40"
-                                Margin="5"
-                                Path="Icon/MonitorList" 
-                                ToolTip.Tip="Switch to list view"
-                />
-            </ToggleButton>
+			<Border Classes="ToolbarSeparator"/>
+
+			<ToggleButton Classes="ToolbarButton" IsChecked="{Binding ViewList}">
+				<icons:IconView Height="22"
+				                Width="22"
+				                Path="Icon/MonitorList"
+				                ToolTip.Tip="Switch to list view"
+				/>
+			</ToggleButton>
 		</StackPanel>
 
-	</Grid>
+	</Border>
 
 </UserControl>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/UIiCommandButton.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/UIiCommandButton.axaml
@@ -13,22 +13,20 @@
         <main:UiCommandDesign />
     </Design.DataContext>
 
-    <ToggleButton      
-        Command="{Binding Command}" 
+    <ToggleButton
+        Classes="ToolbarButton"
+        Command="{Binding Command}"
         CommandParameter="{Binding IsActive}"
         IsChecked="{Binding IsActive}"
         Foreground="{DynamicResource HLab.Brushes.Foreground}"
         >
 
-        <StackPanel>
-            <icons:IconView 
-                Height="40"
-                Width="40"
-                Margin="5"
-                Path="{Binding IconPath}"
-                ToolTip.Tip="{Binding ToolTipText}"
-                />
-        </StackPanel>
+        <icons:IconView
+            Height="22"
+            Width="22"
+            Path="{Binding IconPath}"
+            ToolTip.Tip="{Binding ToolTipText}"
+            />
 
   </ToggleButton>
 </UserControl>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -3,320 +3,268 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:options="clr-namespace:LittleBigMouse.Ui.Avalonia.Options"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:controls="clr-namespace:LittleBigMouse.Ui.Avalonia.Controls"
+             mc:Ignorable="d" d:DesignWidth="440" d:DesignHeight="900"
              x:Class="LittleBigMouse.Ui.Avalonia.Options.LayoutOptions"
              x:DataType="options:LbmOptionsViewModel"
-			 Background="Transparent"
-			 >
-	<UserControl.Styles>
+             Background="Transparent"
+             >
+	<Border Background="{DynamicResource Lbm.Brushes.Pane.Background}">
+		<Grid RowDefinitions="Auto,*">
 
-		<Style Selector="ListBox.RadioButtonListBox">
-			<Setter Property="BorderBrush" Value="Transparent"/>
-		</Style>
-
-		<Style Selector="ListBox.RadioButtonListBox ListBoxItem">
-			<Setter Property="Padding" Value="6,3,6,4" />
-			<Setter Property="BorderBrush" Value="Transparent" />
-
-			<Style Selector="^:selected">
-				<Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-					<Setter Property="Background" Value="Transparent" />
-				</Style>
-			</Style>
-			<Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-				<Setter Property="Background" Value="Transparent" />
-			</Style>
-		</Style>
-
-		<Style Selector="Button.Command">
-			<Setter Property="MinWidth" Value="50"/>
-			<Setter Property="Margin" Value="5,0,0,0" />
-		</Style>
-
-		<Style Selector="Button.Command:disabled /template/ ContentPresenter">
-			<Setter Property="Background" Value="Transparent"/>
-			<Setter Property="Opacity" Value="0.25"/>
-			<Setter Property="OpacityMask" Value="Black"/>
-		</Style>
-		<Style Selector="StackPanel.Options">
-			<Setter Property="Orientation" Value="Vertical"/>
-			<Setter Property="Margin" Value="5,0,0,0"/>
-			<Setter Property="VerticalAlignment" Value="Top"/>
-		</Style>
-	</UserControl.Styles>
-
-	<ScrollViewer>
-		<Grid>
-			<Border Opacity="0.9" Background="{DynamicResource HLab.Brushes.Background}">
-
-				<StackPanel>
-
-					<Grid>
-						<Border
-							Margin="5,10" BorderThickness="2" BorderBrush="{DynamicResource HLab.Brushes.Foreground}" CornerRadius="5"
-							Padding="10">
-							<StackPanel>
-								<CheckBox
-									Content="Auto Check for update"
-									IsChecked="{Binding Path=Model.AutoUpdate, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Enable automatic background checks for updates available online."/>
-
-								<CheckBox
-									Content="Load at startup"
-									IsChecked="{Binding Path=Model.LoadAtStartup, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Enable execution at session startup."/>
-								
-								<CheckBox
-									Content="Start minimized"
-									IsChecked="{Binding Path=Model.StartMinimized, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Minimize to tray at startup."/>
-								
-								<CheckBox
-									Content="Start with elevated privileges"
-									IsChecked="{Binding Path=Model.StartElevated, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Start with elevated privileges."/>
-
-                                <CheckBox
-                                    Content="Elevated"
-                                    IsChecked="{Binding Path=Model.Elevated, FallbackValue=false, Mode=OneWay}"
-									IsEnabled="False"
-                                    ToolTip.Tip="Start with elevated privileges."/>
-								
-								<Label>Daemon Priority</Label>
-								<StackPanel Orientation="Horizontal">
-								<Label VerticalAlignment="Center">Hooked</Label>
-								<ComboBox
-									ItemsSource="{Binding PriorityList}"
-									SelectedItem="{Binding SelectedPriority}">
-
-									<ComboBox.ItemTemplate>
-										<DataTemplate>
-											<Border Background="Transparent">
-												<Label Classes="RadioButtonListBox"
-													   x:DataType="options:ListItem"
-													   Content="{Binding Caption}"
-													   Background="Transparent"
-													   VerticalAlignment="Center"
-													   ToolTip.Tip ="{Binding Description}"/>
-											</Border>
-										</DataTemplate>
-									</ComboBox.ItemTemplate>
-
-								</ComboBox>
-                                <Label VerticalAlignment="Center">Unhooked</Label>
-								<ComboBox
-									ItemsSource="{Binding PriorityList}"
-									SelectedItem="{Binding SelectedPriorityUnhooked}">
-
-									<ComboBox.ItemTemplate>
-										<DataTemplate>
-											<Border Background="Transparent">
-												<Label Classes="RadioButtonListBox"
-													   x:DataType="options:ListItem"
-													   Content="{Binding Caption}"
-													   Background="Transparent"
-													   VerticalAlignment="Center"
-													   ToolTip.Tip ="{Binding Description}"/>
-											</Border>
-										</DataTemplate>
-									</ComboBox.ItemTemplate>
-
-								</ComboBox>
-								</StackPanel>
-							</StackPanel>
-						</Border>
-						<Label
-							Background="{DynamicResource HLab.Brushes.Background}"
-							HorizontalAlignment="Left"
-							VerticalAlignment="Top"
-            >System</Label>
-					</Grid>
-
-
-
-					<Grid>
-						<Border
-							Margin="5,10" BorderThickness="2" BorderBrush="{DynamicResource HLab.Brushes.Foreground}" CornerRadius="5"
-							Padding="10">
-							<StackPanel>
-
-								<StackPanel Classes="Options">
-									<Label ToolTip.Tip="Choose the algorithm to handle screen transitions.">Algorithm</Label>
-
-									<ListBox Classes="RadioButtonListBox"
-											 Background="Transparent"
-											 ItemsSource="{Binding AlgorithmList}"
-											 SelectedItem="{Binding SelectedAlgorithm}">
-
-										<ListBox.ItemTemplate>
-											<DataTemplate>
-												<Border Background="Transparent">
-													<RadioButton Classes="RadioButtonListBox"
-																 x:DataType="options:ListItem"
-																 Content="{Binding Caption}"
-																 Background="Transparent"
-																 VerticalAlignment="Center"
-																 IsChecked="{Binding Path=IsSelected,RelativeSource={RelativeSource AncestorType={x:Type ListBoxItem}},Mode=TwoWay}"
-																 ToolTip.Tip ="{Binding Description}"/>
-												</Border>
-											</DataTemplate>
-										</ListBox.ItemTemplate>
-
-									</ListBox>
-								</StackPanel>
-
-
-								<StackPanel Classes="Options">
-									<Label ToolTip.Tip="Choose the algorithm to handle screen transitions.">Max travel distance</Label>
-
-									<NumericUpDown
-										Minimum="{Binding Model.MinimalMaxTravelDistance, FallbackValue=0}"
-										Increment="10"
-										Value="{Binding Model.MaxTravelDistance, FallbackValue=200}"
-										ClipValueToMinMax="True"/>
-								</StackPanel>
-
-								<StackPanel Classes="Options">
-									<Label ToolTip.Tip="While a game captures the mouse (hidden or confined cursor), LBM pauses and re-checks the capture state at this interval. Lower values react faster, 0 checks on every mouse event.">Game detection interval (ms)</Label>
-
-									<NumericUpDown
-										Minimum="0"
-										Maximum="1000"
-										Increment="10"
-										Value="{Binding Model.FreelookCheckInterval, FallbackValue=100}"
-										ClipValueToMinMax="True"/>
-								</StackPanel>
-
-								<CheckBox
-									Content="Horizontal loop"
-									IsEnabled="{Binding Path=Model.LoopAllowed, FallbackValue=false}"
-									IsChecked="{Binding Path=Model.LoopX, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Allow the cursor to return horizontally by crossing from the opposite side."/>
-								
-								<CheckBox
-									Content="Vertical loop"
-									IsEnabled="{Binding Path=Model.LoopAllowed, FallbackValue=false}"
-									IsChecked="{Binding Path=Model.LoopY, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Allow the cursor to return horizontally by crossing from the opposite side."/>
-
-								<CheckBox
-									Content="Adjust Speed"
-									IsEnabled="{Binding Path=AdjustSpeedAllowed, FallbackValue=false}"
-									IsChecked="{Binding Path=Model.AdjustSpeed, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Adjust the pointer speed when the system doesn't consider the screens ratio"/>
-
-								<CheckBox
-									Content="Adjust Pointer"
-									IsEnabled="{Binding Path=AdjustPointerAllowed, FallbackValue=false}"
-									IsChecked="{Binding Path=Model.AdjustPointer, Mode=TwoWay, FallbackValue=false}"
-									ToolTip.Tip="Adjust the pointer size when the system doesn't consider the screens ratio"/>
-
-							</StackPanel>
-						</Border>
-						<Label
-							Content="Mouse"
-							Background="{DynamicResource HLab.Brushes.Background}"
-							HorizontalAlignment="Left"
-							VerticalAlignment="Top"/>
-					</Grid>
-
-					<Grid>
-						<Border
-							Margin="5,10" BorderThickness="2" BorderBrush="{DynamicResource HLab.Brushes.Foreground}" CornerRadius="5"
-							Padding="10">
-							<StackPanel>
-								<CheckBox
-									Content="Allow overlaps"
-									IsChecked="{Binding Path=Model.AllowOverlaps, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Allow the screens to overlap."/>
-
-								<CheckBox
-									Content="Allow discontinuity"
-									IsChecked="{Binding Path=Model.AllowDiscontinuity, FallbackValue=false, Mode=TwoWay}"
-									ToolTip.Tip="Allow gaps between monitors."/>
-
-							</StackPanel>
-						</Border>
-						<Label
-							Content="Layout"
-							Background="{DynamicResource HLab.Brushes.Background}"
-							HorizontalAlignment="Left"
-							VerticalAlignment="Top"/>
-					</Grid>
-
-					<Grid>
-						<Border
-							Margin="5,10" 
-							BorderThickness="2" 
-							BorderBrush="{DynamicResource HLab.Brushes.Foreground}" 
-							CornerRadius="5"
-							Padding="10">
-
-							<StackPanel>
-								
-								<ListBox
-									ItemsSource="{Binding Model.ExcludedList}"
-									ToolTip.Tip="Those processes will deactivate LittleBigMouse on reaching first plane"
-									SelectedValue="{Binding SelectedExcludedProcess}"
-									>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border Background="Transparent">
-                                                <TextBlock Text="{Binding }"
-                                                           Background="Transparent"
-                                                           VerticalAlignment="Center"
-                                                           ToolTip.Tip ="{Binding }"/>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-								</ListBox>
-								
-								<StackPanel Orientation="Horizontal">
-									<Button Command="{Binding RemoveExcludedProcessCommand}">Remove</Button>
-								</StackPanel>
-								
-								<Label>Match pattern : </Label>
-								<Grid ColumnDefinitions="*,Auto">
-									<TextBox Grid.Column="0" TextWrapping="Wrap" Text="{Binding Pattern, UpdateSourceTrigger=PropertyChanged}"/>
-									<Button Grid.Column="1" Command="{Binding AddExcludedProcessCommand}">Exclude</Button>
-								</Grid>
-								<Label>Seen processes : </Label>
-								<ListBox
-									ItemsSource="{Binding SeenProcesses}"
-									ToolTip.Tip="Those processes will deactivate LittleBigMouse on reaching first plane"
-									SelectedValue="{Binding SelectedSeenProcess}"
-									>
-                                    <ListBox.Styles>
-                                        <Style Selector="Border.match">
-                                            <Setter Property="Background" Value="Green" />
-                                        </Style>
-                                    </ListBox.Styles>
-
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border Classes.match="{Binding Match }">
-                                                <TextBlock
-													x:DataType="options:SeenProcessViewModel"
-													Text="{Binding Caption}"
-													VerticalAlignment="Center"
-													ToolTip.Tip ="{Binding Description}"/>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-									
-								</ListBox>
-							</StackPanel>
-						</Border>
-
-						<Label
-							Content="Excluded processes"
-							Background="{DynamicResource HLab.Brushes.Background}"
-							HorizontalAlignment="Left"
-							VerticalAlignment="Top"/>
-					</Grid>
-				</StackPanel>
+			<Border Grid.Row="0" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Lbm.Brushes.Card.Separator}" Padding="18,12">
+				<Grid ColumnDefinitions="*,Auto">
+					<TextBlock Text="Settings" FontSize="15" FontWeight="SemiBold"
+					           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+					           VerticalAlignment="Center"/>
+					<Border Grid.Column="1" Classes="Badge Success"
+					        IsVisible="{Binding Model.Elevated, FallbackValue=false}"
+					        ToolTip.Tip="LittleBigMouse is running with elevated privileges and can work over elevated apps.">
+						<StackPanel Orientation="Horizontal" Spacing="6">
+							<Path Data="{StaticResource Lbm.Icon.Shield}" Width="12" Height="12" Stretch="Uniform" VerticalAlignment="Center"/>
+							<TextBlock Text="Running elevated" VerticalAlignment="Center"/>
+						</StackPanel>
+					</Border>
+				</Grid>
 			</Border>
-		</Grid>
-	</ScrollViewer>
 
+			<ScrollViewer Grid.Row="1">
+				<StackPanel Margin="16,2,16,18">
+
+					<TextBlock Classes="SectionHeader" Text="General"/>
+
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Update}"
+						                     Header="Check for updates automatically"
+						                     Description="Look for new versions online in the background">
+							<ToggleSwitch IsChecked="{Binding Model.AutoUpdate, FallbackValue=false, Mode=TwoWay}"/>
+						</controls:SettingRow>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Startup}"
+							                     Header="Load at startup"
+							                     Description="Start LittleBigMouse when you sign in">
+								<ToggleSwitch IsChecked="{Binding Model.LoadAtStartup, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Classes="Sub"
+							                     Header="Start minimized to tray">
+								<ToggleSwitch IsChecked="{Binding Model.StartMinimized, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+						</StackPanel>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Shield}"
+						                     Header="Start with elevated privileges"
+						                     Description="Needed to keep working over elevated apps">
+							<ToggleSwitch IsChecked="{Binding Model.StartElevated, FallbackValue=false, Mode=TwoWay}"/>
+						</controls:SettingRow>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Priority}"
+							                     Header="Daemon priority"
+							                     Description="Process priority of the mouse engine"/>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Classes="Sub" Header="While active (hooked)">
+								<ComboBox ItemsSource="{Binding PriorityList}"
+								          SelectedItem="{Binding SelectedPriority}">
+									<ComboBox.ItemTemplate>
+										<DataTemplate>
+											<TextBlock x:DataType="options:ListItem"
+											           Text="{Binding Caption}"
+											           ToolTip.Tip="{Binding Description}"/>
+										</DataTemplate>
+									</ComboBox.ItemTemplate>
+								</ComboBox>
+							</controls:SettingRow>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Classes="Sub" Header="While inactive (unhooked)">
+								<ComboBox ItemsSource="{Binding PriorityList}"
+								          SelectedItem="{Binding SelectedPriorityUnhooked}">
+									<ComboBox.ItemTemplate>
+										<DataTemplate>
+											<TextBlock x:DataType="options:ListItem"
+											           Text="{Binding Caption}"
+											           ToolTip.Tip="{Binding Description}"/>
+										</DataTemplate>
+									</ComboBox.ItemTemplate>
+								</ComboBox>
+							</controls:SettingRow>
+						</StackPanel>
+					</Border>
+
+					<TextBlock Classes="SectionHeader" Text="Mouse"/>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Algorithm}"
+							                     Header="Crossing algorithm"
+							                     Description="How the cursor jumps between screens"/>
+							<ListBox Classes="ChoiceCards" Margin="14,0,6,12"
+							         ItemsSource="{Binding AlgorithmList}"
+							         SelectedItem="{Binding SelectedAlgorithm}">
+								<ListBox.ItemTemplate>
+									<DataTemplate>
+										<StackPanel x:DataType="options:ListItem" Spacing="2">
+											<TextBlock Text="{Binding Caption}" FontSize="13"
+											           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+											<TextBlock Text="{Binding Description}" FontSize="11"
+											           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+											           TextWrapping="Wrap"/>
+										</StackPanel>
+									</DataTemplate>
+								</ListBox.ItemTemplate>
+							</ListBox>
+						</StackPanel>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Ruler}"
+						                     Header="Max travel distance"
+						                     Description="Maximum crossing jump, in pixels">
+							<NumericUpDown Minimum="{Binding Model.MinimalMaxTravelDistance, FallbackValue=0}"
+							               Increment="10"
+							               Value="{Binding Model.MaxTravelDistance, FallbackValue=200}"
+							               ClipValueToMinMax="True"/>
+						</controls:SettingRow>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Gamepad}"
+						                     Header="Game detection interval"
+						                     Description="Re-check mouse capture while gaming, in ms"
+						                     ToolTip.Tip="While a game captures the mouse (hidden or confined cursor), LBM pauses and re-checks the capture state at this interval. Lower values react faster, 0 checks on every mouse event.">
+							<NumericUpDown Minimum="0" Maximum="1000" Increment="10"
+							               Value="{Binding Model.FreelookCheckInterval, FallbackValue=100}"
+							               ClipValueToMinMax="True"/>
+						</controls:SettingRow>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.LoopH}"
+							                     Header="Horizontal loop"
+							                     Description="Re-enter from the opposite side"
+							                     IsEnabled="{Binding Model.LoopAllowed, FallbackValue=false}">
+								<ToggleSwitch IsChecked="{Binding Model.LoopX, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.LoopV}"
+							                     Header="Vertical loop"
+							                     IsEnabled="{Binding Model.LoopAllowed, FallbackValue=false}">
+								<ToggleSwitch IsChecked="{Binding Model.LoopY, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+						</StackPanel>
+					</Border>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Mouse}"
+							                     Header="Adjust pointer speed"
+							                     Description="Keep speed consistent across DPI"
+							                     IsEnabled="{Binding AdjustSpeedAllowed, FallbackValue=false}"
+							                     ToolTip.Tip="Adjust the pointer speed when the system doesn't consider the screens ratio.">
+								<ToggleSwitch IsChecked="{Binding Model.AdjustSpeed, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Pointer}"
+							                     Header="Adjust pointer size"
+							                     Description="Keep size consistent across DPI"
+							                     IsEnabled="{Binding AdjustPointerAllowed, FallbackValue=false}"
+							                     ToolTip.Tip="Adjust the pointer size when the system doesn't consider the screens ratio.">
+								<ToggleSwitch IsChecked="{Binding Model.AdjustPointer, Mode=TwoWay, FallbackValue=false}"/>
+							</controls:SettingRow>
+						</StackPanel>
+					</Border>
+
+					<TextBlock Classes="SectionHeader" Text="Layout"/>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Overlap}"
+							                     Header="Allow overlaps"
+							                     Description="Screens may overlap in the layout">
+								<ToggleSwitch IsChecked="{Binding Model.AllowOverlaps, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+							<Border Classes="SettingSeparator"/>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Gap}"
+							                     Header="Allow discontinuity"
+							                     Description="Gaps between monitors are allowed">
+								<ToggleSwitch IsChecked="{Binding Model.AllowDiscontinuity, FallbackValue=false, Mode=TwoWay}"/>
+							</controls:SettingRow>
+						</StackPanel>
+					</Border>
+
+					<TextBlock Classes="SectionHeader" Text="Excluded processes"/>
+
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Excluded}"
+							                     Header="LBM pauses when these apps are focused"
+							                     Description="Add a process name or pattern"/>
+
+							<ListBox Classes="ProcessList"
+							         ItemsSource="{Binding Model.ExcludedList}"
+							         SelectedValue="{Binding SelectedExcludedProcess}">
+								<ListBox.ItemTemplate>
+									<DataTemplate>
+										<Grid ColumnDefinitions="*,Auto" Background="Transparent">
+											<TextBlock Text="{Binding}" VerticalAlignment="Center" FontSize="13"/>
+											<Button Grid.Column="1" Classes="IconButton"
+											        Command="{Binding $parent[ListBox].((options:LbmOptionsViewModel)DataContext).RemoveExcludedProcessCommand}"
+											        CommandParameter="{Binding}"
+											        ToolTip.Tip="Remove">
+												<Path Data="{StaticResource Lbm.Icon.Trash}" Width="14" Height="14" Stretch="Uniform"/>
+											</Button>
+										</Grid>
+									</DataTemplate>
+								</ListBox.ItemTemplate>
+							</ListBox>
+
+							<Grid ColumnDefinitions="*,Auto" Margin="14,6,14,12">
+								<TextBox Watermark="game.exe or pattern"
+								         Text="{Binding Pattern, UpdateSourceTrigger=PropertyChanged}"
+								         FontSize="13"/>
+								<Button Grid.Column="1" Margin="8,0,0,0"
+								        Command="{Binding AddExcludedProcessCommand}">Exclude</Button>
+							</Grid>
+
+							<Border Classes="SettingSeparator"/>
+
+							<controls:SettingRow Classes="Sub"
+							                     Header="Seen processes"
+							                     Description="Click one to use it as pattern"/>
+							<ListBox Classes="ProcessList"
+							         ItemsSource="{Binding SeenProcesses}"
+							         SelectedValue="{Binding SelectedSeenProcess}"
+							         Margin="0,0,0,8">
+								<ListBox.ItemTemplate>
+									<DataTemplate>
+										<Border Classes.match="{Binding Match}" CornerRadius="4" Padding="4,1" HorizontalAlignment="Left">
+											<Border.Styles>
+												<Style Selector="Border.match">
+													<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>
+												</Style>
+											</Border.Styles>
+											<TextBlock x:DataType="options:SeenProcessViewModel"
+											           Text="{Binding Caption}"
+											           FontSize="13"
+											           VerticalAlignment="Center"
+											           ToolTip.Tip="{Binding Description}"/>
+										</Border>
+									</DataTemplate>
+								</ListBox.ItemTemplate>
+							</ListBox>
+						</StackPanel>
+					</Border>
+
+				</StackPanel>
+			</ScrollViewer>
+		</Grid>
+	</Border>
 </UserControl>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
@@ -34,10 +34,7 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
                 return !string.IsNullOrWhiteSpace(p);
             }));
 
-        RemoveExcludedProcessCommand = ReactiveCommand.Create(
-            RemoveExcludedProcess,
-            this.WhenAnyValue(e => e.SelectedExcludedProcess)
-            .Select(s => !string.IsNullOrWhiteSpace(s)));
+        RemoveExcludedProcessCommand = ReactiveCommand.Create<string?>(RemoveExcludedProcess);
 
         _adjustPointerAllowed = this
             .WhenAnyValue(e => e.Model.IsUnaryRatio, (bool r) => r)
@@ -74,11 +71,12 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
 
     public ICommand RemoveExcludedProcessCommand { get; }
 
-    void RemoveExcludedProcess()
+    void RemoveExcludedProcess(string? process)
     {
-        if (SelectedExcludedProcess is null) return;
+        process ??= SelectedExcludedProcess;
+        if (string.IsNullOrWhiteSpace(process)) return;
         if (Model == null) return;
-        if (Model.ExcludedList.Contains(SelectedExcludedProcess)) Model.ExcludedList.Remove(SelectedExcludedProcess);
+        if (Model.ExcludedList.Contains(process)) Model.ExcludedList.Remove(process);
     }
 
     public ICommand AddExcludedProcessCommand { get; }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -1,0 +1,152 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:LittleBigMouse.Ui.Avalonia.Controls">
+
+	<!-- Lbm.* brushes, icons and the SettingRow ControlTheme live in App.axaml
+	     (Application.Resources) so ThemeDictionaries variant switching works. -->
+
+	<Style Selector="controls|SettingRow.Sub">
+		<Setter Property="Padding" Value="44,8,14,10"/>
+	</Style>
+
+	<Style Selector="controls|SettingRow ToggleSwitch">
+		<Setter Property="OnContent" Value="{x:Null}"/>
+		<Setter Property="OffContent" Value="{x:Null}"/>
+		<Setter Property="MinWidth" Value="0"/>
+		<Setter Property="Margin" Value="0"/>
+		<Setter Property="Padding" Value="0"/>
+	</Style>
+
+	<Style Selector="controls|SettingRow NumericUpDown">
+		<Setter Property="Width" Value="130"/>
+		<Setter Property="FontSize" Value="13"/>
+	</Style>
+
+	<Style Selector="controls|SettingRow ComboBox">
+		<Setter Property="MinWidth" Value="110"/>
+		<Setter Property="FontSize" Value="13"/>
+	</Style>
+
+	<Style Selector="TextBlock.SectionHeader">
+		<Setter Property="FontSize" Value="12"/>
+		<Setter Property="Foreground" Value="{DynamicResource Lbm.Brushes.Text.Secondary}"/>
+		<Setter Property="Margin" Value="4,14,0,4"/>
+	</Style>
+
+	<Style Selector="Border.SettingCard">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
+		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
+		<Setter Property="BorderThickness" Value="1"/>
+		<Setter Property="CornerRadius" Value="8"/>
+		<Setter Property="Margin" Value="0,3"/>
+	</Style>
+
+	<Style Selector="Border.SettingSeparator">
+		<Setter Property="Height" Value="1"/>
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Separator}"/>
+		<Setter Property="Margin" Value="14,0"/>
+	</Style>
+
+	<Style Selector="Border.Badge">
+		<Setter Property="CornerRadius" Value="10"/>
+		<Setter Property="Padding" Value="10,3"/>
+		<Setter Property="VerticalAlignment" Value="Center"/>
+	</Style>
+	<Style Selector="Border.Badge.Success">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Badge.Success.Background}"/>
+	</Style>
+	<Style Selector="Border.Badge.Success TextBlock">
+		<Setter Property="FontSize" Value="12"/>
+		<Setter Property="Foreground" Value="{DynamicResource Lbm.Brushes.Badge.Success.Foreground}"/>
+	</Style>
+	<Style Selector="Border.Badge.Success Path">
+		<Setter Property="Fill" Value="{DynamicResource Lbm.Brushes.Badge.Success.Foreground}"/>
+	</Style>
+
+	<Style Selector="ListBox.ChoiceCards">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="Padding" Value="0"/>
+		<Setter Property="ItemsPanel">
+			<ItemsPanelTemplate>
+				<UniformGrid Rows="1"/>
+			</ItemsPanelTemplate>
+		</Setter>
+	</Style>
+	<Style Selector="ListBox.ChoiceCards ListBoxItem">
+		<Setter Property="Padding" Value="10,8"/>
+		<Setter Property="Margin" Value="0,0,8,0"/>
+		<Setter Property="CornerRadius" Value="8"/>
+		<Setter Property="BorderThickness" Value="1"/>
+		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="VerticalContentAlignment" Value="Top"/>
+	</Style>
+	<Style Selector="ListBox.ChoiceCards ListBoxItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
+	</Style>
+	<Style Selector="ListBox.ChoiceCards ListBoxItem:selected /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>
+		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Accent}"/>
+	</Style>
+
+	<Style Selector="ListBox.ProcessList">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="Padding" Value="0"/>
+		<Setter Property="MaxHeight" Value="150"/>
+	</Style>
+	<Style Selector="ListBox.ProcessList ListBoxItem">
+		<Setter Property="Padding" Value="14,3"/>
+		<Setter Property="MinHeight" Value="28"/>
+	</Style>
+
+	<Style Selector="Border.Toolbar">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
+		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Card.Separator}"/>
+		<Setter Property="BorderThickness" Value="0,0,0,1"/>
+		<Setter Property="Padding" Value="6,4"/>
+	</Style>
+
+	<Style Selector="Border.ToolbarSeparator">
+		<Setter Property="Width" Value="1"/>
+		<Setter Property="Height" Value="22"/>
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Separator}"/>
+		<Setter Property="Margin" Value="6,0"/>
+		<Setter Property="VerticalAlignment" Value="Center"/>
+	</Style>
+
+	<Style Selector="ToggleButton.ToolbarButton">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="CornerRadius" Value="8"/>
+		<Setter Property="Padding" Value="9"/>
+		<Setter Property="Margin" Value="2,0"/>
+		<Setter Property="VerticalAlignment" Value="Center"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:checked /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>
+		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Accent}"/>
+		<Setter Property="BorderThickness" Value="1"/>
+	</Style>
+
+	<Style Selector="Button.IconButton">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="BorderThickness" Value="0"/>
+		<Setter Property="Padding" Value="5"/>
+		<Setter Property="CornerRadius" Value="6"/>
+	</Style>
+	<Style Selector="Button.IconButton Path">
+		<Setter Property="Fill" Value="{DynamicResource Lbm.Brushes.Text.Secondary}"/>
+	</Style>
+	<Style Selector="Button.IconButton:pointerover Path">
+		<Setter Property="Fill" Value="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+	</Style>
+
+</Styles>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -107,6 +107,9 @@
 		<Setter Property="BorderThickness" Value="0,0,0,1"/>
 		<Setter Property="Padding" Value="6,4"/>
 	</Style>
+	<Style Selector="Border.Toolbar.Bottom">
+		<Setter Property="BorderThickness" Value="0,1,0,0"/>
+	</Style>
 
 	<Style Selector="Border.ToolbarSeparator">
 		<Setter Property="Width" Value="1"/>
@@ -116,7 +119,7 @@
 		<Setter Property="VerticalAlignment" Value="Center"/>
 	</Style>
 
-	<Style Selector="ToggleButton.ToolbarButton">
+	<Style Selector="ToggleButton.ToolbarButton, Button.ToolbarButton">
 		<Setter Property="Background" Value="Transparent"/>
 		<Setter Property="BorderThickness" Value="0"/>
 		<Setter Property="CornerRadius" Value="8"/>
@@ -124,11 +127,17 @@
 		<Setter Property="Margin" Value="2,0"/>
 		<Setter Property="VerticalAlignment" Value="Center"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:disabled, Button.ToolbarButton:disabled">
+		<Setter Property="Opacity" Value="0.35"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="Transparent"/>
 	</Style>
 	<Style Selector="ToggleButton.ToolbarButton:checked /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -130,15 +130,30 @@
 		     without an explicit brush monochrome icons stay black on dark. -->
 		<Setter Property="Foreground" Value="{DynamicResource HLab.Brushes.Foreground}"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+	<Style Selector="Button.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
+	</Style>
+	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
+	<Style Selector="Button.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
+	</Style>
+	<!-- OpacityMask forces a composition layer, without it the Opacity value
+	     is applied to the property but ignored by the renderer (same trick as
+	     the old Button.Command style). -->
+	<Style Selector="ToggleButton.ToolbarButton:disabled /template/ ContentPresenter">
 		<Setter Property="Background" Value="Transparent"/>
-		<Setter Property="Opacity" Value="0.35"/>
+		<Setter Property="Opacity" Value="0.25"/>
+		<Setter Property="OpacityMask" Value="Black"/>
+	</Style>
+	<Style Selector="Button.ToolbarButton:disabled /template/ ContentPresenter">
+		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value="0.25"/>
+		<Setter Property="OpacityMask" Value="Black"/>
 	</Style>
 	<Style Selector="ToggleButton.ToolbarButton:checked /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -126,6 +126,9 @@
 		<Setter Property="Padding" Value="9"/>
 		<Setter Property="Margin" Value="2,0"/>
 		<Setter Property="VerticalAlignment" Value="Center"/>
+		<!-- IconView maps black SVG strokes to the inherited foreground ;
+		     without an explicit brush monochrome icons stay black on dark. -->
+		<Setter Property="Foreground" Value="{DynamicResource HLab.Brushes.Foreground}"/>
 	</Style>
 	<Style Selector="ToggleButton.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -136,11 +136,9 @@
 	<Style Selector="ToggleButton.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>
 	</Style>
-	<Style Selector="ToggleButton.ToolbarButton:disabled, Button.ToolbarButton:disabled">
-		<Setter Property="Opacity" Value="0.35"/>
-	</Style>
 	<Style Selector="ToggleButton.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter, Button.ToolbarButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="Transparent"/>
+		<Setter Property="Opacity" Value="0.35"/>
 	</Style>
 	<Style Selector="ToggleButton.ToolbarButton:checked /template/ ContentPresenter#PART_ContentPresenter">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>


### PR DESCRIPTION
## Settings panel and toolbar redesign

The options panel and the top icon bar kept a very dated look (manual GroupBox-style borders, raw checkbox stacks, 50px default-chrome buttons). This PR moves both to a Windows 11 Settings / Fluent 2 style, without touching any engine or persistence logic.

### Settings panel

- **Card-based rows** via a new reusable `SettingRow` control (icon + header + description + right-aligned control). Descriptions that previously only existed as tooltips are now visible.
- **ToggleSwitch** replaces CheckBox for booleans, following the user's Windows accent color.
- **Crossing algorithm** as two selectable description cards.
- "Start minimized" and the two daemon priorities become **sub-rows** of their parent card; the read-only "Elevated" checkbox is now a **"Running elevated" badge** in the panel header.
- **Excluded processes**: per-row delete button, watermarked input, accent highlight for matched processes (was hardcoded green).
- Opaque pane background, width 500 → 440.

### Toolbar

Same HLab icons and behavior, modernized chrome: flat 22px icon buttons with hover pill, checked state as accent-tinted pill, hairline separators, unified strip with bottom border.

### Theming

`Lbm.*` brushes are defined as `ThemeDictionaries` in `Application.Resources` — placing them in a `Styles` include breaks variant-change notifications, which was verified the hard way. Icons are embedded `StreamGeometry` (no new dependency). Both variants verified in VM, including **live** dark↔light switching (`WM_SETTINGCHANGE` broadcast): the HLab registry watcher and Avalonia's platform theme flip together.

### Notes

- All `ILayoutOptions` bindings unchanged; only C# change is `RemoveExcludedProcessCommand` taking the process as parameter.
- No HLab submodule change.

| Dark | Light |
|---|---|
| card rows, violet accent toggles, badge | full flip incl. toolbar and badges |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
