### PR TITLE
fix: show window when app is already running

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -167,6 +167,19 @@ public class MainService : ReactiveModel, IMainService
     {
         _notify.Click += async (s, a) => await ShowControlAsync();
 
+        // When a second instance launches, it signals this event instead of doing nothing.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var evt = Program.ShowWindowEvent;
+                if (evt == null) return;
+                while (evt.WaitOne())
+                    await Dispatcher.UIThread.InvokeAsync(ShowControlAsync);
+            }
+            catch (ObjectDisposedException) { }
+        });
+
         await _notify.AddMenuAsync(-1, "Check for update","Icon/lbm_on", async () => await _updaterLocator().CheckUpdateAsync(true));
         await _notify.AddMenuAsync(-1, "Open","Icon/lbm_off", ShowControlAsync);
         await _notify.AddMenuAsync(-1, "Start","Icon/Start", StartAsync);

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -167,18 +167,18 @@ public class MainService : ReactiveModel, IMainService
     {
         _notify.Click += async (s, a) => await ShowControlAsync();
 
-        // When a second instance launches, it signals this event instead of doing nothing.
-        _ = Task.Run(async () =>
+        // When a second instance launches, it signals this event; show our window instead of doing
+        // nothing. RegisterWaitForSingleObject parks no thread of its own — a pool thread wakes only
+        // when the event is signalled (AutoReset, so each new launch fires the callback once).
+        if (Program.ShowWindowEvent is { } showWindowEvent)
         {
-            try
-            {
-                var evt = Program.ShowWindowEvent;
-                if (evt == null) return;
-                while (evt.WaitOne())
-                    await Dispatcher.UIThread.InvokeAsync(ShowControlAsync);
-            }
-            catch (ObjectDisposedException) { }
-        });
+            ThreadPool.RegisterWaitForSingleObject(
+                showWindowEvent,
+                (_, _) => Dispatcher.UIThread.Post(() => _ = ShowControlAsync()),
+                state: null,
+                millisecondsTimeOutInterval: Timeout.Infinite,
+                executeOnlyOnce: false);
+        }
 
         await _notify.AddMenuAsync(-1, "Check for update","Icon/lbm_on", async () => await _updaterLocator().CheckUpdateAsync(true));
         await _notify.AddMenuAsync(-1, "Open","Icon/lbm_off", ShowControlAsync);

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
@@ -37,6 +37,10 @@ namespace LittleBigMouse.Ui.Avalonia;
 internal class Program
 {
     const string APP_GUID = "51B5711E-1A7F-436E-B3DD-B598901B3FD2";
+    const string SHOW_EVENT_NAME = APP_GUID + "_ShowWindow";
+
+    // Exposed so MainService can wait on it without a DI dependency on Program.
+    internal static EventWaitHandle? ShowWindowEvent;
 
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
@@ -48,15 +52,26 @@ internal class Program
 
         if (!mutex.WaitOne(TimeSpan.Zero, false))
         {
-            Debug.Print("there is already another instance running!");
+            // Signal the running instance to show its window, then exit.
+            try
+            {
+                using var handle = EventWaitHandle.OpenExisting(SHOW_EVENT_NAME);
+                handle.Set();
+            }
+            catch { }
             return;
         }
-        
+
         // TODO (Avalonia 12 / ReactiveUI 23): RxApp.DefaultExceptionHandler is now the read-only
         // RxState.DefaultExceptionHandler. To restore a custom handler, configure it through
         // RxAppBuilder.CreateReactiveUIBuilder().WithExceptionHandler(...).BuildApp().
 
+        using var showWindowEvent = new EventWaitHandle(false, EventResetMode.AutoReset, SHOW_EVENT_NAME);
+        ShowWindowEvent = showWindowEvent;
+
         BuildAvaloniaApp().Start(UIMain, args);
+
+        ShowWindowEvent = null;
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.


### PR DESCRIPTION
If the app is already running in the system tray and you try to open it again, it will now show the main window instead of doing nothing, just like you'd expect from any other app that minimizes to tray.

possibly related: #448