### PR TITLE
Replace export button with a layout menu and add a virtual layout viewer

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -42,6 +42,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool StartMinimized { get; set; } = false;
       public bool StartElevated { get; set; } = false;
       public bool Elevated { get; set; } = true;
+      public bool DebugTools { get; set; } = false;
       public int DaemonPort { get; set; } = 25196;
 
       public bool AdjustSpeedAllowed { get; } = false;
@@ -173,6 +174,11 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// Current elevated state
    /// </summary>
    bool Elevated { get; set; }
+
+   /// <summary>
+   /// Show debugging tools in the ui (virtual layout inspection...)
+   /// </summary>
+   bool DebugTools { get; set; }
 
    /// <summary>
    /// Daemon port for TCP communication

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Assets/Icon/LayoutExport.svg
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Assets/Icon/LayoutExport.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg">
+  <!-- layout motif: two offset monitors, outline only to stay discreet -->
+  <rect x="6" y="10" width="78" height="46" rx="7"
+        style="fill:none;stroke:#000000;stroke-width:7" />
+  <rect x="48" y="68" width="72" height="44" rx="7"
+        style="fill:none;stroke:#000000;stroke-width:7" />
+  <!-- small outgoing arrow, top right: the layout travels -->
+  <path d="M 94,48 114,28"
+        style="fill:none;stroke:#000000;stroke-width:7;stroke-linecap:round" />
+  <path d="M 102,24 h 16 v 16"
+        style="fill:none;stroke:#000000;stroke-width:7;stroke-linecap:round;stroke-linejoin:round" />
+</svg>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMainService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMainService.cs
@@ -7,7 +7,7 @@ public interface IMainService
 {
     void UpdateLayout();
 
-    IMonitorsLayout MonitorsLayout {get;}
+    IMonitorsLayout MonitorsLayout {get; set;}
 
     Task StartNotifierAsync();
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -55,6 +55,7 @@
 			<StreamGeometry x:Key="Lbm.Icon.Gap">M18,16V13H15V22H13V2H15V11H18V8L22,12L18,16M2,12L6,16V13H9V22H11V2H9V11H6V8L2,12Z</StreamGeometry>
 			<StreamGeometry x:Key="Lbm.Icon.Excluded">M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4C10.1,4 8.4,4.6 7.1,5.7L18.3,16.9C19.3,15.5 20,13.8 20,12A8,8 0 0,0 12,4M5.7,7.1C4.6,8.4 4,10.1 4,12A8,8 0 0,0 12,20C13.9,20 15.6,19.4 16.9,18.3L5.7,7.1Z</StreamGeometry>
 			<StreamGeometry x:Key="Lbm.Icon.Trash">M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Debug">M22.7,19L13.6,9.9C14.5,7.6 14,4.9 12.1,3C10.1,1 7.1,0.6 4.7,1.7L9,6L6,9L1.6,4.7C0.4,7.1 0.9,10.1 2.9,12.1C4.8,14 7.5,14.5 9.8,13.6L18.9,22.7C19.3,23.1 19.9,23.1 20.3,22.7L22.6,20.4C23.1,20 23.1,19.3 22.7,19Z</StreamGeometry>
 
 			<ControlTheme x:Key="{x:Type controls:SettingRow}" TargetType="controls:SettingRow">
 				<Setter Property="Padding" Value="14,10"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
@@ -37,7 +37,7 @@
 						          ToolTip.Tip="View a layout exported by another user, without the hardware. Display only: it cannot be loaded as your own layout."/>
 					</MenuFlyout>
 				</Button.Flyout>
-				<icons:IconView Height="22" Width="22" Path="Icon/CopyConfig"/>
+				<icons:IconView Height="22" Width="22" Path="Icon/LayoutExport"/>
 			</Button>
 
 			<Border Classes="ToolbarSeparator"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml
@@ -26,15 +26,17 @@
 
 		<StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
 
-			<Button Classes="ToolbarButton"
-				Click="ImportJSon_Click">
-				<ToolTip.Tip>Import configuration for debugging purpose</ToolTip.Tip>
-				<icons:IconView Height="22" Width="22" Path="Icon/Sys/LoadJson"/>
-			</Button>
-
-			<Button Classes="ToolbarButton"
-				Click="ExportJSon_Click">
-				<ToolTip.Tip>Export configuration for debugging purpose</ToolTip.Tip>
+			<Button Classes="ToolbarButton">
+				<ToolTip.Tip>Export layout</ToolTip.Tip>
+				<Button.Flyout>
+					<MenuFlyout Placement="TopEdgeAlignedLeft">
+						<MenuItem Header="Export layout..." Click="ExportLayout_Click"/>
+						<MenuItem Header="Copy layout" Click="CopyLayout_Click"/>
+						<MenuItem Header="Open virtual layout..." Click="OpenVirtualLayout_Click"
+						          IsVisible="{Binding Model.Options.DebugTools, FallbackValue=False}"
+						          ToolTip.Tip="View a layout exported by another user, without the hardware. Display only: it cannot be loaded as your own layout."/>
+					</MenuFlyout>
+				</Button.Flyout>
 				<icons:IconView Height="22" Width="22" Path="Icon/CopyConfig"/>
 			</Button>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlView.axaml.cs
@@ -50,7 +50,11 @@ public partial class LocationControlView : UserControl
         InitializeComponent();
     }
     
-    async void ImportJSon_Click(object? sender, RoutedEventArgs e)
+    /// <summary>
+    /// Loads an exported layout for on-screen inspection (debug tool):
+    /// the layout is only displayed, it never drives the mouse engine.
+    /// </summary>
+    async void OpenVirtualLayout_Click(object? sender, RoutedEventArgs e)
     {
         try
         {
@@ -62,55 +66,38 @@ public partial class LocationControlView : UserControl
             var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 AllowMultiple = false,
-                FileTypeFilter = new FilePickerFileType[]{ new ("Config file")
+                FileTypeFilter = new FilePickerFileType[]{ new ("Layout export")
                 {
-                    Patterns = new[] { "*.json" },
-                    AppleUniformTypeIdentifiers = new[] { "public.json" },
-                    MimeTypes = new[] { "application/json" }
+                    Patterns = new[] { "*.json", "*.gz" },
+                    AppleUniformTypeIdentifiers = new[] { "public.json", "org.gnu.gnu-zip-archive" },
+                    MimeTypes = new[] { "application/json", "application/gzip" }
                 } },
                 SuggestedStartLocation = folder
             });
 
             if (files.Count < 1) return;
-            
+
             await using var stream = await files[0].OpenReadAsync();
-            using var streamReader = new StreamReader(stream);
-            var json = await streamReader.ReadToEndAsync();
-                
+            var json = await ReadConfigAsync(stream);
+
             if (DataContext is not LocationControlViewModel vm) return;
 
-            vm.ImportConfig(json);
-
+            vm.OpenVirtualLayout(json);
         }
         catch (Exception ex)
         {
-            await ShowErrorAsync("Import failed", ex);
+            await ShowErrorAsync("Open virtual layout failed", ex);
         }
     }
 
-    async void ExportJSon_Click(object? sender, RoutedEventArgs e)
+    async void ExportLayout_Click(object? sender, RoutedEventArgs e)
     {
         if(DataContext is not LocationControlViewModel vm) return;
 
-        var json = vm.ExportConfig();
-
         try
         {
-            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
-            if (clipboard != null)
-            {
-                var data = new global::Avalonia.Input.DataTransfer();
-                data.Add(global::Avalonia.Input.DataTransferItem.CreateText(json));
-                await clipboard.SetDataAsync(data);
-            }
-        }
-        catch
-        {
-            // a clipboard failure should not prevent exporting to a file
-        }
+            var json = vm.ExportConfig();
 
-        try
-        {
             var provider = TopLevel.GetTopLevel(this)?.StorageProvider;
             if (provider == null) return;
 
@@ -135,6 +122,48 @@ public partial class LocationControlView : UserControl
         {
             await ShowErrorAsync("Export failed", ex);
         }
+    }
+
+    async void CopyLayout_Click(object? sender, RoutedEventArgs e)
+    {
+        if(DataContext is not LocationControlViewModel vm) return;
+
+        try
+        {
+            var json = vm.ExportConfig();
+
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null) return;
+
+            var data = new global::Avalonia.Input.DataTransfer();
+            data.Add(global::Avalonia.Input.DataTransferItem.CreateText(json));
+            await clipboard.SetDataAsync(data);
+        }
+        catch (Exception ex)
+        {
+            await ShowErrorAsync("Copy failed", ex);
+        }
+    }
+
+    /// <summary>
+    /// Reads an export as text, transparently decompressing gzip files
+    /// (the export file is gzipped, the clipboard export is plain json).
+    /// </summary>
+    static async Task<string> ReadConfigAsync(Stream stream)
+    {
+        using var memory = new MemoryStream();
+        await stream.CopyToAsync(memory);
+
+        var bytes = memory.ToArray();
+
+        if (bytes.Length > 2 && bytes[0] == 0x1f && bytes[1] == 0x8b)
+        {
+            using var gzip = new GZipStream(new MemoryStream(bytes), CompressionMode.Decompress);
+            using var reader = new StreamReader(gzip, Encoding.UTF8);
+            return await reader.ReadToEndAsync();
+        }
+
+        return Encoding.UTF8.GetString(bytes);
     }
 
     static async Task<IStorageFolder?> TryGetDocumentsFolderAsync(IStorageProvider provider)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -39,6 +39,7 @@ using LittleBigMouse.DisplayLayout;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.DisplayLayout.Monitors.Extensions;
 using LittleBigMouse.Plugins;
+using LittleBigMouse.Ui.Avalonia.Main;
 using LittleBigMouse.Ui.Avalonia.Persistency;
 using LittleBigMouse.Ui.Avalonia.Remote;
 using LittleBigMouse.Zoning;
@@ -202,11 +203,13 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
         return json;
     }
     
-    public JsonExport? ImportConfig(string json)
+    /// <summary>
+    /// Displays a layout rebuilt from an export, for debugging purpose:
+    /// allows inspecting another user's layout without the hardware.
+    /// </summary>
+    public void OpenVirtualLayout(string json)
     {
-        var export = JsonSerializer.Deserialize<JsonExport>(json);
-
-        return export;
+        _mainService.MonitorsLayout = VirtualLayoutFactory.FromJson(json);
     }
 
     public ReactiveCommand<Unit, Unit> SaveCommand { get; }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -50,12 +50,20 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     bool _startElevated;
 
     [DataMember]
-    public bool Elevated 
-    { 
-        get => _elevated; 
-        set => this.SetAndRaise(ref _elevated, value); 
+    public bool Elevated
+    {
+        get => _elevated;
+        set => this.SetAndRaise(ref _elevated, value);
     }
     bool _elevated = false;
+
+    [DataMember]
+    public bool DebugTools
+    {
+        get => _debugTools;
+        set => SetUnsavedValue(ref _debugTools, value);
+    }
+    bool _debugTools;
 
     public int DaemonPort
     { 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/VirtualLayoutFactory.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/VirtualLayoutFactory.cs
@@ -1,0 +1,240 @@
+#nullable enable
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// Rebuilds a MonitorsLayout from a configuration export, for on-screen inspection of a
+/// layout coming from another machine (no hardware needed). Only the "Layout" part of the
+/// export is used; devices and zones are ignored. The resulting layout is display-only:
+/// it is never persisted nor allowed to drive the daemon.
+/// </summary>
+public static class VirtualLayoutFactory
+{
+    static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
+    };
+
+    public static MonitorsLayout FromJson(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // accept either a full export ({"Layout":...}) or a bare layout object
+        var layoutEl = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("Layout", out var l)
+            ? l : root;
+
+        var options = layoutEl.TryGetProperty("Options", out var optEl)
+            ? optEl.Deserialize<ILayoutOptions.Design>(JsonOptions) ?? new ILayoutOptions.Design()
+            : new ILayoutOptions.Design();
+
+        // a virtual layout must never start the mouse engine
+        options.Enabled = false;
+
+        // keep the debug menu visible while the virtual layout is displayed
+        // (its options replace the real layout's ones in the ui)
+        options.DebugTools = true;
+
+        var layout = new MonitorsLayout(options)
+        {
+            Id = GetString(layoutEl, "Id", "virtual")
+        };
+
+        if (layoutEl.TryGetProperty("PhysicalMonitors", out var monitors)
+            && monitors.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var monitorEl in monitors.EnumerateArray())
+            {
+                var monitor = CreateMonitor(monitorEl, layout);
+                layout.AddOrUpdatePhysicalMonitor(monitor);
+
+                foreach (var source in monitor.Sources.Items)
+                {
+                    layout.AddOrUpdatePhysicalSource(source);
+                }
+            }
+        }
+
+        layout.UpdatePhysicalMonitors();
+
+        // born saved: the save button must not light up for a layout that
+        // should never be persisted (saving it would also re-run the startup
+        // scheduling logic with the imported options)
+        foreach (var monitor in layout.PhysicalMonitors)
+        {
+            foreach (var source in monitor.Sources.Items)
+            {
+                source.Source.Saved = true;
+                source.Saved = true;
+            }
+            monitor.Saved = true;
+        }
+        options.Saved = true;
+        layout.Saved = true;
+
+        return layout;
+    }
+
+    static PhysicalMonitor CreateMonitor(JsonElement monitorEl, MonitorsLayout layout)
+    {
+        var id = GetString(monitorEl, "Id", "monitor");
+
+        var modelEl = monitorEl.TryGetProperty("Model", out var m) ? m : default;
+        var pnpCode = GetString(modelEl, "PnpCode", id);
+
+        var model = layout.GetOrAddPhysicalMonitorModel(pnpCode, s => new PhysicalMonitorModel(s));
+
+        if (modelEl.ValueKind == JsonValueKind.Object)
+        {
+            if (modelEl.TryGetProperty("PhysicalSize", out var sizeEl))
+            {
+                var fixedRatio = model.PhysicalSize.FixedAspectRatio;
+                model.PhysicalSize.FixedAspectRatio = false;
+
+                model.PhysicalSize.Width = GetDouble(sizeEl, "Width", model.PhysicalSize.Width);
+                model.PhysicalSize.Height = GetDouble(sizeEl, "Height", model.PhysicalSize.Height);
+                model.PhysicalSize.TopBorder = GetDouble(sizeEl, "TopBorder", model.PhysicalSize.TopBorder);
+                model.PhysicalSize.RightBorder = GetDouble(sizeEl, "RightBorder", model.PhysicalSize.RightBorder);
+                model.PhysicalSize.BottomBorder = GetDouble(sizeEl, "BottomBorder", model.PhysicalSize.BottomBorder);
+                model.PhysicalSize.LeftBorder = GetDouble(sizeEl, "LeftBorder", model.PhysicalSize.LeftBorder);
+
+                model.PhysicalSize.FixedAspectRatio = fixedRatio;
+            }
+
+            model.PnpDeviceName = GetString(modelEl, "PnpDeviceName", pnpCode);
+            model.Logo = GetString(modelEl, "Logo", "icon/Pnp/LBM");
+        }
+
+        var monitor = new PhysicalMonitor(id, layout, model)
+        {
+            DeviceId = GetString(monitorEl, "DeviceId", id),
+            SerialNumber = GetString(monitorEl, "SerialNumber", "N/A")
+        };
+
+        var activeSourceId = monitorEl.TryGetProperty("ActiveSource", out var activeEl)
+                             && activeEl.TryGetProperty("Source", out var activeSrcEl)
+            ? GetString(activeSrcEl, "Id", id)
+            : id;
+
+        if (monitorEl.TryGetProperty("Sources", out var sourcesEl)
+            && sourcesEl.TryGetProperty("Items", out var itemsEl)
+            && itemsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var sourceEl in itemsEl.EnumerateArray())
+            {
+                var source = CreatePhysicalSource(sourceEl, monitor);
+                if (source == null) continue;
+
+                monitor.Sources.Add(source);
+                if (monitor.ActiveSource == null || source.Source.Id == activeSourceId)
+                    monitor.ActiveSource = source;
+            }
+        }
+
+        // some exports may only carry ActiveSource
+        if (monitor.ActiveSource == null && activeEl.ValueKind == JsonValueKind.Object)
+        {
+            var source = CreatePhysicalSource(activeEl, monitor);
+            if (source != null)
+            {
+                monitor.Sources.Add(source);
+                monitor.ActiveSource = source;
+            }
+        }
+
+        // location must be set after the sources: DepthProjection is rebuilt
+        // when ActiveSource changes, which would discard an earlier X/Y
+        if (monitorEl.TryGetProperty("DepthRatio", out var ratioEl))
+        {
+            monitor.DepthRatio.X = GetDouble(ratioEl, "X", 1);
+            monitor.DepthRatio.Y = GetDouble(ratioEl, "Y", 1);
+        }
+
+        if (monitorEl.TryGetProperty("DepthProjection", out var projectionEl))
+        {
+            monitor.DepthProjection.X = GetDouble(projectionEl, "X", 0);
+            monitor.DepthProjection.Y = GetDouble(projectionEl, "Y", 0);
+        }
+
+        if (monitorEl.TryGetProperty("BorderResistance", out var resistanceEl))
+        {
+            monitor.BorderResistance.Left = GetDouble(resistanceEl, "Left", 0);
+            monitor.BorderResistance.Top = GetDouble(resistanceEl, "Top", 0);
+            monitor.BorderResistance.Right = GetDouble(resistanceEl, "Right", 0);
+            monitor.BorderResistance.Bottom = GetDouble(resistanceEl, "Bottom", 0);
+        }
+
+        monitor.Placed = true;
+
+        return monitor;
+    }
+
+    static PhysicalSource? CreatePhysicalSource(JsonElement physicalSourceEl, PhysicalMonitor monitor)
+    {
+        if (!physicalSourceEl.TryGetProperty("Source", out var sourceEl)) return null;
+
+        var source = new DisplaySource(GetString(sourceEl, "Id", monitor.Id))
+        {
+            Primary = GetBool(sourceEl, "Primary"),
+            AttachedToDesktop = GetBool(sourceEl, "AttachedToDesktop"),
+            Orientation = (int)GetDouble(sourceEl, "Orientation", 0),
+            DisplayFrequency = (int)GetDouble(sourceEl, "DisplayFrequency", 0),
+            DeviceName = GetString(sourceEl, "DeviceName", ""),
+            DisplayName = GetString(sourceEl, "DisplayName", ""),
+            SourceName = GetString(sourceEl, "SourceName", ""),
+            SourceNumber = GetString(sourceEl, "SourceNumber", ""),
+            InterfaceName = GetString(sourceEl, "InterfaceName", ""),
+            InterfaceLogo = GetString(sourceEl, "InterfaceLogo", ""),
+            // the wallpaper file belongs to the exporting machine
+            WallpaperPath = ""
+        };
+
+        if (sourceEl.TryGetProperty("InPixel", out var inPixelEl))
+        {
+            source.InPixel.Set(new Rect(
+                new Point(GetDouble(inPixelEl, "X", 0), GetDouble(inPixelEl, "Y", 0)),
+                new Size(GetDouble(inPixelEl, "Width", 0), GetDouble(inPixelEl, "Height", 0))));
+        }
+
+        SetRatio(source.EffectiveDpi, sourceEl, "EffectiveDpi");
+        SetRatio(source.RawDpi, sourceEl, "RawDpi");
+        SetRatio(source.DpiAwareAngularDpi, sourceEl, "DpiAwareAngularDpi");
+
+        return new PhysicalSource(GetString(physicalSourceEl, "DeviceId", source.Id), monitor, source);
+    }
+
+    static void SetRatio(DisplayRatioValue ratio, JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var el)) return;
+        ratio.Set(GetDouble(el, "X", ratio.X), GetDouble(el, "Y", ratio.Y));
+    }
+
+    static string GetString(JsonElement el, string name, string fallback)
+    {
+        if (el.ValueKind != JsonValueKind.Object || !el.TryGetProperty(name, out var p)) return fallback;
+        return p.ValueKind switch
+        {
+            JsonValueKind.String => p.GetString() ?? fallback,
+            JsonValueKind.Null or JsonValueKind.Undefined => fallback,
+            _ => p.GetRawText()
+        };
+    }
+
+    static double GetDouble(JsonElement el, string name, double fallback)
+        => el.ValueKind == JsonValueKind.Object
+           && el.TryGetProperty(name, out var p)
+           && p.ValueKind == JsonValueKind.Number
+            ? p.GetDouble()
+            : fallback;
+
+    static bool GetBool(JsonElement el, string name)
+        => el.ValueKind == JsonValueKind.Object
+           && el.TryGetProperty(name, out var p)
+           && p.ValueKind == JsonValueKind.True;
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -98,6 +98,14 @@
 						</StackPanel>
 					</Border>
 
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Debug}"
+						                     Header="Activate debug tools"
+						                     Description="Extra tools for troubleshooting, like viewing exported layouts">
+							<ToggleSwitch IsChecked="{Binding Model.DebugTools, FallbackValue=false, Mode=TwoWay}"/>
+						</controls:SettingRow>
+					</Border>
+
 					<TextBlock Classes="SectionHeader" Text="Mouse"/>
 
 					<Border Classes="SettingCard">

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
@@ -62,6 +62,7 @@ public static class PersistencyExtensions
         @this.AutoUpdate = mainKey.GetOrSet("AutoUpdate", () => key.GetOrSet("AutoUpdate",() => false));
         @this.StartMinimized = mainKey.GetOrSet("StartMinimized", () => key.GetOrSet("StartMinimized",() => false));
         @this.StartElevated = mainKey.GetOrSet("StartElevated", () => key.GetOrSet("StartElevated",() => false));
+        @this.DebugTools = mainKey.GetOrSet("DebugTools", () => false);
 
         @this.ExcludedList.Clear();
 
@@ -149,6 +150,7 @@ public static class PersistencyExtensions
         mainKey.SetKey("AutoUpdate", @this.AutoUpdate);
         mainKey.SetKey("StartMinimized", @this.StartMinimized);
         mainKey.SetKey("StartElevated", @this.StartElevated);
+        mainKey.SetKey("DebugTools", @this.DebugTools);
 
         var file = ExcludedListPath();
 


### PR DESCRIPTION
## What

The two bottom-bar debug buttons (import / export) become a single menu button:

- **Export layout...** - saves the gzipped json export (no implicit clipboard copy anymore)
- **Copy layout** - copies the json export to the clipboard
- **Open virtual layout...** - rebuilds a layout from an export file (`.json` or `.gz`, as attached by testers on GitHub issues) and displays it, allowing to inspect another user's layout without owning the hardware

Since "Open virtual layout" is display-only and could easily be mistaken for *loading* a layout, it is hidden behind a new **Activate debug tools** option (Settings > General, persisted in the main registry key).

## How

The previous import button deserialized the export and discarded the result, and direct deserialization of the reactive object graph is not possible anyway (interface-typed options, read-only DynamicData collections, parented constructors). The new `VirtualLayoutFactory` rebuilds the layout through the public construction api, mirroring `LayoutFactory`:

- options deserialized into `ILayoutOptions.Design`, with `Enabled` forced off so a virtual layout can never drive the mouse engine, and `DebugTools` kept on so the menu stays available while the virtual layout is displayed
- monitors, models and sources rebuilt field by field; locations applied **after** the sources, because `DepthProjection` is recreated when `ActiveSource` changes
- the layout is born saved, so displaying it does not arm the save/undo/apply cycle and cannot end up persisted to the registry (which would also re-run the startup scheduling logic with imported options)

## Validation

- Factory validated in a console harness against a real 3-monitor export (positions, sizes, borders, dpi, primary flag all correct)
- Live-tested: menu behaviour, option toggle showing/hiding the entry, and opening a modified export (one monitor deliberately displaced) rendering the displaced layout
- Full UI build green (Release x64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
