### PR TITLE
Add confirmation dialog before attaching or detaching a monitor

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -43,6 +43,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool StartElevated { get; set; } = false;
       public bool Elevated { get; set; } = true;
       public bool DebugTools { get; set; } = false;
+      public bool ShowAttachDetachWarning { get; set; } = true;
       public int DaemonPort { get; set; } = 25196;
 
       public bool AdjustSpeedAllowed { get; } = false;
@@ -179,6 +180,11 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// Show debugging tools in the ui (virtual layout inspection...)
    /// </summary>
    bool DebugTools { get; set; }
+
+   /// <summary>
+   /// Ask for confirmation before attaching a monitor to the desktop or detaching it
+   /// </summary>
+   bool ShowAttachDetachWarning { get; set; }
 
    /// <summary>
    /// Daemon port for TCP communication

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -56,6 +56,7 @@
 			<StreamGeometry x:Key="Lbm.Icon.Excluded">M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4C10.1,4 8.4,4.6 7.1,5.7L18.3,16.9C19.3,15.5 20,13.8 20,12A8,8 0 0,0 12,4M5.7,7.1C4.6,8.4 4,10.1 4,12A8,8 0 0,0 12,20C13.9,20 15.6,19.4 16.9,18.3L5.7,7.1Z</StreamGeometry>
 			<StreamGeometry x:Key="Lbm.Icon.Trash">M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z</StreamGeometry>
 			<StreamGeometry x:Key="Lbm.Icon.Debug">M22.7,19L13.6,9.9C14.5,7.6 14,4.9 12.1,3C10.1,1 7.1,0.6 4.7,1.7L9,6L6,9L1.6,4.7C0.4,7.1 0.9,10.1 2.9,12.1C4.8,14 7.5,14.5 9.8,13.6L18.9,22.7C19.3,23.1 19.9,23.1 20.3,22.7L22.6,20.4C23.1,20 23.1,19.3 22.7,19Z</StreamGeometry>
+			<StreamGeometry x:Key="Lbm.Icon.Warning">M13,14H11V9H13M13,18H11V16H13M1,21H23L12,2L1,21Z</StreamGeometry>
 
 			<ControlTheme x:Key="{x:Type controls:SettingRow}" TargetType="controls:SettingRow">
 				<Setter Property="Padding" Value="14,10"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml
@@ -1,0 +1,63 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="LittleBigMouse.Ui.Avalonia.Controls.MonitorWarningDialog"
+        Title="Detach monitor"
+        Width="500"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource Lbm.Brushes.Pane.Background}">
+
+	<StackPanel Margin="24,20" Spacing="14">
+
+		<StackPanel Orientation="Horizontal" Spacing="12">
+			<Path Data="{StaticResource Lbm.Icon.Warning}"
+			      Fill="#E0A030" Width="26" Height="26" Stretch="Uniform"
+			      VerticalAlignment="Center"/>
+			<TextBlock x:Name="HeadingText"
+			           Text="Detach this monitor from the desktop?"
+			           FontSize="16" FontWeight="SemiBold"
+			           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+			           VerticalAlignment="Center" TextWrapping="Wrap"/>
+		</StackPanel>
+
+		<TextBlock x:Name="BodyText" TextWrapping="Wrap" FontSize="13"
+		           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+		           Text="Windows will stop using this monitor: its screen will go black immediately. This change is kept after a restart, and reattaching it from LittleBigMouse does not always succeed."/>
+
+		<Border Background="{DynamicResource Lbm.Brushes.Card.Background}"
+		        BorderBrush="{DynamicResource Lbm.Brushes.Card.Border}"
+		        BorderThickness="1" CornerRadius="6" Padding="14,10">
+			<StackPanel Spacing="6">
+				<TextBlock x:Name="RecoveryTitle"
+				           Text="To get the monitor back with Windows:"
+				           FontSize="13" FontWeight="SemiBold"
+				           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+				<TextBlock TextWrapping="Wrap" FontSize="12"
+				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+				           Text="1. Right-click the desktop and choose Display settings (or open Settings &gt; System &gt; Display)."/>
+				<TextBlock TextWrapping="Wrap" FontSize="12"
+				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+				           Text="2. Select the detached monitor, then under Multiple displays choose 'Extend desktop to this display'. There you can also fix the resolution and refresh rate."/>
+				<TextBlock TextWrapping="Wrap" FontSize="12"
+				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+				           Text="3. If it is not listed, click 'Detect other display' there, or press Win+P and choose 'Extend'."/>
+			</StackPanel>
+		</Border>
+
+		<CheckBox x:Name="DontShowAgainCheckBox" FontSize="13"
+		          Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+		          Content="Don't show this warning again"/>
+
+		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+			<Button x:Name="CancelButton" IsDefault="True" IsCancel="True"
+			        MinWidth="90" HorizontalContentAlignment="Center"
+			        Click="OnCancelClick" Content="Cancel"/>
+			<Button x:Name="ConfirmButton"
+			        MinWidth="90" HorizontalContentAlignment="Center"
+			        Click="OnConfirmClick" Content="Detach"/>
+		</StackPanel>
+
+	</StackPanel>
+</Window>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+/// <summary>
+/// Confirmation shown before attaching or detaching a monitor. The XAML holds the
+/// detach wording; the attach variant swaps the texts in <see cref="ShowAttachAsync"/>.
+/// </summary>
+public partial class MonitorWarningDialog : Window
+{
+    bool _confirmed;
+
+    public MonitorWarningDialog()
+    {
+        InitializeComponent();
+    }
+
+    void OnCancelClick(object? sender, RoutedEventArgs e) => Close(false);
+
+    void OnConfirmClick(object? sender, RoutedEventArgs e)
+    {
+        _confirmed = true;
+        Close(true);
+    }
+
+    public static Task<(bool Confirmed, bool DontShowAgain)> ShowDetachAsync(Window? owner)
+        => new MonitorWarningDialog().ShowAsync(owner);
+
+    public static Task<(bool Confirmed, bool DontShowAgain)> ShowAttachAsync(Window? owner)
+    {
+        var dialog = new MonitorWarningDialog
+        {
+            Title = "Attach monitor"
+        };
+        dialog.HeadingText.Text = "Attach this monitor to the desktop?";
+        dialog.BodyText.Text = "LittleBigMouse will re-enable this monitor with its last saved position, resolution, orientation and refresh rate. If those no longer match your setup, a monitor may receive an unsupported mode or another screen may change resolution.";
+        dialog.RecoveryTitle.Text = "If a screen ends up black or misconfigured:";
+        dialog.ConfirmButton.Content = "Attach";
+
+        return dialog.ShowAsync(owner);
+    }
+
+    /// <summary>
+    /// Returns whether the user confirmed the action, and whether the warning
+    /// should be hidden from now on (only honoured when confirmed).
+    /// The app runs without an ApplicationLifetime, so the owner may be missing:
+    /// in that case the dialog is still shown, centered on screen.
+    /// </summary>
+    async Task<(bool Confirmed, bool DontShowAgain)> ShowAsync(Window? owner)
+    {
+        if (owner != null)
+        {
+            await ShowDialog(owner);
+        }
+        else
+        {
+            var closed = new TaskCompletionSource();
+            Closed += (_, _) => closed.TrySetResult();
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            Show();
+            await closed.Task;
+        }
+
+        return (_confirmed, _confirmed && DontShowAgainCheckBox.IsChecked == true);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -65,6 +65,14 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     }
     bool _debugTools;
 
+    [DataMember]
+    public bool ShowAttachDetachWarning
+    {
+        get => _showAttachDetachWarning;
+        set => SetUnsavedValue(ref _showAttachDetachWarning, value);
+    }
+    bool _showAttachDetachWarning = true;
+
     public int DaemonPort
     { 
         get => _daemonPort; 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -208,6 +208,14 @@
 						</StackPanel>
 					</Border>
 
+					<Border Classes="SettingCard">
+						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Warning}"
+						                     Header="Warn before attaching or detaching a monitor"
+						                     Description="Ask for confirmation and show recovery steps before changing a monitor's desktop attachment">
+							<ToggleSwitch IsChecked="{Binding Model.ShowAttachDetachWarning, FallbackValue=true, Mode=TwoWay}"/>
+						</controls:SettingRow>
+					</Border>
+
 					<TextBlock Classes="SectionHeader" Text="Excluded processes"/>
 
 					<Border Classes="SettingCard">

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
@@ -63,6 +63,7 @@ public static class PersistencyExtensions
         @this.StartMinimized = mainKey.GetOrSet("StartMinimized", () => key.GetOrSet("StartMinimized",() => false));
         @this.StartElevated = mainKey.GetOrSet("StartElevated", () => key.GetOrSet("StartElevated",() => false));
         @this.DebugTools = mainKey.GetOrSet("DebugTools", () => false);
+        @this.ShowAttachDetachWarning = mainKey.GetOrSet("ShowAttachDetachWarning", () => true);
 
         @this.ExcludedList.Clear();
 
@@ -141,6 +142,16 @@ public static class PersistencyExtensions
         return true;
     }
 
+    /// <summary>
+    /// Persist the attach/detach-warning preference on its own: it is changed from the
+    /// warning dialog itself, where the user may never go through the regular save-button flow.
+    /// </summary>
+    public static void SaveShowAttachDetachWarning(this ILayoutOptions @this)
+    {
+        using var mainKey = OpenRootRegKey(true);
+        mainKey?.SetKey("ShowAttachDetachWarning", @this.ShowAttachDetachWarning);
+    }
+
     public static void Save(this ILayoutOptions @this, RegistryKey? mainKey, RegistryKey? key)
     {
         if (mainKey == null) return;
@@ -151,6 +162,7 @@ public static class PersistencyExtensions
         mainKey.SetKey("StartMinimized", @this.StartMinimized);
         mainKey.SetKey("StartElevated", @this.StartElevated);
         mainKey.SetKey("DebugTools", @this.DebugTools);
+        mainKey.SetKey("ShowAttachDetachWarning", @this.ShowAttachDetachWarning);
 
         var file = ExcludedListPath();
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
@@ -240,8 +240,8 @@
 		</StackPanel>
 
 		<StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom">
-			<Button IsVisible="{Binding !Attached}" Command="{Binding AttachCommand}">Attach</Button>
-			<Button IsVisible="{Binding DetachVisible}" Command="{Binding DetachCommand}">Detach</Button>
+			<Button IsVisible="{Binding !Attached}" Command="{Binding AttachCommand}" CommandParameter="{Binding $parent[Window]}">Attach</Button>
+			<Button IsVisible="{Binding DetachVisible}" Command="{Binding DetachCommand}" CommandParameter="{Binding $parent[Window]}">Detach</Button>
 			<Label IsVisible="{Binding Primary}">Primary</Label>
 		</StackPanel>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
@@ -21,11 +21,16 @@
 	  http://www.mgth.fr
 */
 
+using Avalonia.Controls;
 using HLab.Mvvm.ReactiveUI;
 using HLab.Sys.Windows.Monitors.Factory;
 using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Ui.Avalonia.Controls;
+using LittleBigMouse.Ui.Avalonia.Persistency;
 using ReactiveUI;
+using System;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace LittleBigMouse.Ui.Avalonia.Plugins.Default;
@@ -51,13 +56,13 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
             (attached, primary) => attached && !primary)
             .ToProperty(this, e => e.DetachVisible);
 
-        DetachCommand = ReactiveCommand.Create(DetachFromDesktop,this.WhenAnyValue(
-            e => e.Attached, 
+        DetachCommand = ReactiveCommand.CreateFromTask<Window?>(DetachFromDesktopAsync,this.WhenAnyValue(
+            e => e.Attached,
             e => e.Primary,
             (attached,primary) => attached && !primary)
         .ObserveOn(RxSchedulers.MainThreadScheduler));
 
-        AttachCommand = ReactiveCommand.Create(AttachToDesktop,this.WhenAnyValue(e => e.Attached, e => !e).ObserveOn(RxSchedulers.MainThreadScheduler));
+        AttachCommand = ReactiveCommand.CreateFromTask<Window?>(AttachToDesktopAsync,this.WhenAnyValue(e => e.Attached, e => !e).ObserveOn(RxSchedulers.MainThreadScheduler));
     }
 
     public bool Attached => _attached.Value;
@@ -75,19 +80,40 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
     public ICommand AttachCommand { get; }
     public ICommand DetachCommand { get; }
 
-    void DetachFromDesktop()
+    async Task DetachFromDesktopAsync(Window? owner)
     {
+        if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowDetachAsync)) return;
+
         MonitorDeviceHelper.DetachFromDesktop(Model.ActiveSource.Source.DisplayName);
     }
 
-    void AttachToDesktop()
+    async Task AttachToDesktopAsync(Window? owner)
     {
+        if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowAttachAsync)) return;
+
         MonitorDeviceHelper.AttachToDesktop(
             Model.ActiveSource.Source.DisplayName,
             Model.ActiveSource.Source.Primary,
             Model.ActiveSource.Source.InPixel.Bounds,
             Model.ActiveSource.Source.Orientation
             );
+    }
+
+    async Task<bool> ConfirmAsync(Window? owner, Func<Window?, Task<(bool Confirmed, bool DontShowAgain)>> showDialog)
+    {
+        var options = Model.Layout.Options;
+
+        if (!options.ShowAttachDetachWarning) return true;
+
+        var (confirmed, dontShowAgain) = await showDialog(owner);
+
+        if (confirmed && dontShowAgain)
+        {
+            options.ShowAttachDetachWarning = false;
+            options.SaveShowAttachDetachWarning();
+        }
+
+        return confirmed;
     }
 
  }


### PR DESCRIPTION
## Summary

Detach has repeatedly caused user panic: the screen goes black immediately, the change survives restarts, and reattaching from LBM does not always work (#312, #359, #362, #391, #404, #420). Attach can also reapply a stale display mode (wrong resolution / unsupported refresh rate, see #312).

Both buttons now show a confirmation dialog that:
- explains what is about to happen and why it can be hard to undo,
- gives the recovery steps in Windows (Settings > System > Display > Multiple displays > "Extend desktop to this display", "Detect other display", Win+P > Extend),
- offers a "Don't show this warning again" checkbox.

The preference is persisted to the registry immediately when the checkbox is used (not only through the regular save-button flow), and a new toggle in Settings > Layout ("Warn before attaching or detaching a monitor") allows re-enabling the warning.

## Implementation notes

- Single `MonitorWarningDialog` window; the XAML holds the detach wording, the attach variant swaps the texts.
- The dialog owner is passed from the view via `CommandParameter="{Binding $parent[Window]}"` because the app runs without an `ApplicationLifetime`, so `Application.Current.GetTopLevel()` returns null at runtime. If no owner is found the dialog is still shown centered on screen instead of being silently skipped.
- New `ShowAttachDetachWarning` option on `ILayoutOptions` (default true), stored in the main registry key like the other global options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
