### PR TITLE
Attach/detach monitors by identity via the CCD API

### DIFF
--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/DeviceFactory.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/DeviceFactory.cs
@@ -9,7 +9,7 @@ namespace HLab.Sys.Windows.Monitors.Factory;
 
 internal static class DeviceFactory
 {
-    public static MonitorDeviceConnection BuildMonitorDevice(DisplayDevice parent, WinGdi.DisplayDevice device)
+    public static MonitorDeviceConnection BuildMonitorDevice(DisplayDevice parent, WinGdi.DisplayDevice device, string interfacePath)
     {
 
         var monitors = parent.Parent.AllMonitorDevices().ToList();
@@ -23,12 +23,17 @@ internal static class DeviceFactory
             monitor = new MonitorDevice
             {
                 Id = device.DeviceID,
+                InterfacePath = interfacePath,
                 //MonitorDevice
                 Edid = edid,
                 PnpCode = MonitorDeviceHelper.GetPnpCodeFromId(device.DeviceID),
                 PhysicalId = MonitorDeviceHelper.GetPhysicalId(device.DeviceID, edid),
                 SourceId = MonitorDeviceHelper.GetSourceId(device.DeviceID, edid),
             };
+        }
+        else if (string.IsNullOrEmpty(monitor.InterfacePath))
+        {
+            monitor.InterfacePath = interfacePath;
         }
 
         var connection = new MonitorDeviceConnection
@@ -79,22 +84,30 @@ internal static class DeviceFactory
 
     public static DisplayDevice BuildDisplayDeviceAndChildren(
         DisplayDevice parent,
-        WinGdi.DisplayDevice dev
+        WinGdi.DisplayDevice dev,
+        string interfacePath = ""
         )
     {
-        var result = BuildDisplayDevice(parent, dev);
+        var result = BuildDisplayDevice(parent, dev, interfacePath);
 
         uint i = 0;
         var child = new WinGdi.DisplayDevice();
 
-        while (EnumDisplayDevices(result.DeviceName, i++, ref child, 0))
+        while (EnumDisplayDevices(result.DeviceName, i, ref child, 0))
         {
-            result.AddChild(BuildDisplayDeviceAndChildren(result, child));
+            // Same enumeration with EDD_GET_DEVICE_INTERFACE_NAME to capture the device
+            // interface path (\\?\DISPLAY#...), the identity the CCD API works with.
+            var childInterface = new WinGdi.DisplayDevice();
+            var childPath = EnumDisplayDevices(result.DeviceName, i, ref childInterface, EDD_GET_DEVICE_INTERFACE_NAME)
+                ? childInterface.DeviceID : "";
+
+            result.AddChild(BuildDisplayDeviceAndChildren(result, child, childPath));
+            i++;
         }
         return result;
     }
 
-    static DisplayDevice BuildDisplayDevice(DisplayDevice? parent, WinGdi.DisplayDevice device)
+    static DisplayDevice BuildDisplayDevice(DisplayDevice? parent, WinGdi.DisplayDevice device, string interfacePath)
     {
         if(device.DeviceID == "ROOT")
         {
@@ -120,7 +133,7 @@ internal static class DeviceFactory
             return BuildPhysicalAdapter(parent, device);
 
         //if(device.DeviceID.Split('\\')[0] == "MONITOR")
-            return BuildMonitorDevice(parent, device);
+            return BuildMonitorDevice(parent, device, interfacePath);
 
         throw new ArgumentException($"Unknown device type {device.DeviceName}");
 

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
@@ -135,11 +135,136 @@ public static class MonitorDeviceHelper
         @this.WorkArea = mi.WorkArea.ToRect();
     }
 
-    public static void AttachToDesktop(string deviceName, bool primary, Rect area, int orientation, bool apply = true)
+    //==============================================================================
+    // Attach / detach by monitor identity (CCD API).
+    //
+    // ChangeDisplaySettingsEx addresses an adapter *source* (\\.\DISPLAYn). Once a
+    // monitor is detached, Windows lists it as a binding candidate under EVERY
+    // inactive source: with several detached monitors they all report the same
+    // first source, and activating that source lets the driver bind whichever
+    // candidate it prefers — attaching HEC0030 would light up SAME035 (#404, #391).
+    // The CCD path array identifies the *target* (monitor) explicitly, so we
+    // (de)activate the source->target path of that exact monitor instead.
+    //==============================================================================
+
+    static (DisplayConfigPathInfo[] Paths, DisplayConfigModeInfo[] Modes)? QueryDisplayConfigPaths()
     {
+        uint nPath = 0, nMode = 0;
+        if (GetDisplayConfigBufferSizes(QDC_ALL_PATHS, ref nPath, ref nMode) != 0) return null;
+
+        var paths = new DisplayConfigPathInfo[nPath];
+        var modes = new DisplayConfigModeInfo[nMode];
+        if (QueryDisplayConfig(QDC_ALL_PATHS, ref nPath, paths, ref nMode, modes, 0) != 0) return null;
+
+        // QueryDisplayConfig may return fewer elements than allocated
+        if (nPath < paths.Length) Array.Resize(ref paths, (int)nPath);
+        if (nMode < modes.Length) Array.Resize(ref modes, (int)nMode);
+
+        return (paths, modes);
+    }
+
+    static string GetTargetDevicePath(Luid adapterId, uint targetId)
+    {
+        var name = new DisplayConfigTargetDeviceName
+        {
+            Type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME,
+            Size = (uint)Marshal.SizeOf<DisplayConfigTargetDeviceName>(),
+            AdapterId = adapterId,
+            Id = targetId,
+        };
+        return DisplayConfigGetDeviceInfo(ref name) == 0 ? name.MonitorDevicePath : "";
+    }
+
+    static string GetSourceGdiName(Luid adapterId, uint sourceId)
+    {
+        var name = new DisplayConfigSourceDeviceName
+        {
+            Type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
+            Size = (uint)Marshal.SizeOf<DisplayConfigSourceDeviceName>(),
+            AdapterId = adapterId,
+            Id = sourceId,
+        };
+        return DisplayConfigGetDeviceInfo(ref name) == 0 ? name.ViewGdiDeviceName : "";
+    }
+
+    static bool SourceInUse(DisplayConfigPathInfo[] paths, int idx)
+    {
+        var source = paths[idx].SourceInfo;
+        for (var j = 0; j < paths.Length; j++)
+        {
+            if (j == idx) continue;
+            if ((paths[j].Flags & DISPLAYCONFIG_PATH_ACTIVE) == 0) continue;
+            if (paths[j].SourceInfo.AdapterId.Equals(source.AdapterId)
+                && paths[j].SourceInfo.Id == source.Id) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Attach the monitor designated by its device interface path (\\?\DISPLAY#...)
+    /// to the desktop, then apply the requested position/resolution/orientation on
+    /// the source it got bound to.
+    /// </summary>
+    public static bool AttachToDesktop(string monitorDevicePath, bool primary, Rect area, int orientation, bool apply = true)
+    {
+        if (string.IsNullOrEmpty(monitorDevicePath)) return false;
+        if (QueryDisplayConfigPaths() is not { } cfg) return false;
+        var (paths, modes) = cfg;
+
+        var pathIdx = -1;
+        for (var i = 0; i < paths.Length; i++)
+        {
+            if (!paths[i].TargetInfo.TargetAvailable) continue;
+            if (!string.Equals(
+                    GetTargetDevicePath(paths[i].TargetInfo.AdapterId, paths[i].TargetInfo.Id),
+                    monitorDevicePath, StringComparison.OrdinalIgnoreCase)) continue;
+
+            // already active : no need to change the topology, just apply the mode
+            if ((paths[i].Flags & DISPLAYCONFIG_PATH_ACTIVE) != 0)
+            {
+                pathIdx = i;
+                break;
+            }
+
+            if (SourceInUse(paths, i)) continue;
+
+            pathIdx = i;
+            break;
+        }
+
+        if (pathIdx < 0)
+        {
+            Debug.WriteLine($"AttachToDesktop: no available path for {monitorDevicePath}");
+            return false;
+        }
+
+        if ((paths[pathIdx].Flags & DISPLAYCONFIG_PATH_ACTIVE) == 0)
+        {
+            paths[pathIdx].Flags |= DISPLAYCONFIG_PATH_ACTIVE;
+            paths[pathIdx].SourceInfo.ModeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+            paths[pathIdx].TargetInfo.ModeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+
+            var r = SetDisplayConfig((uint)paths.Length, paths, (uint)modes.Length, modes,
+                SetDisplayConfigFlags.Apply
+                | SetDisplayConfigFlags.UseSuppliedDisplayConfig
+                | SetDisplayConfigFlags.AllowChanges
+                | SetDisplayConfigFlags.SaveToDatabase);
+
+            if (r != 0)
+            {
+                Debug.WriteLine($"AttachToDesktop: SetDisplayConfig failed ({r}) for {monitorDevicePath}");
+                return false;
+            }
+        }
+
+        // The monitor is now bound to a known source : place it at the wanted
+        // position/mode (this part is the former ChangeDisplaySettingsEx attach).
+        var sourceName = GetSourceGdiName(paths[pathIdx].SourceInfo.AdapterId, paths[pathIdx].SourceInfo.Id);
+        if (string.IsNullOrEmpty(sourceName)) return false;
+
         var devMode = new DevMode()
         {
-            DeviceName = deviceName,
+            DeviceName = sourceName,
             Position = new WinDef.Point((int)area.X, (int)area.Y),
             PixelsWidth = (uint)area.Width,
             PixelsHeight = (uint)area.Height,
@@ -158,54 +283,90 @@ public static class MonitorDeviceHelper
 
         if (primary) flag |= ChangeDisplaySettingsFlags.SetPrimary;
 
-
-        var ch = ChangeDisplaySettingsEx(deviceName, ref devMode, 0, flag, 0);
+        var ch = ChangeDisplaySettingsEx(sourceName, ref devMode, 0, flag, 0);
 
         if (ch == DispChange.Successful && apply)
             ApplyDesktop();
+
+        return ch == DispChange.Successful;
     }
 
-    public static bool DetachFromDesktop(string deviceName, bool apply = true)
+    /// <summary>
+    /// Detach the monitor designated by its device interface path (\\?\DISPLAY#...)
+    /// from the desktop, by deactivating its active CCD path.
+    /// </summary>
+    public static bool DetachFromDesktop(string monitorDevicePath)
     {
+        if (string.IsNullOrEmpty(monitorDevicePath)) return false;
+        if (QueryDisplayConfigPaths() is not { } cfg) return false;
+        var (paths, modes) = cfg;
 
-        var devMode = new DevMode
+        var found = false;
+        for (var i = 0; i < paths.Length; i++)
         {
-            //DeviceName = "cdd", //= deviceName,
-            //PixelsHeight = 0,
-            //PixelsWidth = 0,
-            Fields = 0
-             | PixelsWidth
-             | PixelsHeight
-             | BitsPerPixel
-             | Position
-             | DisplayFrequency
-             | DisplayFlags
-        };
+            if ((paths[i].Flags & DISPLAYCONFIG_PATH_ACTIVE) == 0) continue;
+            if (!string.Equals(
+                    GetTargetDevicePath(paths[i].TargetInfo.AdapterId, paths[i].TargetInfo.Id),
+                    monitorDevicePath, StringComparison.OrdinalIgnoreCase)) continue;
 
-        //devMode.DeviceName = deviceName;
-        //devMode.PixelsHeight = 0;
-        //devMode.PixelsWidth = 0;
-
-        devMode.BitsPerPel = 32;
-
-        var ch = ChangeDisplaySettingsEx(
-            deviceName,
-            ref devMode,
-            0,
-            ChangeDisplaySettingsFlags.UpdateRegistry
-            | ChangeDisplaySettingsFlags.NoReset
-            , 0);
-
-        Debug.WriteLine($"DetachFromDesktop {deviceName} {ch}");
-
-        if (ch == DispChange.Successful && apply)
-        {
-            ApplyDesktop();
-            return true;
+            paths[i].Flags &= ~DISPLAYCONFIG_PATH_ACTIVE;
+            found = true;
+            break;
         }
 
-        return false;
+        if (!found)
+        {
+            Debug.WriteLine($"DetachFromDesktop: no active path for {monitorDevicePath}");
+            return false;
+        }
+
+        var r = SetDisplayConfig((uint)paths.Length, paths, (uint)modes.Length, modes,
+            SetDisplayConfigFlags.Apply
+            | SetDisplayConfigFlags.UseSuppliedDisplayConfig
+            | SetDisplayConfigFlags.AllowChanges
+            | SetDisplayConfigFlags.SaveToDatabase);
+
+        Debug.WriteLine($"DetachFromDesktop {monitorDevicePath} {r}");
+
+        return r == 0;
     }
+
+    // Former source-based implementation, kept for reference. It detached whatever
+    // monitor was bound to the given \\.\DISPLAYn source by applying an empty mode:
+    //
+    //public static bool DetachFromDesktop(string deviceName, bool apply = true)
+    //{
+    //    var devMode = new DevMode
+    //    {
+    //        Fields = 0
+    //         | PixelsWidth
+    //         | PixelsHeight
+    //         | BitsPerPixel
+    //         | Position
+    //         | DisplayFrequency
+    //         | DisplayFlags
+    //    };
+    //
+    //    devMode.BitsPerPel = 32;
+    //
+    //    var ch = ChangeDisplaySettingsEx(
+    //        deviceName,
+    //        ref devMode,
+    //        0,
+    //        ChangeDisplaySettingsFlags.UpdateRegistry
+    //        | ChangeDisplaySettingsFlags.NoReset
+    //        , 0);
+    //
+    //    Debug.WriteLine($"DetachFromDesktop {deviceName} {ch}");
+    //
+    //    if (ch == DispChange.Successful && apply)
+    //    {
+    //        ApplyDesktop();
+    //        return true;
+    //    }
+    //
+    //    return false;
+    //}
 
 
     public static void ApplyDesktop() => ChangeDisplaySettingsEx(null, 0, 0, 0, 0);

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
@@ -10,6 +10,12 @@ public class MonitorDevice : IEquatable<MonitorDevice>
    public string PnpCode { get; init; } = "";
    public string PhysicalId { get; set; } = "";
    public string SourceId { get; set; } = "";
+
+   /// <summary>
+   /// Device interface path (\\?\DISPLAY#...) identifying this monitor for the
+   /// CCD API, independently of the adapter source it is (or was) bound to.
+   /// </summary>
+   public string InterfacePath { get; set; } = "";
    public Edid Edid { get; set; }
    public string MonitorNumber { get; set; } = "";
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/DisplaySource.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/DisplaySource.cs
@@ -75,6 +75,13 @@ public class DisplaySource : SavableReactiveModel
     public string DisplayName { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
     /// <summary>
+    /// Monitor device interface path (\\?\DISPLAY#...) : identifies the monitor for
+    /// the CCD API regardless of the adapter source it is (or was) bound to.
+    /// </summary>
+    [DataMember]
+    public string InterfacePath { get; set => this.RaiseAndSetIfChanged(ref field, value); }
+
+    /// <summary>
     /// Source number in windows system
     /// </summary>
     [DataMember]

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LayoutFactory.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LayoutFactory.cs
@@ -83,6 +83,8 @@ public static class LayoutFactory
 
     public static DisplaySource UpdateFrom(this DisplaySource source, MonitorDevice monitor)
     {
+        source.InterfacePath = monitor.InterfacePath;
+
         if(monitor.Connections.Count == 0) return source;
         var device = monitor.Connections[0];
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
@@ -84,7 +84,7 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
     {
         if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowDetachAsync)) return;
 
-        MonitorDeviceHelper.DetachFromDesktop(Model.ActiveSource.Source.DisplayName);
+        MonitorDeviceHelper.DetachFromDesktop(Model.ActiveSource.Source.InterfacePath);
     }
 
     async Task AttachToDesktopAsync(Window? owner)
@@ -92,7 +92,7 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
         if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowAttachAsync)) return;
 
         MonitorDeviceHelper.AttachToDesktop(
-            Model.ActiveSource.Source.DisplayName,
+            Model.ActiveSource.Source.InterfacePath,
             Model.ActiveSource.Source.Primary,
             Model.ActiveSource.Source.InPixel.Bounds,
             Model.ActiveSource.Source.Orientation


### PR DESCRIPTION
## Problem

`ChangeDisplaySettingsEx` addresses an adapter **source** (`\\.\DISPLAYn`), not a monitor. Once a monitor is detached from the desktop, Windows enumerates it as a binding candidate under **every** inactive source. With two monitors detached they both report the same first source, so `Connections[0].Parent.DeviceName` gave both tiles the same `DisplayName`, and clicking Attach on one monitor could light up the other — with the wrong mode applied on top (#404, #391, #362, #312).

Verified on hardware (instrumented repro, 3 monitors): with HEC0030 and SAME035 both detached, `EnumDisplayDevices` lists both monitors under each of the 4 inactive sources; attaching via the recorded source name lit up SAME035 instead of HEC0030.

## Fix

Attach and detach now go through the CCD API (`QueryDisplayConfig` / `SetDisplayConfig`), designating the monitor by its **device interface path** (`\\?\DISPLAY#...`):

- the interface path is captured during device enumeration (second `EnumDisplayDevices` call with `EDD_GET_DEVICE_INTERFACE_NAME`) and carried on `MonitorDevice` / `DisplaySource`;
- **detach** deactivates the active source→target path of that exact monitor;
- **attach** activates an available path whose *target* is that monitor (preferring a free source), then applies the requested position/resolution/orientation on the source the monitor got bound to (former `ChangeDisplaySettingsEx` logic, now unambiguous);
- the former source-based detach implementation is kept commented for reference.

## Validation on hardware

Same scenario as the repro, through the new code: detach HEC0030, detach SAME035 (both `-> True`, each targeting the right monitor), then attach HEC0030 → **HEC0030** lights up, SAME035 stays detached. Previously the exact same scenario lit up SAME035.

## Dependency

Depends on mgth/HLab.Core#2 (CCD API definitions) — the submodule pointer is bumped in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
