### PR TITLE
Replace the Detach button with an actions menu: Detach / Make primary

### DIFF
--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
@@ -331,6 +331,127 @@ public static class MonitorDeviceHelper
         return r == 0;
     }
 
+    /// <summary>
+    /// Make the monitor designated by its device interface path (\\?\DISPLAY#...)
+    /// the primary display. Windows defines the primary as the display at (0,0):
+    /// every attached display is shifted accordingly, pending (NoReset), then the
+    /// whole layout is applied at once so intermediate overlaps never exist.
+    /// </summary>
+    public static bool SetPrimary(string monitorDevicePath)
+    {
+        if (string.IsNullOrEmpty(monitorDevicePath)) return false;
+        if (QueryDisplayConfigPaths() is not { } cfg) return false;
+        var (paths, _) = cfg;
+
+        string sourceName = null;
+        for (var i = 0; i < paths.Length; i++)
+        {
+            if ((paths[i].Flags & DISPLAYCONFIG_PATH_ACTIVE) == 0) continue;
+            if (!string.Equals(
+                    GetTargetDevicePath(paths[i].TargetInfo.AdapterId, paths[i].TargetInfo.Id),
+                    monitorDevicePath, StringComparison.OrdinalIgnoreCase)) continue;
+
+            sourceName = GetSourceGdiName(paths[i].SourceInfo.AdapterId, paths[i].SourceInfo.Id);
+            break;
+        }
+
+        if (string.IsNullOrEmpty(sourceName))
+        {
+            Debug.WriteLine($"SetPrimary: no active path for {monitorDevicePath}");
+            return false;
+        }
+
+        var mode = GetCurrentMode(sourceName);
+        if (mode == null) return false;
+
+        var offset = mode.Position;
+        if (offset.X == 0 && offset.Y == 0) return true; // already at origin, hence primary
+
+        // The new primary must be written FIRST, at (0,0) with SetPrimary: once
+        // another display has already been moved pending, the SetPrimary write
+        // gets refused by the driver (verified on AMD).
+        var ok = SetModePending(sourceName, mode, offset, true);
+
+        if (ok)
+        {
+            var device = new WinGdi.DisplayDevice();
+            uint n = 0;
+            while (EnumDisplayDevices(null, n++, ref device, 0))
+            {
+                if ((device.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) == 0) continue;
+                if (device.DeviceName == sourceName) continue;
+
+                var current = GetCurrentMode(device.DeviceName);
+                if (current == null) continue;
+
+                if (SetModePending(device.DeviceName, current, offset, false)) continue;
+
+                ok = false;
+                break;
+            }
+        }
+
+        if (!ok)
+        {
+            ResaveCurrentConfiguration();
+            return false;
+        }
+
+        ApplyDesktop();
+        return true;
+    }
+
+    /// <summary>
+    /// Write a display mode to the registry (NoReset), shifted by the given offset.
+    /// The full current mode is carried along with the new position: a position-only
+    /// DevMode gets refused by some drivers, and an aborted pending write leaves the
+    /// registry configuration inconsistent, failing every further UpdateRegistry call.
+    /// </summary>
+    static bool SetModePending(string deviceName, DisplayMode current, Point offset, bool primary)
+    {
+        var devMode = new DevMode
+        {
+            Position = new WinDef.Point(
+                (int)(current.Position.X - offset.X),
+                (int)(current.Position.Y - offset.Y)),
+            PixelsWidth = (uint)current.Pels.Width,
+            PixelsHeight = (uint)current.Pels.Height,
+            DisplayFrequency = (uint)current.DisplayFrequency,
+            BitsPerPel = 32,
+            Fields = Position |
+                     PixelsWidth |
+                     PixelsHeight |
+                     DisplayFrequency |
+                     BitsPerPixel
+        };
+
+        var flag = ChangeDisplaySettingsFlags.UpdateRegistry | ChangeDisplaySettingsFlags.NoReset;
+        if (primary) flag |= ChangeDisplaySettingsFlags.SetPrimary;
+
+        var ch = ChangeDisplaySettingsEx(deviceName, ref devMode, 0, flag, 0);
+        if (ch == DispChange.Successful) return true;
+
+        Debug.WriteLine($"SetModePending failed on {deviceName} ({ch})");
+        return false;
+    }
+
+    /// <summary>
+    /// Re-apply and re-save the current active configuration as-is. Rewrites a
+    /// coherent registry state when pending display writes were aborted halfway,
+    /// which would otherwise fail every further UpdateRegistry call.
+    /// </summary>
+    static void ResaveCurrentConfiguration()
+    {
+        if (QueryDisplayConfigPaths() is not { } cfg) return;
+        var (paths, modes) = cfg;
+
+        SetDisplayConfig((uint)paths.Length, paths, (uint)modes.Length, modes,
+            SetDisplayConfigFlags.Apply
+            | SetDisplayConfigFlags.UseSuppliedDisplayConfig
+            | SetDisplayConfigFlags.AllowChanges
+            | SetDisplayConfigFlags.SaveToDatabase);
+    }
+
     // Former source-based implementation, kept for reference. It detached whatever
     // monitor was bound to the given \\.\DISPLAYn source by applying an empty mode:
     //

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -43,7 +43,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool StartElevated { get; set; } = false;
       public bool Elevated { get; set; } = true;
       public bool DebugTools { get; set; } = false;
-      public bool ShowAttachDetachWarning { get; set; } = true;
+      public bool ShowMonitorActionWarning { get; set; } = true;
       public int DaemonPort { get; set; } = 25196;
 
       public bool AdjustSpeedAllowed { get; } = false;
@@ -182,9 +182,10 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    bool DebugTools { get; set; }
 
    /// <summary>
-   /// Ask for confirmation before attaching a monitor to the desktop or detaching it
+   /// Ask for confirmation before monitor actions: attaching to the desktop,
+   /// detaching, or making a monitor the primary display
    /// </summary>
-   bool ShowAttachDetachWarning { get; set; }
+   bool ShowMonitorActionWarning { get; set; }
 
    /// <summary>
    /// Daemon port for TCP communication

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml
@@ -34,13 +34,13 @@
 				           Text="To get the monitor back with Windows:"
 				           FontSize="13" FontWeight="SemiBold"
 				           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
-				<TextBlock TextWrapping="Wrap" FontSize="12"
+				<TextBlock x:Name="Step1" TextWrapping="Wrap" FontSize="12"
 				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
 				           Text="1. Right-click the desktop and choose Display settings (or open Settings &gt; System &gt; Display)."/>
-				<TextBlock TextWrapping="Wrap" FontSize="12"
+				<TextBlock x:Name="Step2" TextWrapping="Wrap" FontSize="12"
 				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
 				           Text="2. Select the detached monitor, then under Multiple displays choose 'Extend desktop to this display'. There you can also fix the resolution and refresh rate."/>
-				<TextBlock TextWrapping="Wrap" FontSize="12"
+				<TextBlock x:Name="Step3" TextWrapping="Wrap" FontSize="12"
 				           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
 				           Text="3. If it is not listed, click 'Detect other display' there, or press Win+P and choose 'Extend'."/>
 			</StackPanel>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
@@ -42,6 +42,23 @@ public partial class MonitorWarningDialog : Window
         return dialog.ShowAsync(owner);
     }
 
+    public static Task<(bool Confirmed, bool DontShowAgain)> ShowMakePrimaryAsync(Window? owner)
+    {
+        var dialog = new MonitorWarningDialog
+        {
+            Title = "Make primary monitor"
+        };
+        dialog.HeadingText.Text = "Make this monitor the primary display?";
+        dialog.BodyText.Text = "Windows anchors the desktop on the primary display: every monitor position changes, open windows may move, and the taskbar goes to the new primary. LittleBigMouse will re-anchor its layout accordingly.";
+        dialog.RecoveryTitle.Text = "To revert:";
+        dialog.Step1.Text = "Use 'Make primary' on the previous monitor, or in Settings > System > Display select it and check 'Make this my main display'.";
+        dialog.Step2.IsVisible = false;
+        dialog.Step3.IsVisible = false;
+        dialog.ConfirmButton.Content = "Make primary";
+
+        return dialog.ShowAsync(owner);
+    }
+
     /// <summary>
     /// Returns whether the user confirmed the action, and whether the warning
     /// should be hidden from now on (only honoured when confirmed).

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -66,12 +66,12 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     bool _debugTools;
 
     [DataMember]
-    public bool ShowAttachDetachWarning
+    public bool ShowMonitorActionWarning
     {
-        get => _showAttachDetachWarning;
-        set => SetUnsavedValue(ref _showAttachDetachWarning, value);
+        get => _showMonitorActionWarning;
+        set => SetUnsavedValue(ref _showMonitorActionWarning, value);
     }
-    bool _showAttachDetachWarning = true;
+    bool _showMonitorActionWarning = true;
 
     public int DaemonPort
     { 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -210,9 +210,9 @@
 
 					<Border Classes="SettingCard">
 						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Warning}"
-						                     Header="Warn before attaching or detaching a monitor"
-						                     Description="Ask for confirmation and show recovery steps before changing a monitor's desktop attachment">
-							<ToggleSwitch IsChecked="{Binding Model.ShowAttachDetachWarning, FallbackValue=true, Mode=TwoWay}"/>
+						                     Header="Warn before monitor actions"
+						                     Description="Ask for confirmation before attaching, detaching or making a monitor primary">
+							<ToggleSwitch IsChecked="{Binding Model.ShowMonitorActionWarning, FallbackValue=true, Mode=TwoWay}"/>
 						</controls:SettingRow>
 					</Border>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
@@ -63,7 +63,8 @@ public static class PersistencyExtensions
         @this.StartMinimized = mainKey.GetOrSet("StartMinimized", () => key.GetOrSet("StartMinimized",() => false));
         @this.StartElevated = mainKey.GetOrSet("StartElevated", () => key.GetOrSet("StartElevated",() => false));
         @this.DebugTools = mainKey.GetOrSet("DebugTools", () => false);
-        @this.ShowAttachDetachWarning = mainKey.GetOrSet("ShowAttachDetachWarning", () => true);
+        // "ShowAttachDetachWarning" is the former name of the option, read as fallback
+        @this.ShowMonitorActionWarning = mainKey.GetOrSet("ShowMonitorActionWarning", () => mainKey.GetOrSet("ShowAttachDetachWarning", () => true));
 
         @this.ExcludedList.Clear();
 
@@ -143,13 +144,13 @@ public static class PersistencyExtensions
     }
 
     /// <summary>
-    /// Persist the attach/detach-warning preference on its own: it is changed from the
+    /// Persist the monitor-action-warning preference on its own: it is changed from the
     /// warning dialog itself, where the user may never go through the regular save-button flow.
     /// </summary>
-    public static void SaveShowAttachDetachWarning(this ILayoutOptions @this)
+    public static void SaveShowMonitorActionWarning(this ILayoutOptions @this)
     {
         using var mainKey = OpenRootRegKey(true);
-        mainKey?.SetKey("ShowAttachDetachWarning", @this.ShowAttachDetachWarning);
+        mainKey?.SetKey("ShowMonitorActionWarning", @this.ShowMonitorActionWarning);
     }
 
     public static void Save(this ILayoutOptions @this, RegistryKey? mainKey, RegistryKey? key)
@@ -162,7 +163,7 @@ public static class PersistencyExtensions
         mainKey.SetKey("StartMinimized", @this.StartMinimized);
         mainKey.SetKey("StartElevated", @this.StartElevated);
         mainKey.SetKey("DebugTools", @this.DebugTools);
-        mainKey.SetKey("ShowAttachDetachWarning", @this.ShowAttachDetachWarning);
+        mainKey.SetKey("ShowMonitorActionWarning", @this.ShowMonitorActionWarning);
 
         var file = ExcludedListPath();
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
@@ -245,7 +245,7 @@
 				<DropDownButton.Flyout>
 					<MenuFlyout>
 						<MenuItem Header="Detach" Command="{Binding DetachCommand}" CommandParameter="{Binding $parent[Window]}"/>
-						<MenuItem Header="Make primary" Command="{Binding MakePrimaryCommand}"/>
+						<MenuItem Header="Make primary" Command="{Binding MakePrimaryCommand}" CommandParameter="{Binding $parent[Window]}"/>
 					</MenuFlyout>
 				</DropDownButton.Flyout>
 			</DropDownButton>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorView.axaml
@@ -241,7 +241,14 @@
 
 		<StackPanel HorizontalAlignment="Left" VerticalAlignment="Bottom">
 			<Button IsVisible="{Binding !Attached}" Command="{Binding AttachCommand}" CommandParameter="{Binding $parent[Window]}">Attach</Button>
-			<Button IsVisible="{Binding DetachVisible}" Command="{Binding DetachCommand}" CommandParameter="{Binding $parent[Window]}">Detach</Button>
+			<DropDownButton IsVisible="{Binding DetachVisible}" Content="Actions">
+				<DropDownButton.Flyout>
+					<MenuFlyout>
+						<MenuItem Header="Detach" Command="{Binding DetachCommand}" CommandParameter="{Binding $parent[Window]}"/>
+						<MenuItem Header="Make primary" Command="{Binding MakePrimaryCommand}"/>
+					</MenuFlyout>
+				</DropDownButton.Flyout>
+			</DropDownButton>
 			<Label IsVisible="{Binding Primary}">Primary</Label>
 		</StackPanel>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
@@ -63,6 +63,12 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
         .ObserveOn(RxSchedulers.MainThreadScheduler));
 
         AttachCommand = ReactiveCommand.CreateFromTask<Window?>(AttachToDesktopAsync,this.WhenAnyValue(e => e.Attached, e => !e).ObserveOn(RxSchedulers.MainThreadScheduler));
+
+        MakePrimaryCommand = ReactiveCommand.Create(MakePrimary,this.WhenAnyValue(
+            e => e.Attached,
+            e => e.Primary,
+            (attached,primary) => attached && !primary)
+        .ObserveOn(RxSchedulers.MainThreadScheduler));
     }
 
     public bool Attached => _attached.Value;
@@ -79,6 +85,7 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
 
     public ICommand AttachCommand { get; }
     public ICommand DetachCommand { get; }
+    public ICommand MakePrimaryCommand { get; }
 
     async Task DetachFromDesktopAsync(Window? owner)
     {
@@ -97,6 +104,11 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
             Model.ActiveSource.Source.InPixel.Bounds,
             Model.ActiveSource.Source.Orientation
             );
+    }
+
+    void MakePrimary()
+    {
+        MonitorDeviceHelper.SetPrimary(Model.ActiveSource.Source.InterfacePath);
     }
 
     async Task<bool> ConfirmAsync(Window? owner, Func<Window?, Task<(bool Confirmed, bool DontShowAgain)>> showDialog)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
@@ -64,7 +64,7 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
 
         AttachCommand = ReactiveCommand.CreateFromTask<Window?>(AttachToDesktopAsync,this.WhenAnyValue(e => e.Attached, e => !e).ObserveOn(RxSchedulers.MainThreadScheduler));
 
-        MakePrimaryCommand = ReactiveCommand.Create(MakePrimary,this.WhenAnyValue(
+        MakePrimaryCommand = ReactiveCommand.CreateFromTask<Window?>(MakePrimaryAsync,this.WhenAnyValue(
             e => e.Attached,
             e => e.Primary,
             (attached,primary) => attached && !primary)
@@ -106,8 +106,10 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
             );
     }
 
-    void MakePrimary()
+    async Task MakePrimaryAsync(Window? owner)
     {
+        if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowMakePrimaryAsync)) return;
+
         MonitorDeviceHelper.SetPrimary(Model.ActiveSource.Source.InterfacePath);
     }
 
@@ -115,14 +117,14 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
     {
         var options = Model.Layout.Options;
 
-        if (!options.ShowAttachDetachWarning) return true;
+        if (!options.ShowMonitorActionWarning) return true;
 
         var (confirmed, dontShowAgain) = await showDialog(owner);
 
         if (confirmed && dontShowAgain)
         {
-            options.ShowAttachDetachWarning = false;
-            options.SaveShowAttachDetachWarning();
+            options.ShowMonitorActionWarning = false;
+            options.SaveShowMonitorActionWarning();
         }
 
         return confirmed;


### PR DESCRIPTION
## Summary

The Detach button on monitor tiles becomes an **Actions** dropdown offering:
- **Detach** — unchanged behavior, still guarded by the confirmation dialog (#475) and targeting by monitor identity (#476);
- **Make primary** — new: makes the monitor the primary display.

The menu is shown exactly where the Detach button used to be (attached, non-primary monitors). The Attach button is unchanged.

## Make primary implementation

The monitor is designated by its device interface path like attach/detach: the source it is currently bound to is resolved through the CCD API, then every attached display is shifted so the new primary sits at (0,0), pending (`NoReset`), and the layout is applied in one step.

Two driver quirks shape the code (verified on hardware, AMD RX 7900 XTX):
- the pending write for the new primary must come **first** — once another display has been moved pending, the `CDS_SET_PRIMARY` write is refused;
- each write must carry the **full current mode** (resolution, frequency, depth), not only the position.

An aborted pending sequence leaves the registry display configuration inconsistent, after which *every* `UpdateRegistry` write fails until a coherent configuration is written again — so every return code is checked, and on failure the current configuration is re-applied and re-saved through `SetDisplayConfig` before giving up.

## Validation on hardware

3-monitor setup: Make primary on HEC0030 → HEC0030 becomes primary at (0,0), the other displays shift accordingly, refresh rates preserved (240Hz monitor stays at 240Hz). Make primary on PHL0927 → original layout restored exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
