### PR TITLE
Hide specialized displays (VR headsets) and heal persisted 0x0 monitor sizes

### DIFF
--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
@@ -701,6 +701,7 @@ public static class MonitorDeviceHelper
         }
 
         UpdateMonitorNumbers(list);
+        UpdateSpecializedMonitors(list);
 
         return root;
     }
@@ -792,6 +793,43 @@ public static class MonitorDeviceHelper
         return (path, id);
     }
 
+
+    static bool IsSpecializedTarget(Luid adapterId, uint targetId)
+    {
+        var request = new DisplayConfigGetMonitorSpecialization
+        {
+            Type = DISPLAYCONFIG_DEVICE_INFO_GET_MONITOR_SPECIALIZATION,
+            Size = (uint)Marshal.SizeOf<DisplayConfigGetMonitorSpecialization>(),
+            AdapterId = adapterId,
+            Id = targetId,
+        };
+        // the query is unsupported before Windows 11: treat failures as not specialized
+        return DisplayConfigGetDeviceInfo(ref request) == 0 && request.IsSpecializationEnabled;
+    }
+
+    /// <summary>
+    /// Flag monitors bound to a specialized target (VR headsets like Windows Mixed
+    /// Reality): they are driven by a dedicated runtime and hidden from the desktop
+    /// by Windows, so they must not take part in the mouse layout (#364).
+    /// </summary>
+    static void UpdateSpecializedMonitors(IEnumerable<MonitorDevice> monitors)
+    {
+        if (QueryDisplayConfigPaths() is not { } cfg) return;
+
+        foreach (var path in cfg.Paths)
+        {
+            if (!path.TargetInfo.TargetAvailable) continue;
+            if (!IsSpecializedTarget(path.TargetInfo.AdapterId, path.TargetInfo.Id)) continue;
+
+            var devicePath = GetTargetDevicePath(path.TargetInfo.AdapterId, path.TargetInfo.Id);
+            if (string.IsNullOrEmpty(devicePath)) continue;
+
+            foreach (var monitor in monitors)
+            {
+                if (monitor.InterfacePath == devicePath) monitor.IsSpecialized = true;
+            }
+        }
+    }
 
     /// <summary>
     /// Assign each monitor the number Windows shows in Settings > System > Display.

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
@@ -19,6 +19,12 @@ public class MonitorDevice : IEquatable<MonitorDevice>
    public Edid Edid { get; set; }
    public string MonitorNumber { get; set; } = "";
 
+   /// <summary>
+   /// Specialized display (VR headset like Windows Mixed Reality...): driven by a
+   /// dedicated runtime and hidden from the desktop by Windows.
+   /// </summary>
+   public bool IsSpecialized { get; set; }
+
    [XmlIgnore]
    public List<MonitorDeviceConnection> Connections = new();
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LayoutFactory.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LayoutFactory.cs
@@ -27,6 +27,11 @@ public static class LayoutFactory
 
         foreach (var monitor in service.Root.AllMonitorDevices())
         {
+            // Specialized displays (VR headsets...) are hidden from the desktop by
+            // Windows: keep them out of the layout too, the cursor can never reach
+            // them and their zone would only trap it (#364)
+            if (monitor.IsSpecialized) continue;
+
             var source = layout.PhysicalSources.FirstOrDefault(s => s.DeviceId == monitor.Id);
 
             if (source != null)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Persistency/PersistencyExtentions.cs
@@ -360,8 +360,16 @@ public static class PersistencyExtensions
                 @this.PhysicalSize.BottomBorder = key.GetOrSet(@"Borders\Bottom", ()=>@this.PhysicalSize.BottomBorder);
                 @this.PhysicalSize.LeftBorder = key.GetOrSet(@"Borders\Left", ()=>@this.PhysicalSize.LeftBorder);
 
-                @this.PhysicalSize.Height = key.GetOrSet(@"Size\Height", ()=>@this.PhysicalSize.Height);
-                @this.PhysicalSize.Width = key.GetOrSet(@"Size\Width", ()=>@this.PhysicalSize.Width);
+                // Versions predating the EDID-less size fallback persisted the bogus
+                // 0x0 GDI placeholder for virtual displays (#419): a stored
+                // non-positive size must not override the freshly computed one.
+                var height = key.GetOrSet(@"Size\Height", ()=>@this.PhysicalSize.Height);
+                if (height > 0) @this.PhysicalSize.Height = height;
+                else key.SetKey(@"Size\Height", @this.PhysicalSize.Height.ToString(CultureInfo.InvariantCulture));
+
+                var width = key.GetOrSet(@"Size\Width", ()=>@this.PhysicalSize.Width);
+                if (width > 0) @this.PhysicalSize.Width = width;
+                else key.SetKey(@"Size\Width", @this.PhysicalSize.Width.ToString(CultureInfo.InvariantCulture));
 
                 @this.PhysicalSize.Saved = true;
 


### PR DESCRIPTION
Two follow-ups on the EDID-less/virtual display work (`e9472ad`), addressing the remaining actionable parts of the phantom-display cluster.

## Specialized displays kept out of the layout (#364)

VR headsets (Windows Mixed Reality...) are *specialized displays*: driven by a dedicated runtime and hidden from the desktop by Windows — they don't appear in the display settings, yet LBM enumerated them into the layout where their zone could only trap the cursor.

The CCD `DISPLAYCONFIG_DEVICE_INFO_GET_MONITOR_SPECIALIZATION` query (added in mgth/HLab.Core#3, must be merged together with this PR) flags the monitors bound to a specialized target, and `LayoutFactory` now keeps them out of the layout. On systems where the query is unsupported (pre-Windows 11) it fails gracefully and nothing is filtered.

Verified on a 4-monitor dual-GPU rig: no false positives, numbering intact. The positive case (an actual WMR headset) needs a retest by the #364 reporter.

## Healing of persisted 0x0 monitor sizes (#419)

`e9472ad` computes a sane physical size for EDID-less displays (spacedesk, DisplayLink, RDP...), but anyone who ran LBM on such a display *before* the fix had the bogus 0x0 GDI placeholder persisted in `monitors\{PnpCode}\Size` — and loading let the stored value override the freshly computed one, so existing victims stayed at 0x0. A stored non-positive size is now ignored and rewritten with the computed value.

## Bonus incident note

While validating on the dual-GPU rig after a reboot, Windows itself renumbered the displays (adapter LUIDs are reallocated at boot and their order flipped, iGPU first). Settings showed the new order and LBM followed it exactly — the #479 rule holds under adapter reordering.

Refs #364, #419, #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
