### PR TITLE
Daemon: remember which physical monitor the cursor entered a clone by

### DIFF
--- a/LittleBigMouse.Hook/Engine/MouseEngine.cpp
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.cpp
@@ -247,7 +247,7 @@ void MouseEngine::OnMouseMoveCross(MouseEventArg& e)
 
 	if(Layout.LoopX)
 	{
-		const Zone* zoneOut = nullptr;
+		Zone* zoneOut = nullptr;
 		// we are moving left
 		if(trip.B().X() < trip.A().X())
 			zoneOut = FindTargetZone(nullptr, trip + geo::Point<double>(Layout.Width(),0), pOutInMm, minDistSquared);
@@ -270,7 +270,7 @@ void MouseEngine::OnMouseMoveCross(MouseEventArg& e)
 
 	if(Layout.LoopY)
 	{
-		const Zone* zoneOut = nullptr;
+		Zone* zoneOut = nullptr;
 
 		// we are moving top
 		if(trip.B().Y() < trip.A().Y())
@@ -441,18 +441,24 @@ void MouseEngine::OnMouseMoveStraight(MouseEventArg& e)
 	Move(e, pOut, zoneLinkOut->Target);
 }
 
-void MouseEngine::MoveInMm(MouseEventArg& e, const geo::Point<double>& pOutInMm, const Zone* zoneOut)
+void MouseEngine::MoveInMm(MouseEventArg& e, const geo::Point<double>& pOutInMm, Zone* zoneOut)
 {
 	const auto pOut = zoneOut->ToPixels(pOutInMm);
 
 	Move(e, pOut, zoneOut);
 }
 
-void MouseEngine::Move(MouseEventArg& e, const geo::Point<long>& pOut, const Zone* zoneOut)
+void MouseEngine::Move(MouseEventArg& e, const geo::Point<long>& pOut, Zone* zoneOut)
 {
 	const auto travel = _oldZone->TravelPixels(Layout.MainZones, zoneOut);
 
-	_oldZone = zoneOut->Main;
+	// Keep the zone the cursor actually entered: with duplicated displays several
+	// zones share the same pixel space but sit at different physical locations,
+	// and the exit must be computed from the physical monitor the cursor came in
+	// through (#83, #222). Folding onto Main here lost that memory. Loop copies
+	// never reach this point: their link targets are redirected to the real zone
+	// before serialization.
+	_oldZone = zoneOut;
 	_oldPoint = pOut;
 
 	const auto r = zoneOut->PixelsBounds();

--- a/LittleBigMouse.Hook/Engine/MouseEngine.h
+++ b/LittleBigMouse.Hook/Engine/MouseEngine.h
@@ -40,8 +40,8 @@ class MouseEngine
 	bool TryPassBorderPixel(const ZoneLink* zoneLink, long distance);
 
 	//Final move
-	void Move(MouseEventArg& e, const geo::Point<long>& pOut, const Zone* zoneOut);
-	void MoveInMm(MouseEventArg& e, const geo::Point<double>& pOutInMm, const Zone* zoneOut);
+	void Move(MouseEventArg& e, const geo::Point<long>& pOut, Zone* zoneOut);
+	void MoveInMm(MouseEventArg& e, const geo::Point<double>& pOutInMm, Zone* zoneOut);
 
 	//Final move, cancel leaving monitor
 	void NoZoneMatches(MouseEventArg& e);


### PR DESCRIPTION
## Problem

#83 / #222 — with duplicated displays the cursor behaves as if the clones were separate screens, crossing "between" them and exiting from the wrong place.

The intended design keeps both physical monitors in the layout, bound to the same pixel source. The cursor's pixel position cannot tell which physical monitor it is on, so the daemon must remember which one the cursor *entered through*, and compute the exit from that monitor's borders and neighbors.

## Analysis

The whole pipeline already carries everything needed:

- the UI computes and serializes **per-clone zones with their own links** (verified with a real CCD clone: two zones share `px=3840,0 3840x2160`, each with its own physical bounds and links — PHL→Odyssey on the right, Odyssey→HISENSE on the right, HISENSE→Odyssey on the left);
- link `TargetId`s resolve to the actual physical neighbor in the C++ layout;
- the C++ layout infers the `Main` relation from pixel-bounds equality at parse time.

But `MouseEngine::Move` did `_oldZone = zoneOut->Main`, folding the entered zone onto the first clone sharing its pixels: the entry memory was destroyed and every exit was computed from the wrong physical monitor.

## Fix

Keep the zone the cursor actually entered (`_oldZone = zoneOut`). Loop copies are unaffected: they are never serialized and their link targets are redirected to the real zone before serialization, so the Main-folding only ever mattered for real clones — where it was wrong. `Move`/`MoveInMm` signatures drop a `const` to allow storing the entered zone.

Refs #83, #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
