### PR TITLE
Stop the DI container from retaining every layout generation

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -22,6 +22,7 @@
 */
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -200,9 +201,37 @@ public class MainService : ReactiveModel, IMainService
 
     Task StartAsync() => _littleBigMouseClientService.StartAsync(MonitorsLayout.ComputeZones());
 
+    /// <summary>
+    /// Rolling trace of daemon events: display-event storms (wake from sleep, HDR
+    /// flapping...) rebuild the layout every 5s for hours, and identifying the
+    /// looping event after the fact is otherwise impossible.
+    /// </summary>
+    static void TraceDaemonEvent(LittleBigMouseEvent evt)
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Mgth", "LittleBigMouse");
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "daemon-events.log");
+
+            if (File.Exists(file) && new FileInfo(file).Length > 1_000_000)
+                File.WriteAllText(file, "");
+
+            File.AppendAllText(file, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {evt}\r\n");
+        }
+        catch
+        {
+            // tracing must never take the app down
+        }
+    }
+
     bool _justConnected = false;
     async Task DaemonEventReceived(object? sender, LittleBigMouseServiceEventArgs args)
     {
+        TraceDaemonEvent(args.Event);
+
         switch (args.Event)
         {
             case LittleBigMouseEvent.Running:

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
@@ -121,7 +121,12 @@ internal class Program
                 c.Export<LittleBigMouseClientService>().As<ILittleBigMouseClientService>().Lifestyle.Singleton();
                 c.Export<LbmOptions>().As<ILayoutOptions>().Lifestyle.Singleton();
                 c.Export<ProcessesCollector>().As<IProcessesCollector>().Lifestyle.Singleton();
-                //c.Export<MonitorsLayout>().As<IMonitorsLayout>();
+
+                // A new layout is built on every display change and the previous one is
+                // disposed by MainService. Grace must NOT track these transients in its
+                // root disposal scope: it would keep every generation reachable until
+                // app shutdown (gigabytes after hours of display-event storms).
+                c.Export<MonitorsLayout>().ExternallyOwned();
 
                 c.Export<MainViewModel>().As<IMainPluginsViewModel>().Lifestyle.Singleton();
 


### PR DESCRIPTION
## Incident

After a wake from sleep, every tab switch in the UI took ~25 seconds. Live diagnosis on the affected process:

- stack sampling showed the UI thread CPU-bound in Avalonia styling/invalidation;
- the process had grown to **19 GB / 410 million objects**;
- a display-event storm had been running for hours: at least one daemon event every 5 seconds (saturating the debounce), each rebuilding a full `MonitorsLayout` and restarting the engine;
- `gcroot` on a dump showed **2,769 retained layout generations**, all rooted by the same chain: `Grace DisposalScope → DisposeEntry → MonitorsLayout`.

## Root cause

`MonitorsLayout` is `IDisposable` and resolved through the injected `Func<MonitorsLayout>`: Grace registers every instance it creates in its **root disposal scope**, to be disposed at container shutdown. Every generation stayed reachable for the app's lifetime. `MainService.UpdateLayout`'s `old?.Dispose()` and the #412 fix were correct but powerless against that root — which is also why the headless repro (plain `new`, no DI) collected generations cleanly while the real app leaked.

## Fix

`c.Export<MonitorsLayout>().ExternallyOwned()` — Grace no longer tracks these transients; `MainService` remains their sole owner.

**Verified on the live app**: after 5 forced layout rebuilds (monitor detach/attach cycles), exactly **1** `MonitorsLayout` and 4 `PhysicalSource` remain in a GC dump (previously: one generation per rebuild, forever).

## Storm instrumentation

The storm stopped on its own before it could be identified (prime suspect: HDR flapping on a TV). `MainService` now traces every daemon event with a timestamp to a 1 MB rolling log (`%LOCALAPPDATA%\Mgth\LittleBigMouse\daemon-events.log`) — the missing piece to attack the sleep/wake cluster (#402, #405, #399) next time it happens.

## Follow-up worth noting

Transient view models resolved through the container are `IDisposable` too and get tracked the same way (much lower volume). A later pass should either `ExternallyOwned` them or reconsider disposal tracking globally.

Refs #402, #405, #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
