### PR TITLE
Release: stamp builds with the git tag, supersede the old NSIS install

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -36,8 +36,22 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
 
+    - name: Derive version from tag
+      id: ver
+      run: |
+        if ("${{ github.ref }}" -like "refs/tags/v*") {
+          $v = "${{ github.ref_name }}" -replace '^v',''
+        } else {
+          $v = ""
+        }
+        "version=$v" >> $env:GITHUB_OUTPUT
+        Write-Host "Release version: '$v'"
+
     - name: Build UI (net10, x64 Release)
-      run: dotnet build $env:UI_PROJECT -c Release -p:Platform=x64
+      run: |
+        $buildArgs = @('-c','Release','-p:Platform=x64')
+        if ("${{ steps.ver.outputs.version }}") { $buildArgs += "-p:Version=${{ steps.ver.outputs.version }}" }
+        dotnet build $env:UI_PROJECT @buildArgs
 
     - name: Build hook (C++, x64 Release)
       run: msbuild $env:HOOK_PROJECT /m /p:Configuration=Release /p:Platform=x64
@@ -57,7 +71,7 @@ jobs:
     - name: Compile installer (InnoSetup)
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" LittleBigMouse.Setup\LittleBigMouse.iss
+        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" "/DAppVer=${{ steps.ver.outputs.version }}" LittleBigMouse.Setup\LittleBigMouse.iss
 
     - name: Upload installer artifact
       if: startsWith(github.ref, 'refs/tags/v')

--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -1,8 +1,13 @@
 ﻿; -- LittleBigMouse.iss --
-#define AppVer GetVersionNumbersString('..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\LittleBigMouse.Ui.Avalonia.exe')
-;#define AppVer '5.0.0'
+; AppVer is normally passed by CI from the git tag (ISCC /DAppVer=5.3.0-beta.2)
+; so betas are distinguishable in Programs & Features and in the installer name.
+; Falls back to the built exe's numeric FileVersion for a manual local compile.
+#ifndef AppVer
+  #define AppVer GetVersionNumbersString('..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\LittleBigMouse.Ui.Avalonia.exe')
+#endif
 
 [Setup]
+AppId={{C170D4ED-CDCC-4383-8907-B85461E643FF}
 AppName=Little Big Mouse
 AppVersion={#AppVer}
 DefaultDirName={commonpf}\LittleBigMouse
@@ -24,6 +29,16 @@ Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0
 ;Source: "..\bin\x86\Release\net10.0\*.exe"; DestDir: "{app}"; Check: not Is64BitInstallMode
 ;Source: "..\bin\x86\Release\net10.0\*.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode
 ;Source: "..\bin\x86\Release\net10.0\*.xml"; DestDir: "{app}"; Check: not Is64BitInstallMode; Flags: recursesubdirs
+
+[InstallDelete]
+; Old NSIS install (<= 5.2.3) lived in the same folder; drop its leftover uninstaller.
+Type: files; Name: "{app}\Uninstall.exe"
+
+[Registry]
+; Remove the stale "LittleBigMouse" (NSIS, <= 5.2.3) Programs & Features entry so it
+; no longer shows up next to the Inno-installed one. Cover both registry views.
+Root: HKLM64; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\LittleBigMouse"; Flags: deletekey; Check: IsWin64
+Root: HKLM32; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\LittleBigMouse"; Flags: deletekey
 
 [Icons]
 Name: "{group}\Little Big Mouse"; Filename: "{app}\LittleBigMouse.Ui.Avalonia.exe"


### PR DESCRIPTION
## Why

Two release-hygiene bugs surfaced while preparing 5.3.0-beta.2:

1. **Betas are indistinguishable.** Every 5.3 build reports `FileVersion 5.3.0.0`, so beta.1, beta.2 and the future stable look identical in Programs & Features, in the installer filename, and in the app. The only differentiator was the git hash baked into `ProductVersion` — not visible to users. A tester who installed "beta.2" was in fact still on beta.1 with no way to tell.
2. **The old NSIS install lingers.** The Inno installer registered its own uninstall entry (`unins000.exe`) instead of superseding the pre-5.3 NSIS install (`Uninstall.exe`), leaving a stale `LittleBigMouse 5.2.3.0` next to the new `Little Big Mouse 5.3.0.0` in Programs & Features.

## What

- **CI derives the version from the tag** (`v5.3.0-beta.2` → `5.3.0-beta.2`) and passes it to:
  - the build via `-p:Version`, so `InformationalVersion`/`ProductVersion` carries the prerelease suffix;
  - ISCC via `/DAppVer`, so the installer `AppVersion` (Programs & Features) and the output filename become `LittleBigMouse_5.3.0-beta.2.exe`.
  - Non-tag builds are unchanged (fall back to the csproj default).
- **`LittleBigMouse.iss`**:
  - `AppVer` guarded behind `#ifndef` with the previous `GetVersionNumbersString` fallback for manual local compiles;
  - stable `AppId` GUID so future upgrades supersede cleanly;
  - `[Registry]` deletekey (both views) + `[InstallDelete]` to remove the stale NSIS entry and its leftover `Uninstall.exe`.

Validated by compiling the installer locally with `ISCC /DAppVer=5.3.0-beta.2` → `Successful compile`, output `LittleBigMouse_5.3.0-beta.2.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)