### PR TITLE
Installer: force-close the running app on install/uninstall

### DIFF
--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -18,6 +18,12 @@ SolidCompression=yes
 OutputDir="."
 ArchitecturesInstallIn64BitMode=x64
 OutputBaseFilename=LittleBigMouse_{#AppVer}
+; Force-close the running app instead of asking the user: the Restart Manager's
+; polite WM_CLOSE is treated as "minimize to tray" by the UI and ignored by the
+; windowless hook, so the default (CloseApplications=yes) leaves files locked.
+; A hard taskkill in [Code] backs this up (see StopLittleBigMouse).
+CloseApplications=force
+RestartApplications=no
 
 [Files]
 Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs
@@ -46,8 +52,29 @@ Name: "{group}\Little Big Mouse"; Filename: "{app}\LittleBigMouse.Ui.Avalonia.ex
 [Run]
 Filename: {app}\LittleBigMouse.Ui.Avalonia.exe; Description: Run Application; Flags: postinstall nowait skipifsilent runascurrentuser
 
-;[UninstallRun]
-;Filename: "{cmd}"; Parameters: "/C ""taskkill /im LittleBigMouse.Ui.Avalonia.exe /f /t"
-;Filename: "{cmd}"; Parameters: "/C ""taskkill /im LittleBigMouse.Hook.exe /f /t"
-;Filename: "{app}\LittleBigMouse_Daemon.exe"; Parameters: "--unschedule --exit"
+[Code]
+procedure StopLittleBigMouse;
+var
+  ResultCode: Integer;
+begin
+  { Hard-kill every LittleBigMouse* process (UI loader, UI, and the elevated hook)
+    so their files unlock before we copy/remove them. The wildcard also covers the
+    old pre-5.3 daemon names. The installer runs elevated, so it can end the
+    elevated hook. Missing processes just make taskkill a no-op. }
+  Exec(ExpandConstant('{sys}\taskkill.exe'),
+       '/F /FI "IMAGENAME eq LittleBigMouse*"', '',
+       SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  StopLittleBigMouse;
+  Result := '';
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+    StopLittleBigMouse;
+end;
 


### PR DESCRIPTION
## Problem

Installing (or uninstalling) while Little Big Mouse is running left its files locked. The Inno Restart Manager sends a polite close, which the UI treats as *minimize to tray* and the windowless, elevated hook ignores entirely — so the default `CloseApplications=yes` shows the "please close the application" prompt and can't continue. Casual users had to kill `LittleBigMouse.Ui.Loader.exe` / `LittleBigMouse.Ui.Avalonia.exe` / `LittleBigMouse.Hook.exe` by hand.

## Fix

- `CloseApplications=force` + `RestartApplications=no` so Inno force-closes the file-locking processes via the Restart Manager without prompting.
- `[Code] StopLittleBigMouse`: a hard `taskkill /F /FI "IMAGENAME eq LittleBigMouse*"` run in `PrepareToInstall` (before file copy) and in `CurUninstallStepChanged(usUninstall)` (before removal). The wildcard also covers the old pre-5.3 daemon names, and the installer runs elevated so it can end the elevated hook. It's a no-op when nothing matches.

Validated by compiling locally (`ISCC /DAppVer=5.3.0-beta.2` → successful) with fresh `1dea381` binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)