### PR TITLE
Installer: fix the close-fix killing the setup itself (wildcard)

### DIFF
--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -53,17 +53,25 @@ Name: "{group}\Little Big Mouse"; Filename: "{app}\LittleBigMouse.Ui.Avalonia.ex
 Filename: {app}\LittleBigMouse.Ui.Avalonia.exe; Description: Run Application; Flags: postinstall nowait skipifsilent runascurrentuser
 
 [Code]
-procedure StopLittleBigMouse;
+procedure KillImage(const ExeName: String);
 var
   ResultCode: Integer;
 begin
-  { Hard-kill every LittleBigMouse* process (UI loader, UI, and the elevated hook)
-    so their files unlock before we copy/remove them. The wildcard also covers the
-    old pre-5.3 daemon names. The installer runs elevated, so it can end the
-    elevated hook. Missing processes just make taskkill a no-op. }
-  Exec(ExpandConstant('{sys}\taskkill.exe'),
-       '/F /FI "IMAGENAME eq LittleBigMouse*"', '',
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM ' + ExeName, '',
        SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+procedure StopLittleBigMouse;
+begin
+  { Hard-kill the running app (UI loader, UI, and the elevated hook) so their files
+    unlock before we copy/remove them. Kill by EXACT image name only: a wildcard like
+    "LittleBigMouse*" would also match the setup EXE itself (LittleBigMouse_<ver>.exe)
+    and the installer would terminate itself mid-install. The installer runs elevated,
+    so it can end the elevated hook. Missing processes just make taskkill a no-op. }
+  KillImage('LittleBigMouse.Ui.Loader.exe');
+  KillImage('LittleBigMouse.Ui.Avalonia.exe');
+  KillImage('LittleBigMouse.Hook.exe');
+  KillImage('LittleBigMouse_Daemon.exe');
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;


### PR DESCRIPTION
## Problem (regression from #486)

#486 closed the running app before install with `taskkill /F /FI "IMAGENAME eq LittleBigMouse*"`. That wildcard **also matches the setup executable**, which is named `LittleBigMouse_<version>.exe`. So `PrepareToInstall` killed the app *and the installer itself*: the setup died right after creating its temp directory, leaving an empty install folder and a failed install (exit 1). Users saw the app processes die and then the installer "crash", every time.

Diagnosed with a logged silent run — the Inno log stopped at `Created temporary directory` with nothing after.

## Fix

Kill only the **exact** image names — `LittleBigMouse.Ui.Loader.exe`, `LittleBigMouse.Ui.Avalonia.exe`, `LittleBigMouse.Hook.exe`, `LittleBigMouse_Daemon.exe` — none of which equals the setup exe name.

## Verified

Silent logged install now: `Installation process succeeded`, exit 0, folder fully populated, `ProductVersion 5.3.0-beta.2`, and the stale NSIS `LittleBigMouse 5.2.3.0` Programs & Features entry removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)