### PR TITLE
Installer: restore the LBM icon on the setup executable

### DIFF
--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -13,6 +13,8 @@ AppVersion={#AppVer}
 DefaultDirName={commonpf}\LittleBigMouse
 DefaultGroupName=Little Big Mouse
 UninstallDisplayIcon={app}\LittleBigMouse.Ui.Avalonia.exe
+; Give the setup .exe the LBM icon (the NSIS installer used to, the Inno one didn't).
+SetupIconFile=..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\Assets\lbm-logo.ico
 Compression=lzma2
 SolidCompression=yes
 OutputDir="."


### PR DESCRIPTION
The NSIS installer set `MUI_ICON` to `lbm-logo.ico`; the Inno `.iss` never set `SetupIconFile`, so the setup `.exe` shipped with the generic Inno icon. This points `SetupIconFile` at the same `Assets\lbm-logo.ico` the app (`ApplicationIcon`) and the old NSIS installer use.

Verified: recompiled installer's associated icon extracts cleanly (no longer the Inno default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)