### PR TITLE
Updater: don't let a non-numeric release title break updates

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -85,5 +85,9 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         draft: true
+        # Name the release with the bare numeric version (not the "v5.3.0" tag): the
+        # in-app updater parses the release name as a Version, and a "v" prefix or a
+        # word breaks it (shows "online version 0.0" and blocks the upgrade).
+        name: ${{ steps.ver.outputs.version }}
         files: LittleBigMouse.Setup\LittleBigMouse_*.exe
         generate_release_notes: true

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Updater/ApplicationUpdaterViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Updater/ApplicationUpdaterViewModel.cs
@@ -163,18 +163,40 @@ public class ApplicationUpdaterViewModel : ViewModel, IApplicationUpdater
 
         client.DefaultRequestHeaders.Add("User-Agent", "LittleBigMouse");
         var r = await client.GetAsync("https://api.github.com/repos/Mgth/LittleBigMouse/releases");
-        var json = JsonNode.Parse(r.Content.ReadAsStringAsync().Result);
+        var json = JsonNode.Parse(await r.Content.ReadAsStringAsync());
 
-        var name = json[0]["name"].GetValue<string>();
+        if (json is not JsonArray releases) return;
 
-        Message = json[0]["body"].ToString();
-
-        Url = json[0]["assets"][0]["browser_download_url"].ToString();
-
-        if (Version.TryParse(name, out var onlineVersion))
+        // Pick the newest published, non-prerelease release that has a downloadable asset
+        // and a parseable version. Read the version from the release name (historically a
+        // bare "5.2.3.0") but fall back to the tag ("v5.3.0"), and tolerate a "v" prefix,
+        // so a non-numeric release title can no longer break updates (was showing "0.0").
+        foreach (var release in releases)
         {
+            if (release is null) continue;
+            if (release["draft"]?.GetValue<bool>() == true) continue;
+            if (release["prerelease"]?.GetValue<bool>() == true) continue;
+
+            if (release["assets"] is not JsonArray assets || assets.Count == 0) continue;
+
+            if (!TryParseVersion(release["name"]?.GetValue<string>(), out var onlineVersion)
+                && !TryParseVersion(release["tag_name"]?.GetValue<string>(), out onlineVersion))
+                continue;
+
             NewVersion = onlineVersion;
+            Message = release["body"]?.ToString() ?? "";
+            Url = assets[0]?["browser_download_url"]?.ToString() ?? "";
+            return;
         }
+    }
+
+    static bool TryParseVersion(string? text, out Version version)
+    {
+        version = new Version();
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        text = text.Trim();
+        if (text[0] is 'v' or 'V') text = text[1..];
+        return Version.TryParse(text, out version!);
     }
     
     public async Task CheckUpdateAsync(bool show)


### PR DESCRIPTION
## Problem

The in-app updater parses the GitHub release **name** as a `Version` ([ApplicationUpdaterViewModel.cs](LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Updater/ApplicationUpdaterViewModel.cs)):

```csharp
var name = json[0]["name"].GetValue<string>();
if (Version.TryParse(name, out var onlineVersion)) NewVersion = onlineVersion;
```

Old releases were named `5.2.3.0` (bare number) so it worked. The 5.3.0 release was named `Little Big Mouse 5.3.0`, and the CI default would otherwise be the tag `v5.3.0` — both fail `Version.TryParse`, so the updater shows **"online version 0.0"** and blocks the upgrade for every already-deployed client (5.2.3, beta.1, …).

## Fix

- **CI** names the release with the bare numeric version (`steps.ver.outputs.version`) instead of the `v`-prefixed tag, so the currently-deployed updaters keep working on the next release.
- **`CheckVersion()`** hardened for future clients: iterate releases, skip drafts/prereleases, require a downloadable asset, read the version from the release name **and fall back to `tag_name`**, tolerating a leading `v`. Also `await` the response instead of blocking on `.Result`.

The already-published 5.3.0 release was renamed to `5.3.0.0` by hand as the immediate unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)