### PR TITLE
Updater: scroll the changelog so long notes can't hide the buttons

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Updater/ApplicationUpdaterView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Updater/ApplicationUpdaterView.axaml
@@ -6,7 +6,7 @@
         xmlns:updater="clr-namespace:LittleBigMouse.Ui.Avalonia.Updater"
         mc:Ignorable="d" 
         Width="400"
-        Height="260"
+        MaxHeight="560"
         WindowStartupLocation="CenterScreen"
 		SizeToContent="Height"
         Title="Update Little Big Mouse"
@@ -15,28 +15,31 @@
         x:DataType="updater:ApplicationUpdaterViewModel"
         >
     <DockPanel Margin="10">
-        <TextBlock 
-            
-            DockPanel.Dock="Top" 
-            FontWeight="Bold" 
-            Text="{Binding Message,FallbackValue=New version available}"
-            TextWrapping="WrapWithOverflow"
-            />
-        
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
             <Label>Current Version :</Label>
             <Label Content="{Binding CurrentVersion}"/>
         </StackPanel>
-        
+
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
             <Label>Online version :</Label>
             <Label Content="{Binding NewVersion}"/>
         </StackPanel>
-            
-        <ProgressBar DockPanel.Dock="Top" Height="20" Value="{Binding Progress}" Maximum="100" Margin="20"/>
+
+        <!-- Buttons and progress stay pinned at the bottom, always visible. -->
         <StackPanel Height="40" DockPanel.Dock="Bottom" VerticalAlignment="Bottom" HorizontalAlignment="Right" Orientation="Horizontal">
             <Button FontWeight="Bold" IsDefault="True" Padding="5" Command="{Binding UpdateCommand}"> Update </Button>
             <Button Padding="5" Click="ButtonBase_OnClick"> Cancel </Button>
         </StackPanel>
+        <ProgressBar DockPanel.Dock="Bottom" Height="20" Value="{Binding Progress}" Maximum="100" Margin="20"/>
+
+        <!-- Changelog fills the middle and scrolls, so a long release body can no
+             longer grow the window past the screen and hide the buttons. -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="300" Margin="0,0,0,8">
+            <TextBlock
+                FontWeight="Bold"
+                Text="{Binding Message,FallbackValue=New version available}"
+                TextWrapping="Wrap"
+                />
+        </ScrollViewer>
     </DockPanel>
 </Window>


### PR DESCRIPTION
The update dialog is `SizeToContent="Height"` with the release body docked at the top, so a long changelog grew the window past the screen and pushed the **Update / Cancel** buttons off the bottom (the reason 5.3.0's notes had to be trimmed to almost nothing).

Fix: put the changelog in a bounded `ScrollViewer` (`MaxHeight="300"`) that fills the middle of the dialog, pin the progress bar and buttons to the bottom, and cap the window at `MaxHeight="560"`. Long release bodies now scroll instead of overflowing.

Client-side, so it takes effect from the next build onwards; existing clients still need short-ish notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)