### PR TITLE
Fix UI crash in Span/Tile wallpaper modes on edge-case geometry (#492)

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/WallpaperRendererHelper.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/WallpaperRendererHelper.cs
@@ -252,7 +252,7 @@ public static class WallpaperRendererHelper
 
         return ctx
             .Resize(resize)
-            .Crop(target);
+            .CropClamped(target, resize);
     }
 
     static IImageProcessingContext SpanCenter(this IImageProcessingContext ctx, Rectangle target, Rectangle fullArea)
@@ -269,7 +269,17 @@ public static class WallpaperRendererHelper
 
         return ctx
             .Resize(resize)
-            .Crop(target);
+            .CropClamped(target, resize);
+    }
+
+    // Integer truncation in the ratio/resize math above (and in the source Rect -> pixel
+    // conversions) can leave the crop rectangle up to 1px past the resized image. ImageSharp
+    // then throws "Crop rectangle should be smaller than the source bounds", which surfaces on
+    // a background thread and takes down the whole UI (see issue #492). Clamp to the image
+    // bounds so the Span/Tile wallpaper modes can never crash on edge-case geometry.
+    static IImageProcessingContext CropClamped(this IImageProcessingContext ctx, Rectangle target, Size bounds)
+    {
+        return ctx.Crop(Rectangle.Intersect(target, new Rectangle(0, 0, bounds.Width, bounds.Height)));
     }
 
     public static void ImageSharpDebugStats()


### PR DESCRIPTION
Fixes #492.

## Symptom
On startup the Avalonia UI crashes (the mouse hook keeps working). Stack trace ends in:

```
System.ArgumentException: Crop rectangle should be smaller than the source bounds. (Parameter 'cropRectangle')
   at SixLabors.ImageSharp.Processing.Processors.Transforms.CropProcessor..ctor(...)
   at LittleBigMouse.Ui.Avalonia.MonitorFrame.WallpaperRendererHelper.SpanCenter(...)
   at ...MonitorFrameViewModel.SetWallpaper(...)
```

## Root cause
`SpanCenter`/`SpanOrigin` rescale the wallpaper across the full multi-monitor bounding box and crop each monitor's slice out of it. Integer truncation in `(int)(ratio * source.Width/Height)` (plus the source `Rect` → pixel `(int)` conversions) can leave the crop rectangle up to **1px past** the resized image. ImageSharp rejects that. Because the render runs on a background thread, the unhandled exception propagates through the ReactiveUI pipeline and tears down the whole UI.

Only the **Span** (and, by the same pattern, **Tile**) wallpaper fit is affected — it depends on the ratio between the wallpaper and the total desktop bounds, which is why it hits some setups and not others.

## Fix
Clamp the crop rectangle to the resized image bounds with a small `CropClamped` helper (`Rectangle.Intersect`). Worst case the monitor slice is 1px smaller, which is imperceptible; the path can no longer throw.

## Verification
- `dotnet build -c Release` on the UI project: **0 errors**.
- Standalone ImageSharp 3.1.11 repro with two 1920×1080 monitors and a wallpaper that shrinks to 302×200 → `resize=959×635` while the crop's right edge lands at **960**:
  - **before:** `Crop` throws the exact reported `ArgumentException`;
  - **after:** `CropClamped` → 479×270 crop, no exception (1px narrower slice).

## Note for maintainers
The reporting user hit a genuine bug. However a **now-removed throwaway account** posted a `lbm_patch_v54.zip` "fix" on the issue ~1 minute after it opened — a trojanized-DLL bait targeting readers of the thread. That comment has been hidden and the account reported; this PR is the real fix. There is no 5.4 release; latest is 5.3.0.

## Workaround for affected users
Windows *Settings → Personalization → Background → Choose a fit*: switch **Span** to **Fill**/**Fit**, then relaunch the UI (LBM reads the live Windows wallpaper position, so this avoids the code path).
