### PR TITLE
Exclude Xbox / Game Pass games by default (#494)

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ExcludedProcessDefaults.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ExcludedProcessDefaults.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace LittleBigMouse.DisplayLayout.Monitors;
+
+/// <summary>
+/// Canonical default exclusion list: game-launcher install-path fragments whose windows LBM should
+/// leave alone (matched as substrings against the foreground process path by the daemon). Single
+/// source of truth shared by the seed file (<c>CreateExcludedFile</c>), the one-time top-up
+/// migration (<c>PersistencyExtensions</c>) and the "Add defaults" button (<c>LbmOptionsViewModel</c>).
+/// </summary>
+public static class ExcludedProcessDefaults
+{
+    /// <summary>
+    /// Bumped whenever entries are added to <see cref="All"/>, to drive the one-time migration that
+    /// tops up the lists of users who kept the stock defaults. A later manual removal is respected
+    /// (the migration only runs once per version).
+    /// </summary>
+    public const int Version = 1;
+
+    /// <summary>Header comment written atop a freshly seeded file (':'-prefixed lines are ignored by the daemon).</summary>
+    public const string Header = ":Excluded processes";
+
+    /// <summary>The defaults that shipped before <see cref="Version"/> 1.</summary>
+    public static readonly IReadOnlyList<string> LegacyV0 =
+    [
+        @"\Epic Games\",
+        @"\steamapps\",
+        @"\Riot Games\",
+    ];
+
+    /// <summary>
+    /// The current default entries. <c>\XboxGames\</c> was added in Version 1 (#494): Xbox / Game Pass
+    /// titles install under <c>…\XboxGames\…\Content\</c> regardless of the chosen install drive.
+    /// </summary>
+    public static readonly IReadOnlyList<string> All =
+    [
+        .. LegacyV0,
+        @"\XboxGames\",
+    ];
+}

--- a/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
+++ b/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.DisplayLayout;
 using Microsoft.Win32;
@@ -101,6 +103,8 @@ public static class PersistencyExtensions
             @this.ExcludedList.Add(line);
         }
 
+        MigrateExcludedDefaults(@this.ExcludedList, mainKey, file);
+
         if (key == null) return;
         // Options to be loaded from the layout key
         @this.AllowOverlaps = key.GetOrSet("AllowOverlaps", () => false);
@@ -119,6 +123,40 @@ public static class PersistencyExtensions
         @this.PriorityUnhooked = key.GetOrSet("PriorityUnhooked", () => "Below");
 
         @this.Saved = true;
+    }
+
+    /// <summary>
+    /// One-time top-up of the default exclusion list. When new default entries ship (e.g. Xbox game
+    /// folders, #494) they must reach users who already have an <c>Excluded.txt</c> — a fresh seed
+    /// only covers new installs. Runs once per <see cref="ExcludedProcessDefaults.Version"/> (tracked
+    /// in the registry) and only when the list still holds every previous default, so a customized
+    /// list — or a default the user deliberately removed later — is left untouched. Rewrites the file
+    /// too, since the daemon reads it, not this in-memory list.
+    /// </summary>
+    static void MigrateExcludedDefaults(ICollection<string> list, RegistryKey mainKey, string file)
+    {
+        var applied = mainKey.GetOrSet("ExcludedDefaultsVersion", () => 0);
+        if (applied >= ExcludedProcessDefaults.Version) return;
+
+        // Only top up a list that still holds all the previous defaults (i.e. the user kept them).
+        if (ExcludedProcessDefaults.LegacyV0.All(list.Contains))
+        {
+            var added = false;
+            foreach (var entry in ExcludedProcessDefaults.All)
+            {
+                if (list.Contains(entry)) continue;
+                list.Add(entry);
+                added = true;
+            }
+
+            if (added)
+            {
+                try { File.WriteAllLines(file, list); }
+                catch { /* best effort: the in-memory list is updated regardless */ }
+            }
+        }
+
+        mainKey.SetKey("ExcludedDefaultsVersion", ExcludedProcessDefaults.Version.ToString(CultureInfo.InvariantCulture));
     }
 
     static bool IsProcessElevated()

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -250,6 +250,11 @@
 								        Command="{Binding AddExcludedProcessCommand}">Exclude</Button>
 							</Grid>
 
+							<Button HorizontalAlignment="Left" Margin="14,0,14,12"
+							        Command="{Binding AddDefaultsCommand}"
+							        Content="Add defaults"
+							        ToolTip.Tip="Add the built-in default exclusions (Epic, Steam, Riot, Xbox game folders) that aren't already in the list"/>
+
 							<Border Classes="SettingSeparator"/>
 
 							<controls:SettingRow Classes="Sub"

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
@@ -36,6 +36,8 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
 
         RemoveExcludedProcessCommand = ReactiveCommand.Create<string?>(RemoveExcludedProcess);
 
+        AddDefaultsCommand = ReactiveCommand.Create(AddDefaults);
+
         _adjustPointerAllowed = this
             .WhenAnyValue(e => e.Model.IsUnaryRatio, (bool r) => r)
             .Log(this, "_adjustPointerAllowed")
@@ -87,6 +89,18 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         if(Model.ExcludedList.Contains(p)) return ;
 
         Model.ExcludedList.Add(p);
+    }
+
+    // Top up the list with any built-in default exclusions (game launchers) not already present.
+    // Restores defaults a user pruned, and surfaces newly-added ones (e.g. Xbox games, #494).
+    public ICommand AddDefaultsCommand { get; }
+    void AddDefaults()
+    {
+        if (Model == null) return;
+        foreach (var entry in ExcludedProcessDefaults.All)
+        {
+            if (!Model.ExcludedList.Contains(entry)) Model.ExcludedList.Add(entry);
+        }
     }
 
     /// <summary>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -107,7 +107,8 @@ public partial class LittleBigMouseClientService : ILittleBigMouseClientService
         Directory.CreateDirectory(dir);
         // Self-heal: a buggy earlier version created "Excluded.txt" as a *directory*.
         if (Directory.Exists(file)) Directory.Delete(file, true);
-        File.WriteAllText(file, ":Excluded processes\n\\Epic Games\\\n\\steamapps\\\n\\Riot Games\\\n");
+        var lines = new[] { ExcludedProcessDefaults.Header }.Concat(ExcludedProcessDefaults.All);
+        File.WriteAllText(file, string.Join("\n", lines) + "\n");
     }
 
     public void LaunchDaemon()


### PR DESCRIPTION
Fixes #494.

Xbox / Game Pass titles install under `…\XboxGames\…\Content\` and keep sliding across monitors even in fullscreen, because the default exclusion list only covered Epic / Steam / Riot.

## Changes
- **`ExcludedProcessDefaults`** (new, Core) — single source of truth for the default exclusions (Epic, Steam, Riot, **`\XboxGames\`**), with a `Version` and the pre-v1 `LegacyV0` set. Shared by the seed file, the migration and the UI.
- **Seed** — `CreateExcludedFile` writes from `ExcludedProcessDefaults` instead of a hardcoded string, so fresh installs get Xbox.
- **One-time top-up migration** (`PersistencyExtensions.LoadOptions`) — reaches existing users, not just fresh installs. Gated by a registry marker (`ExcludedDefaultsVersion`) so it runs once; only tops up a list that still holds all previous defaults (a customized list, or a default removed later, is left alone); rewrites `Excluded.txt` since the daemon reads the file, not the in-memory list.
- **"Add defaults" button** (options) — adds any missing default exclusions to the list (persisted on Save, like the other edits).

## Migration behaviour
| Existing list | Result |
|---|---|
| stock (Epic+Steam+Riot) | + Xbox, file rewritten, marker=1 |
| already has Xbox + stock | no-op, marker=1 |
| customized (a default removed) | untouched, marker=1 |
| Xbox removed later | not re-added (marker already 1) |
| fresh install (no file) | seeded with Xbox |

Daemon unchanged — it has no built-in defaults, it reads `Excluded.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)