### PR TITLE
Fix GetOrAddPhysicalMonitorModel never reusing the cached model

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorsLayout.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorsLayout.cs
@@ -127,16 +127,23 @@ public class MonitorsLayout : SavableReactiveModel, IMonitorsLayout
    public PhysicalMonitorModel GetOrAddPhysicalMonitorModel(string id, Func<string, PhysicalMonitorModel> value)
    {
       PhysicalMonitorModel? result = null;
-      _physicalMonitorModelsCache.Lookup(id);
       _physicalMonitorModelsCache.Edit(u =>
       {
          var lookup = u.Lookup(id);
          if (lookup.HasValue)
          {
+            // Reuse the existing model: monitors sharing a PnpCode (identical make/model) must share
+            // ONE PhysicalMonitorModel, so model-level edits (physical size, borders, PnP name) apply
+            // to all of them and persist consistently. Recreating here defeated the cache — two
+            // identical monitors got separate instances, and one's stale Save overwrote the other's
+            // registry key, silently dropping the user's change.
             result = lookup.Value;
          }
-         result = value(id);
-         u.AddOrUpdate(result);
+         else
+         {
+            result = value(id);
+            u.AddOrUpdate(result);
+         }
       });
       if (result == null) throw new Exception("GetOrAddPhysicalMonitorModel failed");
       return result;


### PR DESCRIPTION
`GetOrAddPhysicalMonitorModel` looked the model up in the `SourceCache` but then overwrote the result with a freshly built instance **unconditionally** — the create/`AddOrUpdate` lines sat outside the `else`, so the `if (lookup.HasValue)` branch was dead code and every call returned a new `PhysicalMonitorModel`. The cache stored models but never handed a stored one back.

### Effect
Two monitors sharing a PnpCode (identical make/model) got **separate** model instances. Model-level settings (physical size, borders, PnP name) persist per-model under `monitors\{PnpCode}\…`, so on save one monitor wrote its value and the other's stale Save overwrote it — silently dropping the user's change on reload. In the UI it looked editable and saved, but wasn't.

### Fix
Reuse the cached instance when present; build + `AddOrUpdate` only when absent. Drop the dead `Lookup(id)` whose result was discarded.

### Behaviour change
Identical monitors now share one model instance (the intended design), so model-level edits apply to all of them live and persist consistently.

⚠️ Worth a runtime check with two identical monitors: edit a border on one → the other updates live; save → reload keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)