### PR TITLE
Border values: per model | per monitor option (#470 redesign)

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
@@ -1,0 +1,64 @@
+using System.Reactive.Concurrency;
+using ReactiveUI;
+
+namespace LittleBigMouse.DisplayLayout.Dimensions;
+
+/// <summary>
+/// A size decorator that keeps the width/height/position of its <see cref="DisplaySize.Source"/>
+/// (the shared per-model physical size) but takes the four bezel borders from a separate per-monitor
+/// <see cref="DisplayBorders"/> holder. This is what "Border values: per monitor" roots a monitor's
+/// geometry at, so identical monitors can carry different borders while still sharing their size.
+/// Sits at the raw-size root of the chain (below rotation/scale), so those transforms apply to the
+/// overridden borders exactly as they do to the model's.
+/// </summary>
+public class DisplayBorderOverride : DisplaySize
+{
+    public DisplayBorderOverride(IDisplaySize source, DisplayBorders borderSource) : base(source)
+    {
+        BorderSource = borderSource;
+
+        _x = this.WhenAnyValue(e => e.Source.X).ToProperty(this, e => e.X, scheduler: Scheduler.Immediate);
+        _y = this.WhenAnyValue(e => e.Source.Y).ToProperty(this, e => e.Y, scheduler: Scheduler.Immediate);
+        _width = this.WhenAnyValue(e => e.Source.Width).ToProperty(this, e => e.Width, scheduler: Scheduler.Immediate);
+        _height = this.WhenAnyValue(e => e.Source.Height).ToProperty(this, e => e.Height, scheduler: Scheduler.Immediate);
+
+        _leftBorder = this.WhenAnyValue(e => e.BorderSource.Left).ToProperty(this, e => e.LeftBorder, scheduler: Scheduler.Immediate);
+        _topBorder = this.WhenAnyValue(e => e.BorderSource.Top).ToProperty(this, e => e.TopBorder, scheduler: Scheduler.Immediate);
+        _rightBorder = this.WhenAnyValue(e => e.BorderSource.Right).ToProperty(this, e => e.RightBorder, scheduler: Scheduler.Immediate);
+        _bottomBorder = this.WhenAnyValue(e => e.BorderSource.Bottom).ToProperty(this, e => e.BottomBorder, scheduler: Scheduler.Immediate);
+
+        base.Init();
+    }
+
+    /// <summary>The per-monitor border values this override reads from (distinct from the inherited
+    /// <see cref="DisplaySize.Borders"/>, which is the computed Thickness output).</summary>
+    public DisplayBorders BorderSource { get; }
+
+    // Size + position: pass through to the shared per-model source.
+    public override double X { get => _x?.Value ?? 0; set => Source.X = value; }
+    readonly ObservableAsPropertyHelper<double> _x;
+
+    public override double Y { get => _y?.Value ?? 0; set => Source.Y = value; }
+    readonly ObservableAsPropertyHelper<double> _y;
+
+    public override double Width { get => _width?.Value ?? 0; set => Source.Width = value; }
+    readonly ObservableAsPropertyHelper<double> _width;
+
+    public override double Height { get => _height?.Value ?? 0; set => Source.Height = value; }
+    readonly ObservableAsPropertyHelper<double> _height;
+
+    // Borders: read from / written to the per-monitor holder, NOT the shared source.
+    public override double LeftBorder { get => _leftBorder?.Value ?? 0; set => BorderSource.Left = value; }
+    readonly ObservableAsPropertyHelper<double> _leftBorder;
+
+    public override double TopBorder { get => _topBorder?.Value ?? 0; set => BorderSource.Top = value; }
+    readonly ObservableAsPropertyHelper<double> _topBorder;
+
+    public override double RightBorder { get => _rightBorder?.Value ?? 0; set => BorderSource.Right = value; }
+    readonly ObservableAsPropertyHelper<double> _rightBorder;
+
+    public override double BottomBorder { get => _bottomBorder?.Value ?? 0; set => BorderSource.Bottom = value; }
+    readonly ObservableAsPropertyHelper<double> _bottomBorder;
+
+    public override string TransformToString => "BorderOverride";
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -31,6 +31,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool AdjustPointer { get; set; } = false;
       public bool AdjustSpeed { get; set; } = false;
       public string Algorithm { get; set; } = "Strait";
+      public string BorderValues { get; set; } = "PerModel";
       public string Priority { get; set; } = "Normal";
       public string PriorityUnhooked { get; set; } = "Below";
       public bool IsUnaryRatio { get; set; } = false;
@@ -119,6 +120,12 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// - CornerCrossing
    /// </summary>
    string Algorithm { get; set; }
+
+   /// <summary>
+   /// Where bezel borders are stored: "PerModel" (default — shared by all monitors of the same
+   /// make/model) or "PerMonitor" (each physical monitor keeps its own).
+   /// </summary>
+   string BorderValues { get; set; }
 
 
    /// <summary>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
@@ -85,6 +85,43 @@ public class PhysicalMonitor : SavableReactiveModel
             .Do(ParseDisplaySources)
             .Subscribe().DisposeWith(this);
 
+        // Per-monitor border source, seeded from the model so "PerMonitor" starts matching "PerModel".
+        Borders = new DisplayBorders
+        {
+            Left = model.PhysicalSize.LeftBorder,
+            Top = model.PhysicalSize.TopBorder,
+            Right = model.PhysicalSize.RightBorder,
+            Bottom = model.PhysicalSize.BottomBorder,
+        };
+        _borderOverride = new DisplayBorderOverride(model.PhysicalSize, Borders);
+
+        // The size the geometry is built from: the shared per-model size, or — when "Border values"
+        // is "PerMonitor" — the same size with this monitor's own borders substituted. Reactive so a
+        // mode switch rewires rotation / projection / zones live.
+        _effectivePhysicalSize = this.WhenAnyValue(e => e.Layout.Options.BorderValues)
+            .Select(mode => mode == "PerMonitor" ? (IDisplaySize)_borderOverride : Model.PhysicalSize)
+            .ToProperty(this, e => e.EffectivePhysicalSize, initialValue: model.PhysicalSize)
+            .DisposeWith(this);
+
+        // Keep the per-monitor borders mirroring the model while NOT in per-monitor mode, so switching
+        // to "PerMonitor" starts from the current model borders (no visual jump). In per-monitor mode
+        // the mirror stops and Borders keeps its own loaded / user-edited values.
+        this.WhenAnyValue(
+                e => e.Layout.Options.BorderValues,
+                e => e.Model.PhysicalSize.LeftBorder,
+                e => e.Model.PhysicalSize.TopBorder,
+                e => e.Model.PhysicalSize.RightBorder,
+                e => e.Model.PhysicalSize.BottomBorder)
+            .Where(t => t.Item1 != "PerMonitor")
+            .Subscribe(_ =>
+            {
+                Borders.Left = Model.PhysicalSize.LeftBorder;
+                Borders.Top = Model.PhysicalSize.TopBorder;
+                Borders.Right = Model.PhysicalSize.RightBorder;
+                Borders.Bottom = Model.PhysicalSize.BottomBorder;
+            })
+            .DisposeWith(this);
+
         _physicalRotated = this.WhenAnyValue(
             e => e.EffectivePhysicalSize,
             e => e.ActiveSource.Source.Orientation,
@@ -183,7 +220,16 @@ public class PhysicalMonitor : SavableReactiveModel
     /// It exists as the single seam where a future "Border values: per monitor" option can substitute
     /// a per-monitor border source, without touching any geometry consumer. See the border-values plan.
     /// </summary>
-    public IDisplaySize EffectivePhysicalSize => Model.PhysicalSize;
+    public IDisplaySize EffectivePhysicalSize => _effectivePhysicalSize.Value;
+    readonly ObservableAsPropertyHelper<IDisplaySize> _effectivePhysicalSize;
+
+    /// <summary>
+    /// This monitor's own bezel borders, used to build the geometry only when "Border values" is
+    /// "PerMonitor". Seeded from the model at construction; loaded from / saved to the monitor's own
+    /// registry key. In "PerModel" mode the geometry ignores these and uses the shared model borders.
+    /// </summary>
+    public DisplayBorders Borders { get; }
+    readonly DisplayBorderOverride _borderOverride;
 
     /// <summary>
     /// Dimensions with rotation applied

--- a/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
+++ b/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
@@ -92,6 +92,7 @@ public static class PersistencyExtensions
         @this.DebugTools = mainKey.GetOrSet("DebugTools", () => false);
         // "ShowAttachDetachWarning" is the former name of the option, read as fallback
         @this.ShowMonitorActionWarning = mainKey.GetOrSet("ShowMonitorActionWarning", () => mainKey.GetOrSet("ShowAttachDetachWarning", () => true));
+        @this.BorderValues = mainKey.GetOrSet("BorderValues", () => "PerModel");
 
         @this.ExcludedList.Clear();
 
@@ -244,6 +245,7 @@ public static class PersistencyExtensions
         mainKey.SetKey("StartElevated", @this.StartElevated);
         mainKey.SetKey("DebugTools", @this.DebugTools);
         mainKey.SetKey("ShowMonitorActionWarning", @this.ShowMonitorActionWarning);
+        mainKey.SetKey("BorderValues", @this.BorderValues);
 
         var file = ExcludedListPath();
 
@@ -337,6 +339,17 @@ public static class PersistencyExtensions
         @this.BorderResistance.Bottom =  key.GetOrSet(@"BorderResistance\Bottom", ()=> @this.BorderResistance.Bottom);
         @this.BorderResistance.Saved = true;
 
+        // Per-monitor bezel borders — only in "PerMonitor" mode ("PerModel" keeps them on the shared
+        // model key). Defaults were seeded from the model at construction, so an absent key just keeps
+        // the model's values.
+        if (@this.Layout.Options.BorderValues == "PerMonitor")
+        {
+            @this.Borders.Left = key.GetOrSet(@"Borders\Left", () => @this.Model.PhysicalSize.LeftBorder);
+            @this.Borders.Top = key.GetOrSet(@"Borders\Top", () => @this.Model.PhysicalSize.TopBorder);
+            @this.Borders.Right = key.GetOrSet(@"Borders\Right", () => @this.Model.PhysicalSize.RightBorder);
+            @this.Borders.Bottom = key.GetOrSet(@"Borders\Bottom", () => @this.Model.PhysicalSize.BottomBorder);
+        }
+
         @this.Saved = true;
 
         return @this;
@@ -364,6 +377,14 @@ public static class PersistencyExtensions
         key.SetKey(@"BorderResistance\Bottom", @this.BorderResistance.Bottom);
 
         @this.BorderResistance.Saved = true;
+
+        if (@this.Layout.Options.BorderValues == "PerMonitor")
+        {
+            key.SetKey(@"Borders\Left", @this.Borders.Left);
+            key.SetKey(@"Borders\Top", @this.Borders.Top);
+            key.SetKey(@"Borders\Right", @this.Borders.Right);
+            key.SetKey(@"Borders\Bottom", @this.Borders.Bottom);
+        }
 
 
         foreach (var source in @this.Sources.Items)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -222,6 +222,14 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     }
     string _algorithm = "Strait";
 
+    [DataMember]
+    public string BorderValues
+    {
+        get => _borderValues;
+        set => SetUnsavedValue(ref _borderValues, value);
+    }
+    string _borderValues = "PerModel";
+
     public ObservableCollection<string> ExcludedList { get; } = new();
 
     public string GetConfigPath(string layoutId, bool create)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -209,6 +209,29 @@
 					</Border>
 
 					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Ruler}"
+							                     Header="Border values"
+							                     Description="Where each monitor's bezel borders are stored"/>
+							<ListBox Classes="ChoiceCards" Margin="14,0,6,12"
+							         ItemsSource="{Binding BorderValuesList}"
+							         SelectedItem="{Binding SelectedBorderValues}">
+								<ListBox.ItemTemplate>
+									<DataTemplate>
+										<StackPanel x:DataType="options:ListItem" Spacing="2">
+											<TextBlock Text="{Binding Caption}" FontSize="13"
+											           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+											<TextBlock Text="{Binding Description}" FontSize="11"
+											           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+											           TextWrapping="Wrap"/>
+										</StackPanel>
+									</DataTemplate>
+								</ListBox.ItemTemplate>
+							</ListBox>
+						</StackPanel>
+					</Border>
+
+					<Border Classes="SettingCard">
 						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Warning}"
 						                     Header="Warn before monitor actions"
 						                     Description="Ask for confirmation before attaching, detaching or making a monitor primary">

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
@@ -53,6 +53,9 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         _selectedAlgorithm = this.WhenAnyValue(e => e.Model.Algorithm)
             .Select(a => AlgorithmList.Find(e => e.Id == a)).ToProperty(this, nameof(SelectedAlgorithm));
 
+        _selectedBorderValues = this.WhenAnyValue(e => e.Model.BorderValues)
+            .Select(a => BorderValuesList.Find(e => e.Id == a)).ToProperty(this, nameof(SelectedBorderValues));
+
         _selectedPriority = this.WhenAnyValue(e => e.Model.Priority)
             .Select(a => PriorityList.Find(e => e.Id == a)).ToProperty(this, nameof(SelectedPriority));
 
@@ -123,6 +126,12 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         new("Cross", "Corner crossing", "In direction-friendly manner, allows traversal through corners.")
     ];
 
+    public List<ListItem> BorderValuesList { get; } =
+    [
+        new("PerModel", "Per model", "Borders are shared by all monitors of the same make/model."),
+        new("PerMonitor", "Per monitor", "Each physical monitor keeps its own borders.")
+    ];
+
     public List<ListItem> PriorityList { get; } =
     [
         new("Idle", "Idle", ""),
@@ -143,6 +152,17 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         }
     }
     readonly ObservableAsPropertyHelper<ListItem?> _selectedAlgorithm;
+
+    public ListItem? SelectedBorderValues
+    {
+        get => _selectedBorderValues.Value;
+        set
+        {
+            if (Model == null) return;
+            Model.BorderValues = value?.Id ?? "PerModel";
+        }
+    }
+    readonly ObservableAsPropertyHelper<ListItem?> _selectedBorderValues;
 
     public ListItem? SelectedPriority
     {


### PR DESCRIPTION
Stacks on #498 (the geometry seam). GitHub will retarget this to `master` once #498 merges.

Redesign of #470. Bezel borders are **per-model by design** (a property of the make/model, shared by all monitors of the same PnpCode — and the planned online border DB keys on the model). Rather than change the default, this adds an **option** so users who want per-monitor borders can opt in, without forcing triple-identical-screen users to enter the same values three times.

### Changes
- `BorderValues` option (`"PerModel"` default | `"PerMonitor"`), persisted on the main key.
- `DisplayBorderOverride`: a size decorator keeping width/height/position from the shared per-model size but taking the four borders from a per-monitor holder.
- `PhysicalMonitor.EffectivePhysicalSize` (the Phase-2 seam) is now reactive on the option: PerMonitor roots geometry at the override, else at the model. A `Borders` holder carries the per-monitor values; a mirror keeps it aligned with the model while NOT in PerMonitor, so switching modes doesn't jump.
- Persistence: PerMonitor borders under the monitor key (`Layouts\{id}\PhysicalMonitors\{Id}\Borders\*`); PerModel keeps the existing per-model key untouched; absent per-monitor key seeds from the model.
- UI: a "Border values" choice card in the Layout options.

**Default is PerModel → existing behaviour and stored values unchanged.**

### Needs runtime verification (two identical monitors)
- PerModel: unchanged; borders shared, one save, reload consistent.
- PerMonitor: borders diverge per monitor, persist under per-Id keys, reload correct.
- Rotation + borders in both modes; mode switch back and forth (no jump / no data loss).

Plan: `.claude/plans/border-values.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)