### PR TITLE
Fix per-monitor border values button

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Concurrency;
+using LittleBigMouse.DisplayLayout;
 using ReactiveUI;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
@@ -22,10 +23,17 @@ public class DisplayBorderOverride : DisplaySize
         _width = this.WhenAnyValue(e => e.Source.Width).ToProperty(this, e => e.Width, scheduler: Scheduler.Immediate);
         _height = this.WhenAnyValue(e => e.Source.Height).ToProperty(this, e => e.Height, scheduler: Scheduler.Immediate);
 
-        _leftBorder = this.WhenAnyValue(e => e.BorderSource.Left).ToProperty(this, e => e.LeftBorder, scheduler: Scheduler.Immediate);
-        _topBorder = this.WhenAnyValue(e => e.BorderSource.Top).ToProperty(this, e => e.TopBorder, scheduler: Scheduler.Immediate);
-        _rightBorder = this.WhenAnyValue(e => e.BorderSource.Right).ToProperty(this, e => e.RightBorder, scheduler: Scheduler.Immediate);
-        _bottomBorder = this.WhenAnyValue(e => e.BorderSource.Bottom).ToProperty(this, e => e.BottomBorder, scheduler: Scheduler.Immediate);
+        // Subscribe directly to the captured borderSource instead of going through
+        // this.WhenAnyValue(e => e.BorderSource.*), which requires ReactiveUI to resolve
+        // a get-only property chain and may silently drop inner-property subscriptions.
+        _leftBorder = borderSource.WhenAnyValue(e => e.Left)
+            .ToProperty(this, e => e.LeftBorder, scheduler: Scheduler.Immediate);
+        _topBorder = borderSource.WhenAnyValue(e => e.Top)
+            .ToProperty(this, e => e.TopBorder, scheduler: Scheduler.Immediate);
+        _rightBorder = borderSource.WhenAnyValue(e => e.Right)
+            .ToProperty(this, e => e.RightBorder, scheduler: Scheduler.Immediate);
+        _bottomBorder = borderSource.WhenAnyValue(e => e.Bottom)
+            .ToProperty(this, e => e.BottomBorder, scheduler: Scheduler.Immediate);
 
         base.Init();
     }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScale.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScale.cs
@@ -22,6 +22,7 @@
 */
 
 
+using LittleBigMouse.DisplayLayout;
 using ReactiveUI;
 using System.Reactive.Concurrency;
 
@@ -48,8 +49,8 @@ public class DisplayScale : DisplaySize
             .ToProperty(this, e => e.Width, scheduler: Scheduler.Immediate);
 
         _leftBorder = this.WhenAnyValue(
-            e => e.Source.LeftBorder, 
-            e => e.Ratio.X, 
+            e => e.Source.LeftBorder,
+            e => e.Ratio.X,
             (width, r) => width * r)
             .ToProperty(this, e => e.LeftBorder, scheduler: Scheduler.Immediate);
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInMm.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInMm.cs
@@ -77,7 +77,7 @@ public class DisplaySizeInMm : DisplaySize
 
     public override double Y { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-    public override double TopBorder { get; set => SetUnsavedValue(ref field, Math.Max(value, 0.0));} = 20.0;
+    public override double TopBorder { get; set => SetUnsavedValue(ref field, Math.Max(value, 0.0)); } = 20.0;
 
     public override double RightBorder { get; set => SetUnsavedValue(ref field, Math.Max(value, 0.0)); } = 20.0;
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
@@ -23,12 +23,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reactive.Concurrency;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 using DynamicData;
 using HLab.Base.ReactiveUI;
+using LittleBigMouse.DisplayLayout;
 using LittleBigMouse.DisplayLayout.Dimensions;
 using ReactiveUI;
 
@@ -95,54 +98,66 @@ public class PhysicalMonitor : SavableReactiveModel
         };
         _borderOverride = new DisplayBorderOverride(model.PhysicalSize, Borders);
 
+        // Observe BorderValues directly via ILayoutOptions.PropertyChanged — WhenAnyValue through
+        // IMonitorsLayout (which declares no INotifyPropertyChanged) loses the innermost subscription.
+        var borderValuesObs = Observable
+            .FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                h => Layout.Options.PropertyChanged += h,
+                h => Layout.Options.PropertyChanged -= h)
+            .Where(e => e.EventArgs.PropertyName == nameof(ILayoutOptions.BorderValues))
+            .Select(_ => Layout.Options.BorderValues)
+            .StartWith(Layout.Options.BorderValues)
+            .DistinctUntilChanged();
+
         // The size the geometry is built from: the shared per-model size, or — when "Border values"
         // is "PerMonitor" — the same size with this monitor's own borders substituted. Reactive so a
         // mode switch rewires rotation / projection / zones live.
-        _effectivePhysicalSize = this.WhenAnyValue(e => e.Layout.Options.BorderValues)
+        // Shared, replayed stream — Replay(1) ensures _physicalRotated and _depthProjectionUnrotated
+        // receive the current value when they subscribe, without missing the StartWith emission that
+        // already fired for _effectivePhysicalSize. Direct subscription also avoids the
+        // WhenAnyValue(e => e.EffectivePhysicalSize) OAPH-PropertyChanged round-trip that breaks
+        // in Avalonia's synchronous reentrancy model (mode-change event → OAPH fires → inner
+        // PropertyChanged → WhenAnyValue chain stops).
+        var effectiveSizeObs = borderValuesObs
             .Select(mode => mode == "PerMonitor" ? (IDisplaySize)_borderOverride : Model.PhysicalSize)
-            .ToProperty(this, e => e.EffectivePhysicalSize, initialValue: model.PhysicalSize)
+            .Replay(1)
+            .RefCount();
+
+        _effectivePhysicalSize = effectiveSizeObs
+            .ToProperty(this, e => e.EffectivePhysicalSize, initialValue: model.PhysicalSize, scheduler: Scheduler.Immediate)
             .DisposeWith(this);
 
-        // Keep the per-monitor borders mirroring the model while NOT in per-monitor mode, so switching
-        // to "PerMonitor" starts from the current model borders (no visual jump). In per-monitor mode
-        // the mirror stops and Borders keeps its own loaded / user-edited values.
-        this.WhenAnyValue(
-                e => e.Layout.Options.BorderValues,
-                e => e.Model.PhysicalSize.LeftBorder,
-                e => e.Model.PhysicalSize.TopBorder,
-                e => e.Model.PhysicalSize.RightBorder,
-                e => e.Model.PhysicalSize.BottomBorder)
-            .Where(t => t.Item1 != "PerMonitor")
-            .Subscribe(_ =>
-            {
-                Borders.Left = Model.PhysicalSize.LeftBorder;
-                Borders.Top = Model.PhysicalSize.TopBorder;
-                Borders.Right = Model.PhysicalSize.RightBorder;
-                Borders.Bottom = Model.PhysicalSize.BottomBorder;
-            })
-            .DisposeWith(this);
 
-        _physicalRotated = this.WhenAnyValue(
-            e => e.EffectivePhysicalSize,
-            e => e.ActiveSource.Source.Orientation,
-            (physicalSize, orientation) => physicalSize.Rotate(orientation)
-        ).Log(this, "_physicalRotated").ToProperty(this, e => e.PhysicalRotated).DisposeWith(this);
+        effectiveSizeObs
+            .CombineLatest(
+                this.WhenAnyValue(e => e.ActiveSource.Source.Orientation),
+                (physicalSize, orientation) => physicalSize.Rotate(orientation)
+            )
+            .Subscribe(r => PhysicalRotated = r)
+            .DisposeWith(this);
 
         //RemainingPhysicalMonitors = Layout.PhysicalMonitors.Items.AsObservableChangeSet().Filter(s => !Equals(s, this)).AsObservableList();
 
         DepthRatio = new DisplayRatioValue(1.0, 1.0);
 
-        _depthProjection = this.WhenAnyValue(
-            e => e.PhysicalRotated,
-            e => e.DepthRatio,
-            (physicalRotated, ratio) => physicalRotated.Scale(ratio).Locate()
-            ).Log(this, "_inMm").ToProperty(this, e => e.DepthProjection).DisposeWith(this);
+        // Use Subscribe + ReferenceEquals setter instead of ToProperty to bypass
+        // DistinctUntilChanged(EqualityComparer<IDisplaySize>.Default), which would suppress
+        // the PerModel→PerMonitor switch when both DPs have identical values (borders not yet loaded).
+        effectiveSizeObs
+            .CombineLatest(
+                this.WhenAnyValue(e => e.ActiveSource.Source.Orientation),
+                this.WhenAnyValue(e => e.DepthRatio),
+                (physicalSize, orientation, ratio) => (IDisplaySize)physicalSize.Rotate(orientation).Scale(ratio).Locate()
+            )
+            .Log(this, "_inMm")
+            .Subscribe(dp => DepthProjection = dp)
+            .DisposeWith(this);
 
-        _depthProjectionUnrotated = this.WhenAnyValue(
-            e => e.EffectivePhysicalSize,
-            e => e.DepthRatio,
-            (physicalSize, ratio) => physicalSize.Scale(ratio)
-            ).Log(this, "_inMmU").ToProperty(this, e => e.DepthProjectionUnrotated).DisposeWith(this);
+        _depthProjectionUnrotated = effectiveSizeObs
+            .CombineLatest(
+                this.WhenAnyValue(e => e.DepthRatio),
+                (physicalSize, ratio) => physicalSize.Scale(ratio)
+            ).Log(this, "_inMmU").ToProperty(this, e => e.DepthProjectionUnrotated, scheduler: Scheduler.Immediate).DisposeWith(this);
 
         _diagonal = this.WhenAnyValue(
             e => e.DepthProjection.Height,
@@ -151,11 +166,24 @@ public class PhysicalMonitor : SavableReactiveModel
             ).Log(this, "_diagonal").ToProperty(this, e => e.Diagonal).DisposeWith(this);
 
         this.UnsavedOn(
-            e => e.Model, 
-            e => e.DepthProjection, 
-            e => e.DepthRatio, 
+            e => e.Model,
+            e => e.DepthProjection,
+            e => e.DepthRatio,
             e => e.BorderResistance
         );
+
+        // DisplayBorders is not ISavable so UnsavedOn cannot track it.
+        // Skip(1) drops the initial combined emission at subscription time.
+        // Load() resets Saved=true at its end, so loading does not leave a dirty flag.
+        this.WhenAnyValue(
+                e => e.Borders.Left,
+                e => e.Borders.Top,
+                e => e.Borders.Right,
+                e => e.Borders.Bottom,
+                (l, t, r, b) => (l, t, r, b))
+            .Skip(1)
+            .Subscribe(_ => Saved = false)
+            .DisposeWith(this);
     }
 
     void ParseDisplaySources(IReadOnlyCollection<PhysicalSource> obj)
@@ -234,8 +262,17 @@ public class PhysicalMonitor : SavableReactiveModel
     /// <summary>
     /// Dimensions with rotation applied
     /// </summary>
-    [DataMember] public IDisplaySize PhysicalRotated => _physicalRotated.Value;
-    readonly ObservableAsPropertyHelper<IDisplaySize> _physicalRotated;
+    [DataMember] public IDisplaySize PhysicalRotated
+    {
+        get;
+        private set
+        {
+            if (ReferenceEquals(field, value)) return;
+            this.RaisePropertyChanging();
+            field = value;
+            this.RaisePropertyChanged();
+        }
+    }
 
 
     // Mm
@@ -244,8 +281,24 @@ public class PhysicalMonitor : SavableReactiveModel
     /// Dimensions with depth ratio applied to deal with monitor distance
     /// </summary>
     [DataMember]
-    public IDisplaySize DepthProjection => _depthProjection.Value;
-    readonly ObservableAsPropertyHelper<IDisplaySize> _depthProjection;
+    public IDisplaySize DepthProjection
+    {
+        get;
+        private set
+        {
+            if (ReferenceEquals(field, value)) return;
+            // Carry the layout-computed position forward so monitors don't collapse to 0,0
+            // when a mode switch replaces the DP object with a fresh one.
+            if (field is not null && value is not null)
+            {
+                value.X = field.X;
+                value.Y = field.Y;
+            }
+            this.RaisePropertyChanging();
+            field = value;
+            this.RaisePropertyChanged();
+        }
+    }
 
     /// <summary>
     /// Dimensions with depth ratio applied but without rotation

--- a/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
+++ b/LittleBigMouse.Platform.Windows/PersistencyExtensions.cs
@@ -341,16 +341,13 @@ public static class PersistencyExtensions
         @this.BorderResistance.Bottom =  key.GetOrSet(@"BorderResistance\Bottom", ()=> @this.BorderResistance.Bottom);
         @this.BorderResistance.Saved = true;
 
-        // Per-monitor bezel borders — only in "PerMonitor" mode ("PerModel" keeps them on the shared
-        // model key). Defaults were seeded from the model at construction, so an absent key just keeps
-        // the model's values.
-        if (@this.Layout.Options.BorderValues == "PerMonitor")
-        {
-            @this.Borders.Left = key.GetOrSet(@"Borders\Left", () => @this.Model.PhysicalSize.LeftBorder);
-            @this.Borders.Top = key.GetOrSet(@"Borders\Top", () => @this.Model.PhysicalSize.TopBorder);
-            @this.Borders.Right = key.GetOrSet(@"Borders\Right", () => @this.Model.PhysicalSize.RightBorder);
-            @this.Borders.Bottom = key.GetOrSet(@"Borders\Bottom", () => @this.Model.PhysicalSize.BottomBorder);
-        }
+        // Always load per-monitor bezel borders regardless of current mode, so switching to
+        // PerMonitor is live (no restart required). Defaults fall back to the model values via
+        // GetOrSet, so a first-time run seeds the registry with the shared model values.
+        @this.Borders.Left = key.GetOrSet(@"Borders\Left", () => @this.Model.PhysicalSize.LeftBorder);
+        @this.Borders.Top = key.GetOrSet(@"Borders\Top", () => @this.Model.PhysicalSize.TopBorder);
+        @this.Borders.Right = key.GetOrSet(@"Borders\Right", () => @this.Model.PhysicalSize.RightBorder);
+        @this.Borders.Bottom = key.GetOrSet(@"Borders\Bottom", () => @this.Model.PhysicalSize.BottomBorder);
 
         @this.Saved = true;
 
@@ -380,13 +377,11 @@ public static class PersistencyExtensions
 
         @this.BorderResistance.Saved = true;
 
-        if (@this.Layout.Options.BorderValues == "PerMonitor")
-        {
-            key.SetKey(@"Borders\Left", @this.Borders.Left);
-            key.SetKey(@"Borders\Top", @this.Borders.Top);
-            key.SetKey(@"Borders\Right", @this.Borders.Right);
-            key.SetKey(@"Borders\Bottom", @this.Borders.Bottom);
-        }
+        // Always persist per-monitor borders so they survive a Save() while in PerModel mode.
+        key.SetKey(@"Borders\Left", @this.Borders.Left);
+        key.SetKey(@"Borders\Top", @this.Borders.Top);
+        key.SetKey(@"Borders\Right", @this.Borders.Right);
+        key.SetKey(@"Borders\Bottom", @this.Borders.Bottom);
 
 
         foreach (var source in @this.Sources.Items)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/SizeViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/SizeViewModel.cs
@@ -23,6 +23,8 @@
 
 using Avalonia;
 using HLab.Mvvm.ReactiveUI;
+using LittleBigMouse.DisplayLayout;
+using LittleBigMouse.DisplayLayout.Dimensions;
 using LittleBigMouse.DisplayLayout.Monitors;
 using ReactiveUI;
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModel.cs
@@ -5,6 +5,7 @@ using HLab.ColorTools;
 using HLab.Geo.Avalonia;
 using HLab.Mvvm.Annotations;
 using HLab.Mvvm.ReactiveUI;
+using LittleBigMouse.DisplayLayout;
 using LittleBigMouse.DisplayLayout.Dimensions;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Plugins;
@@ -23,7 +24,11 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
       _rotated = this.WhenAnyValue(
           e => e.MonitorsPresenter.VisualRatio,
           e => e.Model.DepthProjection,
-          (ratio, mm) => mm.ScaleWithLocation(ratio)
+          e => e.Model.Borders.Left,
+          e => e.Model.Borders.Top,
+          e => e.Model.Borders.Right,
+          e => e.Model.Borders.Bottom,
+          (ratio, mm, _l, _t, _r, _b) => mm?.ScaleWithLocation(ratio)
       ).Log(this, "_rotated").ToProperty(this, e => e.Rotated);
 
       _rotation = this.WhenAnyValue(
@@ -87,7 +92,7 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
           e => e.MonitorsPresenter.VisualRatio,
           e => e.Model.DepthProjectionUnrotated,
           e => e.Model.ActiveSource.Source.Orientation,
-          (ratio, mmu, o) => mmu.ScaleWithLocation(ratio)
+          (ratio, mmu, _) => mmu.ScaleWithLocation(ratio)
       ).Log(this, "_unrotated").ToProperty(this, e => e.Unrotated);
 
       var cmd = ReactiveCommand.CreateFromTask<(string, WallpaperStyle, ColorRGB<double>)>(p => SetWallpaper(p.Item1, p.Item2, p.Item3));


### PR DESCRIPTION
the per monitor boarder values button did not work properly, this should fix it. 

ideas from #470

1. Border edits in PerMonitor mode did not update the monitor frame visual. Root cause: ToProperty wraps the observable in DistinctUntilChanged using value-based Equals (IDisplaySize : IEquatable<IDisplaySize>). The origin monitor at X=0,Y=0 always matched the new object by value, silently suppressing the update. Fix: replaced the OAPH with Subscribe through a ReferenceEquals-gated setter (same pattern as PhysicalRotated).

2. Switching back from PerMonitor to PerModel collapsed monitors to 0,0. Root cause: every mode switch creates a fresh DisplayLocate at X=0,Y=0, losing the layout-calculated positions. Fix: the DepthProjection setter copies X and Y from the outgoing object to the incoming one.

3. Switching PerMonitor -> PerModel -> PerMonitor required a full restart. Root cause: a mirror subscription overwrote Borders with model values on every non-PerMonitor mode, and Load() only read per-monitor borders when already in PerMonitor mode at startup. Fix: removed the mirror; made Load() and Save() unconditional for per-monitor borders.