### PR TITLE
Fix tray icon: no blink on startup, instant vanish on hide and exit

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -200,12 +200,14 @@ public class MainService : ReactiveModel, IMainService
         });
         await _notify.AddMenuAsync(-1, "Exit", "Icon/sys/Close", QuitAsync);
 
+        // Apply the initial "hide tray icon" preference BEFORE loading the icon bitmap.
+        // SetIconAsync queues a dispatcher lambda that checks _visible; if Visible=false
+        // is already set here, the lambda returns early and NIM_ADD never fires.
+        _notify.Visible = !_options.HideTrayIcon;
+
         await _notify.SetIconAsync("Icon/lbm_off",128);
 
         _notify.Show();
-
-        // Apply the initial "hide tray icon" preference.
-        _notify.Visible = !_options.HideTrayIcon;
     }
 
     public void AddControlPlugin(Action<IMainPluginsViewModel>? action)


### PR DESCRIPTION
Fixes several notification-area bugs on Windows:

Depends on mgth/HLab.Avalonia#3
 Changes:

Bumps HLab.Avalonia submodule to the commit from the companion PR

> - Moves _notify.Visible = !_options.HideTrayIcon before SetIconAsync in MainService.StartNotifierAsync. Without this ordering, SetIconAsync queues a show-lambda on the dispatcher before the Visible=false flag is set, causing a brief blink even when "Hide Tray Icon" is enabled