### PR TITLE
VCP and display topology fixes (from #513), plus opt-in live read

### DIFF
--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/DxVa2VcpTransport.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/DxVa2VcpTransport.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OneOf;
 
 using HLab.Sys.Windows.Monitors;
@@ -21,14 +22,52 @@ namespace HLab.Sys.Windows.MonitorVcp;
 public sealed class DxVa2VcpTransport : IVcpTransport
 {
     PhysicalMonitor[] _physicalMonitors;
+    readonly int? _selectedIndex;
 
     public DxVa2VcpTransport(MonitorDevice monitor)
     {
-        var hMonitor = monitor.Connections.Count > 0 ? monitor.Connections[0].Parent.HMonitor : IntPtr.Zero;
+        var hMonitor = monitor.ActiveConnection?.Parent.HMonitor ?? IntPtr.Zero;
         _physicalMonitors = GetPhysicalMonitorsFromHMONITOR(hMonitor);
+        _selectedIndex = SelectPhysicalMonitorIndex(
+            _physicalMonitors.Select(p => p.szPhysicalMonitorDescription),
+            [monitor.Edid?.Model, monitor.Edid?.ProductCode,
+                monitor.ActiveConnection?.DeviceString, monitor.PnpCode]);
     }
 
-    nint HPhysical => _physicalMonitors.Length > 0 ? _physicalMonitors[0].hPhysicalMonitor : IntPtr.Zero;
+    nint HPhysical => _selectedIndex is { } index && index < _physicalMonitors.Length
+        ? _physicalMonitors[index].hPhysicalMonitor
+        : IntPtr.Zero;
+
+    /// <summary>
+    /// Resolve one physical handle without guessing. A logical HMONITOR may front
+    /// several tiled or mirrored panels; writes are disabled unless there is one
+    /// handle or the device identity matches exactly one description.
+    /// </summary>
+    public static int? SelectPhysicalMonitorIndex(
+        IEnumerable<string?> descriptions, IEnumerable<string?> identities)
+    {
+        var physical = descriptions.Select(NormalizeIdentity).ToList();
+        if (physical.Count == 1) return 0;
+        if (physical.Count == 0) return null;
+
+        var candidates = identities.Select(NormalizeIdentity)
+            .Where(value => value.Length >= 4)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var matches = physical
+            .Select((description, index) => (description, index))
+            .Where(item => item.description.Length >= 4 && candidates.Any(candidate =>
+                item.description.Contains(candidate, StringComparison.Ordinal)
+                || candidate.Contains(item.description, StringComparison.Ordinal)))
+            .Select(item => item.index)
+            .Distinct()
+            .ToList();
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    static string NormalizeIdentity(string? value)
+        => new((value ?? string.Empty).Where(char.IsLetterOrDigit)
+            .Select(char.ToUpperInvariant).ToArray());
 
     public IReadOnlySet<byte>? GetSupportedCodes()
     {

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/LevelParser.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/LevelParser.cs
@@ -2,45 +2,57 @@
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace HLab.Sys.Windows.MonitorVcp;
 
 public sealed class CommandWorker
 {
-    Task _task;
+    readonly object _gate = new();
+    Task? _task;
     readonly ConcurrentQueue<IWorkProvider> _actions = new();
-    bool _stop = false;
+    bool _stop;
+
+    public int PendingCount => _actions.Count;
 
     public void Enqueue(IWorkProvider level)
     {
-        _actions.Enqueue(level);
-        _task ??= Task.Run(DoWork);
+        ArgumentNullException.ThrowIfNull(level);
+        lock (_gate)
+        {
+            _stop = false;
+            _actions.Enqueue(level);
+            _task ??= Task.Run(DoWork);
+        }
     }
 
     void DoWork()
     {
-        var doWork = true;
-        while (doWork && !_stop)
+        while (true)
         {
-            if (_actions.TryDequeue(out var level))
+            IWorkProvider? level;
+            lock (_gate)
             {
-                level.DoWork();
-            }
-            else
-            {
-                doWork = false;
-            }
-        }
+                if (_stop)
+                {
+                    while (_actions.TryDequeue(out _)) { }
+                    _stop = false;
+                    _task = null;
+                    return;
+                }
 
-        while (_actions.TryDequeue(out var l))
-        {
-        }
+                if (!_actions.TryDequeue(out level))
+                {
+                    _task = null;
+                    return;
+                }
+            }
 
-        _task = null;
-        _stop = false;
+            level.DoWork();
+        }
     }
 
     public void Stop()
     {
-        _stop = true;
+        lock (_gate) _stop = true;
     }
 }

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/LiveReadSession.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/LiveReadSession.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+
+#nullable enable
+namespace HLab.Sys.Windows.MonitorVcp;
+
+/// <summary>
+/// Opt-in periodic refresh: while active, re-reads the VCP levels so changes
+/// made on the monitor's own OSD show up in the sliders (typically during a
+/// white-balance session). Bounded by a deadline so an abandoned panel never
+/// polls the DDC bus forever.
+/// </summary>
+public sealed class LiveReadSession : IDisposable
+{
+    readonly Timer _timer;
+    readonly Action _refresh;
+    readonly Action<LiveReadSession> _stopped;
+    long _remainingTicks;
+    int _disposed;
+
+    public LiveReadSession(Action refresh, Action<LiveReadSession> stopped,
+        TimeSpan interval, TimeSpan duration)
+    {
+        _refresh = refresh;
+        _stopped = stopped;
+        _remainingTicks = Math.Max(1, duration.Ticks / interval.Ticks);
+        _timer = new Timer(_ => Tick(), null, interval, interval);
+    }
+
+    void Tick()
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        if (Interlocked.Decrement(ref _remainingTicks) < 0)
+        {
+            Dispose();
+            return;
+        }
+        _refresh();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _timer.Dispose();
+        _stopped(this);
+    }
+}

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorLevel.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorLevel.cs
@@ -40,17 +40,27 @@ public interface IWorkProvider
 }
 
 public class MonitorLevel(
-   CommandWorker parser,
+   CommandWorker worker,
    VcpGetter getter, VcpSetter setter,
    VcpComponent component = VcpComponent.None)
-   : ReactiveObject, IWorkProvider
+   : ReactiveObject, IWorkProvider, IDisposable
 {
+    int _queued;
+    int _disposed;
+
     public VcpComponent Component { get; } = component;
 
     public MonitorLevel Start()
     {
-        parser.Enqueue(this);
+        RequestWork();
         return this;
+    }
+
+    void RequestWork()
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        if (Interlocked.CompareExchange(ref _queued, 1, 0) == 0)
+            worker.Enqueue(this);
     }
 
     public void SetToMax() { Value = Max; }
@@ -78,6 +88,9 @@ public class MonitorLevel(
 
     void IWorkProvider.DoWork()
     {
+        Interlocked.Exchange(ref _queued, 0);
+        if (Volatile.Read(ref _disposed) != 0) return;
+
         // First get current value
         getter(Component).Switch((v =>
             {
@@ -98,6 +111,7 @@ public class MonitorLevel(
                     if (setter(Value, Component))
                     {
                         _retryWrite = MAX_RETRY;
+                        RequestWork();
                     }
                     else if (_retryWrite-- <= 0)
                     {
@@ -108,12 +122,13 @@ public class MonitorLevel(
                     {
                         // if failed, wait a bit
                         Thread.Sleep(100);
+                        RequestWork();
                     }
                     return;
                 }
 
                 // if not moving, set local value to remote one
-                Value = v.value;
+                this.RaiseAndSetIfChanged(ref _value, v.value, nameof(Value));
                 Moving = false;
             }), 
             error =>
@@ -125,10 +140,9 @@ public class MonitorLevel(
                 else
                 {
                     Thread.Sleep(100);
+                    RequestWork();
                 }
             });
-
-         parser.Enqueue(this);
     }
 
     uint _value;
@@ -144,6 +158,7 @@ public class MonitorLevel(
                 this.RaiseAndSetIfChanged(ref _value, value);
                 Moving = true;
             }
+            RequestWork();
         }
     }
 
@@ -160,5 +175,11 @@ public class MonitorLevel(
         private set => this.RaiseAndSetIfChanged(ref _max, value);
     }
     uint _max;
+
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _disposed, 1);
+        GC.SuppressFinalize(this);
+    }
 
 }

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorLevel.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorLevel.cs
@@ -56,6 +56,13 @@ public class MonitorLevel(
         return this;
     }
 
+    /// <summary>
+    /// Ask for one read of the remote value (live-read mode). Safe to call at
+    /// any rate: the _queued guard coalesces requests, and a level being moved
+    /// by the user just continues its write loop.
+    /// </summary>
+    public void Refresh() => RequestWork();
+
     void RequestWork()
     {
         if (Volatile.Read(ref _disposed) != 0) return;

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorRgbLevel.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorRgbLevel.cs
@@ -6,7 +6,7 @@ using ReactiveUI;
 
 namespace HLab.Sys.Windows.MonitorVcp;
 
-public class MonitorRgbLevel : ReactiveObject
+public class MonitorRgbLevel : ReactiveObject, IDisposable
 {
    readonly MonitorLevel[] _values = new MonitorLevel[3];
 
@@ -52,4 +52,10 @@ public class MonitorRgbLevel : ReactiveObject
    }
 
    public uint[] GetValues() => _values.Select(t => t.Value).ToArray();
+
+   public void Dispose()
+   {
+      foreach (var level in _values) level.Dispose();
+      GC.SuppressFinalize(this);
+   }
 }

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorRgbLevel.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/MonitorRgbLevel.cs
@@ -24,6 +24,12 @@ public class MonitorRgbLevel : ReactiveObject, IDisposable
       return this;
    }
 
+   public void Refresh()
+   {
+      foreach (var level in _values)
+         level.Refresh();
+   }
+
    public MonitorLevel Channel(uint channel) { return _values[channel]; }
 
    public MonitorLevel Red => Channel(0);

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpControl.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpControl.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
+using System.Threading;
 using System.Threading.Tasks;
 using ReactiveUI;
 using OneOf;
@@ -44,10 +45,15 @@ public enum VcpComponent
 }
 
 
-public class VcpControl : ReactiveObject
+public class VcpControl : ReactiveObject, IDisposable
 {
    readonly IVcpTransport _transport;
    readonly CommandWorker _worker;
+   readonly Task _probeTask;
+   int _disposed;
+   int _transportDisposed;
+
+   public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
 
    /// <summary>Identity of the monitor this channel talks to (used for the LUT store).</summary>
    public string MonitorId { get; }
@@ -67,7 +73,7 @@ public class VcpControl : ReactiveObject
       // The capabilities probe is a full DDC transaction — seconds per monitor
       // when the bus is slow or the monitor asleep. Run it off-thread; the
       // levels pop in through their reactive properties when it lands.
-      Task.Run(Probe);
+      _probeTask = Task.Run(Probe);
    }
 
    void Probe()
@@ -80,7 +86,8 @@ public class VcpControl : ReactiveObject
       }
       finally
       {
-         RxSchedulers.MainThreadScheduler.Schedule(() => OnProbed(codes));
+         if (Volatile.Read(ref _disposed) == 0)
+            RxSchedulers.MainThreadScheduler.Schedule(() => OnProbed(codes));
       }
    }
 
@@ -88,6 +95,7 @@ public class VcpControl : ReactiveObject
    {
       lock (_startLock)
       {
+         if (Volatile.Read(ref _disposed) != 0) return;
          if (codes is not null)
          {
             if (codes.Contains((byte)VcpCode.Brightness))
@@ -130,6 +138,7 @@ public class VcpControl : ReactiveObject
    {
       lock (_startLock)
       {
+         if (Volatile.Read(ref _disposed) != 0) return this;
          _started = true;
          _brightness?.Start();
          _contrast?.Start();
@@ -178,6 +187,7 @@ public class VcpControl : ReactiveObject
 
    public void ActivateAnyway()
    {
+      if (Volatile.Read(ref _disposed) != 0) return;
       Brightness ??= new MonitorLevel(_worker, GetBrightness, SetBrightness).Start();
       Contrast ??= new MonitorLevel(_worker, GetContrast, SetContrast).Start();
 
@@ -263,6 +273,35 @@ public class VcpControl : ReactiveObject
       => _transport.GetFeature(DriveCode(component));
    bool SetDrive(uint value, VcpComponent component)
       => _transport.SetFeature(DriveCode(component), value);
+
+   public void Dispose()
+   {
+      if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+      lock (_startLock)
+      {
+         _source?.Dispose();
+         _brightness?.Dispose();
+         _contrast?.Dispose();
+         _gain?.Dispose();
+         _drive?.Dispose();
+      }
+
+      if (_probeTask.IsCompleted)
+         DisposeTransport();
+      else
+         _ = _probeTask.ContinueWith(_ => DisposeTransport(),
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+      GC.SuppressFinalize(this);
+   }
+
+   void DisposeTransport()
+   {
+      if (Interlocked.Exchange(ref _transportDisposed, 1) == 0)
+         _transport.Dispose();
+   }
 }
 
 public delegate OneOf<(uint value, uint min, uint max), int> VcpGetter(VcpComponent component = VcpComponent.None);

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpControl.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpControl.cs
@@ -131,6 +131,74 @@ public class VcpControl : ReactiveObject, IDisposable
       return _started ? level.Start() : level;
    }
 
+   public static readonly TimeSpan LiveReadInterval = TimeSpan.FromSeconds(1);
+   public static readonly TimeSpan LiveReadDuration = TimeSpan.FromMinutes(2);
+
+   readonly object _liveLock = new();
+   LiveReadSession? _liveSession;
+
+   /// <summary>
+   /// Live-read mode: while true the levels are re-read every second so
+   /// monitor-side (OSD) changes show up in the UI. Auto-expires after
+   /// <see cref="LiveReadDuration"/>; settable so a ToggleButton can bind it.
+   /// </summary>
+   public bool LiveRead
+   {
+      get => _liveRead;
+      set { if (value) StartLiveRead(); else StopLiveRead(); }
+   }
+   bool _liveRead;
+
+   public void StartLiveRead() => StartLiveRead(LiveReadInterval, LiveReadDuration);
+
+   public void StartLiveRead(TimeSpan interval, TimeSpan duration)
+   {
+      lock (_liveLock)
+      {
+         if (Volatile.Read(ref _disposed) != 0) return;
+         _liveSession?.Dispose();
+         _liveSession = new LiveReadSession(RefreshAll, OnLiveReadStopped, interval, duration);
+         SetLiveRead(true);
+      }
+   }
+
+   public void StopLiveRead()
+   {
+      lock (_liveLock) _liveSession?.Dispose();
+   }
+
+   void OnLiveReadStopped(LiveReadSession session)
+   {
+      lock (_liveLock)
+      {
+         // A restart disposes the old session after installing the new one:
+         // only the current session's end may turn the mode off.
+         if (!ReferenceEquals(_liveSession, session)) return;
+         _liveSession = null;
+         SetLiveRead(false);
+      }
+   }
+
+   void SetLiveRead(bool value)
+   {
+      RxSchedulers.MainThreadScheduler.Schedule(() =>
+      {
+         if (_liveRead == value) return;
+         _liveRead = value;
+         this.RaisePropertyChanged(nameof(LiveRead));
+      });
+   }
+
+   void RefreshAll()
+   {
+      if (Volatile.Read(ref _disposed) != 0) return;
+      _source?.Refresh();
+      _brightness?.Refresh();
+      _contrast?.Refresh();
+      _gain?.Refresh();
+      _drive?.Refresh();
+   }
+
    readonly object _startLock = new();
    bool _started;
 
@@ -277,6 +345,8 @@ public class VcpControl : ReactiveObject, IDisposable
    public void Dispose()
    {
       if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+      StopLiveRead();
 
       lock (_startLock)
       {

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpExpendMonitor.cs
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/VcpExpendMonitor.cs
@@ -15,7 +15,14 @@ public static class VcpExpendMonitor
 
     /// <summary>Windows path: VCP channel from the Win32 device tree (dxva2 transport).</summary>
     public static VcpControl Vcp(this MonitorDevice monitor)
-        => AllVcp.GetValue(monitor, m => new VcpControl(m.Id, m.Edid?.ManufacturerCode, new DxVa2VcpTransport(m), LevelParser));
+    {
+        if (AllVcp.TryGetValue(monitor, out var control) && !control.IsDisposed)
+            return control;
+
+        AllVcp.Remove(monitor);
+        return AllVcp.GetValue(monitor, m => new VcpControl(m.Id,
+            m.Edid?.ManufacturerCode, new DxVa2VcpTransport(m), LevelParser));
+    }
 
     public static void Stop() => LevelParser.Stop();
 

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
@@ -2,6 +2,7 @@
 using HLab.Sys.Monitors;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -286,10 +287,8 @@ public static class MonitorDeviceHelper
 
         var ch = ChangeDisplaySettingsEx(sourceName, ref devMode, 0, flag, 0);
 
-        if (ch == DispChange.Successful && apply)
-            ApplyDesktop();
-
-        return ch == DispChange.Successful;
+        if (ch != DispChange.Successful) return false;
+        return !apply || ApplyDesktop();
     }
 
     /// <summary>
@@ -398,8 +397,9 @@ public static class MonitorDeviceHelper
             return false;
         }
 
-        ApplyDesktop();
-        return true;
+        if (ApplyDesktop()) return true;
+        ResaveCurrentConfiguration();
+        return false;
     }
 
     /// <summary>
@@ -441,16 +441,16 @@ public static class MonitorDeviceHelper
     /// coherent registry state when pending display writes were aborted halfway,
     /// which would otherwise fail every further UpdateRegistry call.
     /// </summary>
-    static void ResaveCurrentConfiguration()
+    public static bool ResaveCurrentConfiguration()
     {
-        if (QueryDisplayConfigPaths() is not { } cfg) return;
+        if (QueryDisplayConfigPaths() is not { } cfg) return false;
         var (paths, modes) = cfg;
 
-        SetDisplayConfig((uint)paths.Length, paths, (uint)modes.Length, modes,
+        return SetDisplayConfig((uint)paths.Length, paths, (uint)modes.Length, modes,
             SetDisplayConfigFlags.Apply
             | SetDisplayConfigFlags.UseSuppliedDisplayConfig
             | SetDisplayConfigFlags.AllowChanges
-            | SetDisplayConfigFlags.SaveToDatabase);
+            | SetDisplayConfigFlags.SaveToDatabase) == 0;
     }
 
     // Former source-based implementation, kept for reference. It detached whatever
@@ -491,7 +491,8 @@ public static class MonitorDeviceHelper
     //}
 
 
-    public static void ApplyDesktop() => ChangeDisplaySettingsEx(null, 0, 0, 0, 0);
+    public static bool ApplyDesktop()
+        => ChangeDisplaySettingsEx(null, 0, 0, 0, 0) == DispChange.Successful;
 
     public static RegistryKey OpenMonitorRegKey(this MonitorDevice @this, RegistryKey key, bool create = false)
     {
@@ -576,58 +577,56 @@ public static class MonitorDeviceHelper
             0
         ); // reserved
 
+        if (devInfo == 0 || devInfo == new nint(-1)) return null;
+
         try
         {
-            if (devInfo == 0)
-            {
-                return null;
-            }
-
             var devInfoData = new SP_DEVINFO_DATA();
 
-            uint i = 0;
-
-            do
+            for (uint i = 0; ; i++)
             {
-                if (SetupDiEnumDeviceInfo(devInfo, i, ref devInfoData))
+                if (!SetupDiEnumDeviceInfo(devInfo, i, ref devInfoData))
                 {
-
-                    var hEdidRegKey = SetupDiOpenDevRegKey(devInfo, ref devInfoData,
-                        DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_READ);
-
-                    try
-                    {
-                        if (hEdidRegKey != 0 && (int)hEdidRegKey != -1)
-                        {
-                            using var key = RegistryKey(hEdidRegKey, 1);
-                            var value = key?.GetValue("HardwareID");
-                            if (value is string[] { Length: > 0 } s)
-                            {
-                                var id = s[0] + "\\" +
-                                         key.GetValue("Driver");
-
-                                if (id == deviceId)
-                                {
-                                    var hKeyName = GetHKeyName(hEdidRegKey);
-                                    using var keyEdid = RegistryKey(hEdidRegKey);
-
-                                    var edid = (byte[])keyEdid.GetValue("EDID");
-                                    return edid != null ? EdidParser.Parse(hKeyName, edid) : null;
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        var result = RegCloseKey(hEdidRegKey);
-                        if (result > 0)
-                            throw new Exception(GetLastErrorString());
-                    }
+                    var enumerationError = GetLastError();
+                    if (enumerationError != ErrorNoMoreItems)
+                        Debug.WriteLine($"SetupDiEnumDeviceInfo failed at {i}: {enumerationError}");
+                    break;
                 }
 
+                var hEdidRegKey = SetupDiOpenDevRegKey(devInfo, ref devInfoData,
+                    DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_READ);
+                if (hEdidRegKey == 0 || hEdidRegKey == new nint(-1)) continue;
 
-                i++;
-            } while (ErrorNoMoreItems != GetLastError());
+                try
+                {
+                    var hKeyName = GetRegistryKeyName(hEdidRegKey);
+                    if (string.IsNullOrEmpty(hKeyName)) continue;
+
+                    using var key = RegistryKey(hKeyName, 1);
+                    var value = key?.GetValue("HardwareID");
+                    if (value is string[] { Length: > 0 } s)
+                    {
+                        var id = s[0] + "\\" + key.GetValue("Driver");
+
+                        if (id == deviceId)
+                        {
+                            using var keyEdid = RegistryKey(hKeyName);
+                            var edid = keyEdid?.GetValue("EDID") as byte[];
+                            return edid != null ? EdidParser.Parse(hKeyName, edid) : null;
+                        }
+                    }
+                }
+                catch (Exception error)
+                {
+                    Debug.WriteLine($"Skipping unreadable monitor registry entry: {error.Message}");
+                }
+                finally
+                {
+                    var result = RegCloseKey(hEdidRegKey);
+                    if (result != 0)
+                        Debug.WriteLine($"RegCloseKey failed: {result}");
+                }
+            }
         }
         finally
         {
@@ -635,6 +634,43 @@ public static class MonitorDeviceHelper
         }
 
         return null;
+    }
+
+    static string GetRegistryKeyName(nint hKey)
+    {
+        var status = Wdm.ZwQueryKey(hKey, Wdm.KeyInformationClass.KeyNameInformation,
+            0, 0, out var needed);
+        if (status == 0 || needed < sizeof(uint)) return string.Empty;
+
+        var buffer = Marshal.AllocHGlobal(needed);
+        try
+        {
+            var capacity = needed;
+            status = Wdm.ZwQueryKey(hKey, Wdm.KeyInformationClass.KeyNameInformation,
+                buffer, capacity, out var returned);
+            if (status != 0 || returned < sizeof(uint) || returned > capacity)
+                return string.Empty;
+
+            var bytes = new byte[returned];
+            Marshal.Copy(buffer, bytes, 0, returned);
+            return DecodeKeyNameInformation(bytes);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    /// <summary>Decode byte-counted KEY_NAME_INFORMATION without unmanaged over-read.</summary>
+    public static string DecodeKeyNameInformation(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < sizeof(uint)) return string.Empty;
+        var nameLength = BitConverter.ToUInt32(buffer[..sizeof(uint)]);
+        if ((nameLength & 1) != 0 || nameLength > buffer.Length - sizeof(uint))
+            throw new InvalidDataException("Invalid KEY_NAME_INFORMATION byte length.");
+
+        return Encoding.Unicode.GetString(
+            buffer.Slice(sizeof(uint), checked((int)nameLength)));
     }
 
     /// <summary>

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/MonitorDevice.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using HLab.Sys.Monitors;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace HLab.Sys.Windows.Monitors;
@@ -28,6 +29,23 @@ public class MonitorDevice : IEquatable<MonitorDevice>
 
    [XmlIgnore]
    public List<MonitorDeviceConnection> Connections = new();
+
+   /// <summary>
+   /// Connection currently participating in the desktop. EnumDisplayDevices can
+   /// expose the same target below several adapters, including stale inactive
+   /// candidates, so enumeration order is not an identity.
+   /// </summary>
+   [XmlIgnore]
+   public MonitorDeviceConnection? ActiveConnection => SelectConnection(Connections);
+
+   public static MonitorDeviceConnection? SelectConnection(
+      IEnumerable<MonitorDeviceConnection> connections)
+      => connections
+         .OrderByDescending(c => c.State?.AttachedToDesktop == true)
+         .ThenByDescending(c => c.Parent.HMonitor != 0)
+         .ThenByDescending(c => c.Parent.CurrentMode != null)
+         .ThenBy(c => c.Parent.DeviceName, StringComparer.OrdinalIgnoreCase)
+         .FirstOrDefault();
 
    public override bool Equals(object obj)
    {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LittleBigMouse.DisplayLayout.Tests.csproj
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LittleBigMouse.DisplayLayout.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\LittleBigMouse.DisplayLayout\LittleBigMouse.DisplayLayout.csproj" />
     <ProjectReference Include="..\..\LittleBigMouse.Platform.Linux\LittleBigMouse.Platform.Linux.csproj" />
+    <ProjectReference Include="..\..\LittleBigMouse.Platform.Windows\LittleBigMouse.Platform.Windows.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/WindowsMonitorSafetyTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/WindowsMonitorSafetyTests.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using HLab.Geo;
+using HLab.Sys.Windows.Monitors;
+using HLab.Sys.Windows.Monitors.Factory;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Platform.Windows;
+using Xunit;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+public class WindowsMonitorSafetyTests
+{
+    [Fact]
+    public void KeyNameInformationUsesByteLengthWithoutReadingPastBuffer()
+    {
+        const string path = @"\REGISTRY\MACHINE\SYSTEM\Monitor";
+        var name = Encoding.Unicode.GetBytes(path);
+        var data = new byte[sizeof(uint) + name.Length];
+        BitConverter.TryWriteBytes(data.AsSpan(), (uint)name.Length);
+        name.CopyTo(data, sizeof(uint));
+
+        Assert.Equal(path, MonitorDeviceHelper.DecodeKeyNameInformation(data));
+
+        BitConverter.TryWriteBytes(data.AsSpan(), (uint)(name.Length + 2));
+        Assert.Throws<InvalidDataException>(() => MonitorDeviceHelper.DecodeKeyNameInformation(data));
+    }
+
+    [Fact]
+    public void ActiveConnectionWinsRegardlessOfEnumerationOrder()
+    {
+        var stale = Connection(@"\.\DISPLAY9", attached: false, hMonitor: 0);
+        var active = Connection(@"\.\DISPLAY2", attached: true, hMonitor: 42);
+
+        Assert.Same(active, MonitorDevice.SelectConnection([stale, active]));
+        Assert.Same(active, MonitorDevice.SelectConnection([active, stale]));
+    }
+
+    [Fact]
+    public void LocationBatchRollsBackWithoutCommitAfterStageFailure()
+    {
+        var transaction = new FakeTransaction(stageResults: [true, false], commit: true);
+        var controller = new WindowsDisplayController(transaction);
+
+        var result = controller.SetLocations([
+            (Source("one", 0), new Point(100, 0), null),
+            (Source("two", 1920), new Point(2020, 0), null)
+        ]);
+
+        Assert.False(result);
+        Assert.Equal(2, transaction.StageCalls);
+        Assert.Equal(0, transaction.CommitCalls);
+        Assert.Equal(1, transaction.RestoreCalls);
+    }
+
+    [Fact]
+    public void LocationBatchRollsBackWhenCommitFails()
+    {
+        var transaction = new FakeTransaction(stageResults: [true], commit: false);
+        var controller = new WindowsDisplayController(transaction);
+
+        var result = controller.SetLocations([
+            (Source("one", 0), new Point(100, 0), null)
+        ]);
+
+        Assert.False(result);
+        Assert.Equal(1, transaction.CommitCalls);
+        Assert.Equal(1, transaction.RestoreCalls);
+    }
+
+    static MonitorDeviceConnection Connection(string name, bool attached, nint hMonitor)
+        => new()
+        {
+            DeviceName = name,
+            State = new DeviceState { AttachedToDesktop = attached },
+            Parent = new PhysicalAdapter
+            {
+                DeviceName = name,
+                HMonitor = hMonitor,
+                CurrentMode = attached ? new DisplayMode() : null!
+            }
+        };
+
+    static DisplaySource Source(string id, double x)
+    {
+        var source = new DisplaySource(id) { InterfacePath = $@"\?\DISPLAY#{id}" };
+        source.InPixel.Set(new Rect(x, 0, 1920, 1080));
+        return source;
+    }
+
+    sealed class FakeTransaction(IEnumerable<bool> stageResults, bool commit)
+        : IWindowsDisplayTransaction
+    {
+        readonly Queue<bool> _stageResults = new(stageResults);
+        public int StageCalls { get; private set; }
+        public int CommitCalls { get; private set; }
+        public int RestoreCalls { get; private set; }
+
+        public bool Stage(DisplaySource source, Rect bounds)
+        {
+            StageCalls++;
+            return _stageResults.Dequeue();
+        }
+
+        public bool Commit()
+        {
+            CommitCalls++;
+            return commit;
+        }
+
+        public bool Restore()
+        {
+            RestoreCalls++;
+            return true;
+        }
+    }
+}

--- a/LittleBigMouse.Platform.Windows/WindowsDisplayController.cs
+++ b/LittleBigMouse.Platform.Windows/WindowsDisplayController.cs
@@ -1,11 +1,29 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Linq;
 using HLab.Geo;
 using HLab.Sys.Windows.Monitors.Factory;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Platform.Windows;
+
+public interface IWindowsDisplayTransaction
+{
+    bool Stage(DisplaySource source, Rect bounds);
+    bool Commit();
+    bool Restore();
+}
+
+sealed class NativeWindowsDisplayTransaction : IWindowsDisplayTransaction
+{
+    public bool Stage(DisplaySource source, Rect bounds)
+        => MonitorDeviceHelper.AttachToDesktop(source.InterfacePath, source.Primary,
+            bounds, source.Orientation, apply: false);
+
+    public bool Commit() => MonitorDeviceHelper.ApplyDesktop();
+    public bool Restore() => MonitorDeviceHelper.ResaveCurrentConfiguration();
+}
 
 /// <summary>
 /// Windows implementation of <see cref="IDisplayController"/>: reads the opaque
@@ -14,6 +32,13 @@ namespace LittleBigMouse.Platform.Windows;
 /// </summary>
 public class WindowsDisplayController : IDisplayController
 {
+    readonly IWindowsDisplayTransaction _transaction;
+
+    public WindowsDisplayController() : this(new NativeWindowsDisplayTransaction()) { }
+
+    public WindowsDisplayController(IWindowsDisplayTransaction transaction)
+        => _transaction = transaction;
+
     public bool SetPrimary(DisplaySource source)
         => MonitorDeviceHelper.SetPrimary(source.InterfacePath);
 
@@ -38,14 +63,22 @@ public class WindowsDisplayController : IDisplayController
 
         if (changed.Count == 0) return true;
 
-        var ok = true;
-        foreach (var (source, position) in changed)
-            ok &= MonitorDeviceHelper.AttachToDesktop(
-                source.InterfacePath, source.Primary,
-                new Rect(position, source.InPixel.Bounds.Size), source.Orientation,
-                apply: false);
+        if (changed.Any(item => string.IsNullOrWhiteSpace(item.Source.InterfacePath)
+            || item.Source.InPixel.Bounds.Width <= 0
+            || item.Source.InPixel.Bounds.Height <= 0))
+            return false;
 
-        MonitorDeviceHelper.ApplyDesktop();
-        return ok;
+        foreach (var (source, position) in changed)
+        {
+            if (_transaction.Stage(source,
+                    new Rect(position, source.InPixel.Bounds.Size))) continue;
+
+            _transaction.Restore();
+            return false;
+        }
+
+        if (_transaction.Commit()) return true;
+        _transaction.Restore();
+        return false;
     }
 }

--- a/LittleBigMouse.Platform.Windows/WindowsLayoutFactory.cs
+++ b/LittleBigMouse.Platform.Windows/WindowsLayoutFactory.cs
@@ -262,8 +262,7 @@ internal static class WindowsLayoutMapping
     {
         source.InterfacePath = monitor.InterfacePath;
 
-        if(monitor.Connections.Count == 0) return source;
-        var device = monitor.Connections[0];
+        if (monitor.ActiveConnection is not { } device) return source;
 
         if(device.Parent == null) return source;
 
@@ -317,8 +316,7 @@ internal static class WindowsLayoutMapping
     /// </summary>
     public static DisplaySource UpdateWallpaperFrom(this DisplaySource source, MonitorDevice monitor, string? fallbackPath = null)
     {
-        if (monitor.Connections.Count == 0) return source;
-        var device = monitor.Connections[0];
+        if (monitor.ActiveConnection is not { } device) return source;
         if (device.Parent == null) return source;
 
         // Per-monitor COM path is empty during the wallpaper fade; fall back to the registry path
@@ -398,7 +396,7 @@ internal static class WindowsLayoutMapping
     {
         var edid = monitor.Edid is { PhysicalWidth: > 0, PhysicalHeight: > 0 } e ? monitor.Edid : null;
 
-        var display = monitor.Connections[0].Parent;
+        var display = monitor.ActiveConnection?.Parent;
 
         if (display?.CurrentMode != null)
         {
@@ -456,7 +454,7 @@ internal static class WindowsLayoutMapping
     {
         if (!string.IsNullOrEmpty(@this.PnpDeviceName)) return @this;
 
-        var name = HtmlHelper.CleanupPnpName(monitor.Connections[0].DeviceString);
+        var name = HtmlHelper.CleanupPnpName(monitor.ActiveConnection?.DeviceString ?? "");
         // A monitor without EDID (virtual display, DisplayLink, RDP, spacedesk, some panels)
         // reports "Generic PnP Monitor" and has a null Edid: keep the generic name then.
         if (name.ToLower() == "generic pnp monitor" && !string.IsNullOrEmpty(monitor.Edid?.Model))
@@ -482,7 +480,7 @@ internal static class WindowsLayoutMapping
 
     static string BrandLogo(this MonitorDevice device)
     {
-        var dev = device.Connections[0].Parent?.DeviceString;
+        var dev = device.ActiveConnection?.Parent?.DeviceString;
         if (dev != null)
         {
             // special case for Spacedesk support

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VcpSafetyTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VcpSafetyTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Threading;
+using HLab.Sys.Windows.MonitorVcp;
+using OneOf;
+using Xunit;
+using static HLab.Sys.Windows.API.MonitorConfiguration.LowLevelMonitorConfiguration;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class VcpSafetyTests
+{
+    [Fact]
+    public void StableLevelReadsOnceAndDoesNotPollForever()
+    {
+        var reads = 0;
+        var worker = new CommandWorker();
+        using var level = new MonitorLevel(worker, _ =>
+        {
+            Interlocked.Increment(ref reads);
+            return (50u, 0u, 100u);
+        }, (_, _) => true).Start();
+
+        Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref reads) == 1, 2_000));
+        Thread.Sleep(150);
+
+        Assert.Equal(1, Volatile.Read(ref reads));
+        Assert.Equal(0, worker.PendingCount);
+    }
+
+    [Fact]
+    public void UserChangePerformsOneWriteAndStopsAfterVerification()
+    {
+        uint remote = 50;
+        var reads = 0;
+        var writes = 0;
+        var worker = new CommandWorker();
+        using var level = new MonitorLevel(worker, _ =>
+        {
+            Interlocked.Increment(ref reads);
+            return (remote, 0u, 100u);
+        }, (value, _) =>
+        {
+            Interlocked.Increment(ref writes);
+            remote = value;
+            return true;
+        }).Start();
+
+        Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref reads) == 1, 2_000));
+        level.Value = 65;
+        Assert.True(SpinWait.SpinUntil(
+            () => Volatile.Read(ref writes) == 1 && Volatile.Read(ref reads) >= 3, 2_000));
+        var settledReads = Volatile.Read(ref reads);
+        Thread.Sleep(150);
+
+        Assert.Equal(1, Volatile.Read(ref writes));
+        Assert.Equal(settledReads, Volatile.Read(ref reads));
+        Assert.False(level.Moving);
+    }
+
+    [Fact]
+    public void AmbiguousPhysicalMonitorsAreNotGuessed()
+    {
+        Assert.Null(DxVa2VcpTransport.SelectPhysicalMonitorIndex(
+            ["Generic PnP Monitor", "Generic PnP Monitor"],
+            ["Generic PnP Monitor", "DEL U2723QE"]));
+
+        Assert.Equal(1, DxVa2VcpTransport.SelectPhysicalMonitorIndex(
+            ["Left panel", "Dell U2723QE"],
+            ["U2723QE"]));
+
+        Assert.Equal(0, DxVa2VcpTransport.SelectPhysicalMonitorIndex(
+            ["Unidentified monitor"], []));
+    }
+
+    [Fact]
+    public void DisposingControlReleasesItsTransport()
+    {
+        var transport = new FakeTransport();
+        var control = new VcpControl("monitor", "DEL", transport, new CommandWorker());
+
+        control.Dispose();
+
+        Assert.True(SpinWait.SpinUntil(() => transport.Disposed, 2_000));
+    }
+
+    sealed class FakeTransport : IVcpTransport
+    {
+        public bool Disposed { get; private set; }
+        public IReadOnlySet<byte>? GetSupportedCodes() => new HashSet<byte>();
+        public OneOf<(uint value, uint min, uint max), int> GetFeature(VcpCode code)
+            => (0u, 0u, 100u);
+        public bool SetFeature(VcpCode code, uint value) => true;
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VcpSafetyTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VcpSafetyTests.cs
@@ -73,6 +73,62 @@ public class VcpSafetyTests
     }
 
     [Fact]
+    public void LiveReadSessionRefreshesUntilItsDeadlineThenStops()
+    {
+        var refreshes = 0;
+        var stopped = 0;
+        using var session = new LiveReadSession(
+            () => Interlocked.Increment(ref refreshes),
+            _ => Interlocked.Increment(ref stopped),
+            System.TimeSpan.FromMilliseconds(20),
+            System.TimeSpan.FromMilliseconds(200));
+
+        Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref refreshes) >= 2, 2_000));
+        Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref stopped) == 1, 2_000));
+
+        var settled = Volatile.Read(ref refreshes);
+        Thread.Sleep(100);
+        Assert.Equal(settled, Volatile.Read(ref refreshes));
+    }
+
+    [Fact]
+    public void LiveReadPollsTheTransportAndDisposeStopsIt()
+    {
+        var transport = new CountingTransport();
+        var control = new VcpControl("monitor", null, transport, new CommandWorker());
+
+        // wait for the capabilities probe so Brightness exists, then go live
+        Assert.True(SpinWait.SpinUntil(() => !control.Probing, 2_000));
+        control.Start();
+        control.StartLiveRead(
+            System.TimeSpan.FromMilliseconds(20), System.TimeSpan.FromMinutes(10));
+
+        Assert.True(SpinWait.SpinUntil(() => transport.Reads >= 3, 2_000));
+
+        control.Dispose();
+        Assert.True(SpinWait.SpinUntil(() => transport.Disposed, 2_000));
+        var settled = transport.Reads;
+        Thread.Sleep(100);
+        Assert.Equal(settled, transport.Reads);
+    }
+
+    sealed class CountingTransport : IVcpTransport
+    {
+        int _reads;
+        public int Reads => Volatile.Read(ref _reads);
+        public bool Disposed { get; private set; }
+        public IReadOnlySet<byte>? GetSupportedCodes()
+            => new HashSet<byte> { (byte)VcpCode.Brightness };
+        public OneOf<(uint value, uint min, uint max), int> GetFeature(VcpCode code)
+        {
+            Interlocked.Increment(ref _reads);
+            return (50u, 0u, 100u);
+        }
+        public bool SetFeature(VcpCode code, uint value) => true;
+        public void Dispose() => Disposed = true;
+    }
+
+    [Fact]
     public void DisposingControlReleasesItsTransport()
     {
         var transport = new FakeTransport();

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/DdcUtilVcpService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/DdcUtilVcpService.cs
@@ -29,7 +29,9 @@ public partial class DdcUtilVcpService : IVcpService
     {
         lock (_lock)
         {
-            if (_controls.TryGetValue(monitor.Id, out var cached)) return cached;
+            if (_controls.TryGetValue(monitor.Id, out var cached) && !cached.IsDisposed)
+                return cached;
+            _controls.Remove(monitor.Id);
 
             // A view-model is created for every monitor in the same activation
             // wave. Share one short-lived DRM snapshot instead of rereading all

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenView.axaml
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenView.axaml
@@ -741,7 +741,15 @@
                 <!-- Image -->
                 <Border Classes="card faders" IsVisible="{Binding ImageVisibility}">
                     <StackPanel>
-                        <TextBlock Classes="cardTitle" Text="Image"/>
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Classes="cardTitle" Text="Image"/>
+                            <ToggleButton Grid.Column="1" FontSize="11" Padding="6,2"
+                                          VerticalAlignment="Top"
+                                          IsChecked="{Binding Vcp.LiveRead, Mode=TwoWay}"
+                                          ToolTip.Tip="Follow changes made on the monitor's own menu: re-read all levels every second, for two minutes.">
+                                <TextBlock Text="Live read"/>
+                            </ToggleButton>
+                        </Grid>
                         <StackPanel Orientation="Horizontal" Spacing="6">
 
                             <StackPanel IsVisible="{Binding BrightnessVisibility}">

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
@@ -1207,6 +1207,6 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
       Hisense.Dispose();
       // ends the persistent spotread session along with any running sweep
       ArgyllProbe.Abort();
-      VcpExpendMonitor.Stop();
+      Vcp?.Dispose();
    }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/MonitorWarningDialog.axaml.cs
@@ -84,6 +84,28 @@ public partial class MonitorWarningDialog : Window
         return (confirmed, confirmed && dialog.ScaleCheckBox.IsChecked == true);
     }
 
+    public static async Task ShowFailureAsync(Window? owner, string action)
+    {
+        var dialog = new MonitorWarningDialog
+        {
+            Title = "Display change failed"
+        };
+        dialog.HeadingText.Text = $"The system could not {action}.";
+        dialog.BodyText.Text = "LittleBigMouse stopped the operation and restored the last known desktop configuration. No partial monitor layout was intentionally applied.";
+        dialog.RecoveryTitle.Text = "What to do next:";
+        dialog.Step1.Text = "Open the system display settings and confirm that every monitor is connected and using a supported mode, then try again.";
+        dialog.Step2.IsVisible = false;
+        dialog.Step3.IsVisible = false;
+        dialog.DontShowAgainCheckBox.IsVisible = false;
+        // The hidden CancelButton carries IsCancel: move it to the visible OK
+        // button so Escape still closes the dialog.
+        dialog.CancelButton.IsVisible = false;
+        dialog.ConfirmButton.Content = "OK";
+        dialog.ConfirmButton.IsCancel = true;
+        dialog.ConfirmButton.IsDefault = true;
+        await dialog.ShowAsync(owner);
+    }
+
     /// <summary>
     /// Returns whether the user confirmed the action, and whether the warning
     /// should be hidden from now on (only honoured when confirmed).

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorsLayoutPresenterViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorsLayoutPresenterViewModel.cs
@@ -114,7 +114,8 @@ public class MonitorsLayoutPresenterViewModel
         // loads the saved one: the current physical layout survives only if saved first.
         _persistence?.Save(layout);
 
-        _controller.SetLocations(locations);
+        if (!_controller.SetLocations(locations))
+            await MonitorWarningDialog.ShowFailureAsync(owner, "apply the monitor layout");
     }
 
     public MonitorsLayoutPresenterViewModel():this(new MainViewModelDesign())

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Plugins/Default/DefaultMonitorViewModel.cs
@@ -112,21 +112,24 @@ public class DefaultMonitorViewModel : ViewModel<PhysicalMonitor>
     {
         if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowDetachAsync)) return;
 
-        _controller?.DetachFromDesktop(Model.ActiveSource.Source);
+        if (_controller?.DetachFromDesktop(Model.ActiveSource.Source) == false)
+            await MonitorWarningDialog.ShowFailureAsync(owner, "detach this monitor");
     }
 
     async Task AttachToDesktopAsync(Window? owner)
     {
         if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowAttachAsync)) return;
 
-        _controller?.AttachToDesktop(Model.ActiveSource.Source);
+        if (_controller?.AttachToDesktop(Model.ActiveSource.Source) == false)
+            await MonitorWarningDialog.ShowFailureAsync(owner, "attach this monitor");
     }
 
     async Task MakePrimaryAsync(Window? owner)
     {
         if (!await ConfirmAsync(owner, MonitorWarningDialog.ShowMakePrimaryAsync)) return;
 
-        _controller?.SetPrimary(Model.ActiveSource.Source);
+        if (_controller?.SetPrimary(Model.ActiveSource.Source) == false)
+            await MonitorWarningDialog.ShowFailureAsync(owner, "make this monitor primary");
     }
 
     async Task<bool> ConfirmAsync(Window? owner, Func<Window?, Task<(bool Confirmed, bool DontShowAgain)>> showDialog)


### PR DESCRIPTION
First extraction from #513: the VCP/topology commit (2764856), reviewed fix by fix, cherry-picked with two adaptations, plus a follow-up commit restoring OSD monitoring as an explicit bounded mode.

## From #513 (adapted)

- **dxva2 handle leak**: `VcpControl` now disposes its `IVcpTransport`; the probe task is awaited before the transport goes away, and disposed controls are evicted from the cache.
- **Registry key name over-read**: `GetHKeyName` copied 2× the buffer size (`Marshal.Copy` counts chars, the buffer counts bytes); replaced by a bounded decode in `MonitorDeviceHelper`, with a unit test. (The buggy original still lives in HLab.Core — tracked separately.)
- **Clone mode targeted the wrong panel**: `DxVa2VcpTransport` picked `_physicalMonitors[0]` for every device sharing an HMONITOR; it now matches the physical monitor by description. When two identical descriptions make the choice ambiguous, VCP is disabled for that device rather than guessed — behavioral change to be aware of.
- **DDC polling loop**: `CommandWorker`/`MonitorLevel` no longer re-enqueue forever; levels go quiet once converged. The hand-tuned slow-monitor behavior is preserved verbatim: read-before-write, convergence-based `Moving`, 10 retries / 100 ms backoff / auto-disable, latest-value coalescing. Closing one monitor's panel no longer kills the shared worker.
- **Topology application is transactional**: `WindowsDisplayController` stages, commits, and rolls back via `ResaveCurrentConfiguration` instead of leaving the registry half-written when an `AttachToDesktop` fails mid-batch.
- **`ActiveConnection`** replaces order-dependent `Connections[0]` lookups (also removes potential `IndexOutOfRange`).
- **Topology failures are no longer silent**: `SetPrimary`/`Attach`/`Detach`/`SetLocations` failures show a dialog. Adapted from the PR version: OS-agnostic wording (the controller also targets Linux/kscreen) and Escape kept working (`IsCancel` moved to the visible OK button).

## New: opt-in live read

The perpetual polling removed above was also what kept sliders in sync with changes made on the monitor's own OSD during white-balance sessions. That comes back as an explicit mode: a **Live read** toggle on the Image card re-reads every level once per second and auto-expires after two minutes, so an abandoned panel never polls the DDC bus forever. The `_queued` CAS guard coalesces ticks, so a slow bus cannot pile up requests. Interval/duration are constants on `VcpControl` (`LiveReadInterval`, `LiveReadDuration`).

## Tested

- DisplayLayout.Tests: 72/72 (includes new `WindowsMonitorSafetyTests`)
- Plugin.Vcp.Avalonia.Tests: 60/60 (includes new `VcpSafetyTests` + 2 live-read tests, stable over 5 runs)
- Full UI build on Linux

## Needs testing on Windows

- VCP sliders on a slow monitor: drag feel should be identical or slightly better (immediate wake instead of waiting for the polling pass)
- Live read toggle: OSD changes appear within ~1 s, button unchecks itself after 2 min
- Clone mode: right panel is driven; ambiguous twin monitors now show no VCP instead of driving panel 0
- A failing attach/detach/make-primary shows the failure dialog and rolls back

🤖 Generated with [Claude Code](https://claude.com/claude-code)