### PR TITLE
Hook and UI lifecycle fixes (from #513)

### DIFF
--- a/LittleBigMouse-Hook-Rust/examples/cursor_probe.rs
+++ b/LittleBigMouse-Hook-Rust/examples/cursor_probe.rs
@@ -1,7 +1,13 @@
 //! Manual check: ask KWin where the cursor is (evdev backend start-position probe).
+#[cfg(target_os = "linux")]
 fn main() {
     match littlebigmouse_hook::hook::linux::evdev::kwin_cursor_pos() {
         Some(p) => println!("cursor at ({},{})", p.x(), p.y()),
         None => println!("probe failed (no KWin?)"),
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("cursor_probe is available on Linux only");
 }

--- a/LittleBigMouse-Hook-Rust/examples/enum_bench.rs
+++ b/LittleBigMouse-Hook-Rust/examples/enum_bench.rs
@@ -2,8 +2,10 @@
 //! The pump runs this every 2 s on the routing thread — if it is slow, the
 //! cursor hitches at the same cadence.
 
+#[cfg(target_os = "linux")]
 use std::time::Instant;
 
+#[cfg(target_os = "linux")]
 fn main() {
     // Warm-up (dentry/inode caches).
     let _ = evdev::enumerate().count();
@@ -20,5 +22,14 @@ fn main() {
         total += us;
         std::hint::black_box((mice, kbds));
     }
-    println!("two enumerates: avg {}us, worst {}us over {N} runs", total / N as u128, worst);
+    println!(
+        "two enumerates: avg {}us, worst {}us over {N} runs",
+        total / N as u128,
+        worst
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("enum_bench is available on Linux only");
 }

--- a/LittleBigMouse-Hook-Rust/src/hook/windows/mouse.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/windows/mouse.rs
@@ -12,7 +12,9 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::Ordering;
 
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
-use windows::Win32::UI::WindowsAndMessaging::{CallNextHookEx, HHOOK, MSLLHOOKSTRUCT, WM_MOUSEMOVE};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallNextHookEx, HHOOK, MSLLHOOKSTRUCT, WM_MOUSEMOVE,
+};
 
 use crate::engine::event::MouseEventArg;
 use crate::geometry::Point;
@@ -41,8 +43,7 @@ pub unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPAR
 }
 
 fn process(code: i32, wparam: WPARAM, lparam: LPARAM) -> bool {
-    // Faithful to the C++ filter `(wParam & WM_MOUSEMOVE) != 0`.
-    if !(code >= 0 && lparam.0 != 0 && (wparam.0 & WM_MOUSEMOVE as usize) != 0) {
+    if !is_mouse_move_message(code, wparam, lparam) {
         return false;
     }
 
@@ -83,4 +84,46 @@ fn process(code: i32, wparam: WPARAM, lparam: LPARAM) -> bool {
         CROSSINGS.fetch_add(1, Ordering::Relaxed);
     }
     e.handled
+}
+
+// The C++ hook filtered with `(wParam & WM_MOUSEMOVE) != 0`, but every mouse
+// message carries bit 0x200 (WM_LBUTTONDOWN = 0x201, WM_MOUSEWHEEL = 0x20A…):
+// clicks and wheel events entered the engine as moves, and a click landing on
+// a border mid-crossing could be swallowed by the LRESULT(1) return.
+fn is_mouse_move_message(code: i32, wparam: WPARAM, lparam: LPARAM) -> bool {
+    code >= 0 && lparam.0 != 0 && wparam.0 == WM_MOUSEMOVE as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEWHEEL,
+        WM_RBUTTONDOWN, WM_RBUTTONUP, WM_XBUTTONDOWN, WM_XBUTTONUP,
+    };
+
+    #[test]
+    fn only_mouse_move_can_enter_the_routing_engine() {
+        let pointer = LPARAM(1);
+        assert!(is_mouse_move_message(
+            0,
+            WPARAM(WM_MOUSEMOVE as usize),
+            pointer
+        ));
+
+        for message in [
+            WM_LBUTTONDOWN,
+            WM_LBUTTONUP,
+            WM_RBUTTONDOWN,
+            WM_RBUTTONUP,
+            WM_MBUTTONDOWN,
+            WM_MBUTTONUP,
+            WM_MOUSEWHEEL,
+            WM_MOUSEHWHEEL,
+            WM_XBUTTONDOWN,
+            WM_XBUTTONUP,
+        ] {
+            assert!(!is_mouse_move_message(0, WPARAM(message as usize), pointer));
+        }
+    }
 }

--- a/LittleBigMouse-Hook-Rust/src/platform/windows/process.rs
+++ b/LittleBigMouse-Hook-Rust/src/platform/windows/process.rs
@@ -1,14 +1,14 @@
 //! Process/window helpers — port of the exe-path resolution in
 //! `HookerWinEvents.cpp` (`GetExecutablePathFromProcessId`).
 
-use windows::core::PWSTR;
-use windows::Win32::Foundation::{CloseHandle, HANDLE, HWND, MAX_PATH};
+use windows::core::{HRESULT, PWSTR};
+use windows::Win32::Foundation::{CloseHandle, ERROR_INSUFFICIENT_BUFFER, HANDLE, HWND};
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
 use windows::Win32::System::Threading::{
     GetCurrentProcessId, OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
-    PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
 
@@ -57,19 +57,53 @@ fn parent_pid(pid: u32) -> Option<u32> {
 }
 
 fn exe_path_from_pid(pid: u32) -> Option<String> {
+    // LIMITED is enough for QueryFullProcessImageNameW and, unlike
+    // PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, is granted on elevated or
+    // anticheat-protected processes — exactly the games exclusions target.
     let handle: HANDLE =
-        unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid) }.ok()?;
-
-    let mut buf = [0u16; MAX_PATH as usize];
-    let mut size = buf.len() as u32;
-    let result = unsafe {
-        QueryFullProcessImageNameW(handle, PROCESS_NAME_WIN32, PWSTR(buf.as_mut_ptr()), &mut size)
-    };
+        unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+    let result = query_process_path(handle);
     unsafe {
         let _ = CloseHandle(handle);
     }
-
     result
-        .ok()
-        .map(|_| String::from_utf16_lossy(&buf[..size as usize]))
+}
+
+fn query_process_path(handle: HANDLE) -> Option<String> {
+    const MAX_NT_PATH: usize = 32_768;
+    let mut capacity = 260usize;
+
+    loop {
+        let mut buf = vec![0u16; capacity];
+        let mut size = capacity as u32;
+        let query = unsafe {
+            QueryFullProcessImageNameW(
+                handle,
+                PROCESS_NAME_WIN32,
+                PWSTR(buf.as_mut_ptr()),
+                &mut size,
+            )
+        };
+        match query {
+            Ok(()) => return Some(String::from_utf16_lossy(&buf[..size as usize])),
+            Err(error) if error.code() == HRESULT::from_win32(ERROR_INSUFFICIENT_BUFFER.0) => {}
+            Err(_) => return None,
+        }
+
+        if capacity >= MAX_NT_PATH {
+            return None;
+        }
+        capacity = (capacity * 2).min(MAX_NT_PATH);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_current_process_with_limited_query_rights() {
+        let path = exe_path_from_pid(unsafe { GetCurrentProcessId() }).expect("current exe path");
+        assert!(!path.is_empty());
+    }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LittleBigMouse.Ui.Avalonia.Tests.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LittleBigMouse.Ui.Avalonia.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Platforms>AnyCPU;x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LittleBigMouse.Ui.Avalonia\LittleBigMouse.Ui.Avalonia.csproj" />
+  </ItemGroup>
+</Project>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
@@ -1,3 +1,5 @@
+using MsBox.Avalonia.Enums;
+using LittleBigMouse.Ui.Avalonia.Main;
 using LittleBigMouse.Ui.Avalonia.MonitorFrame;
 using Xunit;
 
@@ -5,6 +7,13 @@ namespace LittleBigMouse.Ui.Avalonia.Tests;
 
 public sealed class UiLifecycleTests
 {
+    [Theory]
+    [InlineData(ButtonResult.Yes, true)]
+    [InlineData(ButtonResult.No, false)]
+    [InlineData(ButtonResult.None, false)]
+    public void CloseConfirmationOnlyAcceptsYes(ButtonResult result, bool expected)
+        => Assert.Equal(expected, MainViewModel.ShouldShutdown(result));
+
     [Fact]
     public void OlderAsyncResourceCannotReplaceNewerOne()
     {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
@@ -1,0 +1,43 @@
+using LittleBigMouse.Ui.Avalonia.MonitorFrame;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+public sealed class UiLifecycleTests
+{
+    [Fact]
+    public void OlderAsyncResourceCannotReplaceNewerOne()
+    {
+        using var slot = new LatestResourceSlot<TestResource>();
+        var olderGeneration = slot.Begin();
+        var newerGeneration = slot.Begin();
+        var newer = new TestResource();
+        var older = new TestResource();
+
+        Assert.True(slot.TryReplace(newerGeneration, newer));
+        Assert.False(slot.TryReplace(olderGeneration, older));
+        Assert.True(older.Disposed);
+        Assert.False(newer.Disposed);
+    }
+
+    [Fact]
+    public void ReplacingAndDisposingResourceReleasesEveryOwnedInstance()
+    {
+        var slot = new LatestResourceSlot<TestResource>();
+        var first = new TestResource();
+        var second = new TestResource();
+        Assert.True(slot.TryReplace(slot.Begin(), first));
+        Assert.True(slot.TryReplace(slot.Begin(), second));
+
+        Assert.True(first.Disposed);
+        Assert.False(second.Disposed);
+        slot.Dispose();
+        Assert.True(second.Disposed);
+    }
+
+    sealed class TestResource : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
@@ -56,7 +57,7 @@ public class MainViewModel : ViewModel, IMainViewModel, IMainPluginsViewModel
         LocalizationService = localizationService;
         Options = options;
         
-        CloseCommand = ReactiveCommand.Create(Close);
+        CloseCommand = ReactiveCommand.CreateFromTask(CloseAsync);
 
         _commandsCache.Connect()
             .Sort(SortExpressionComparer<IUiCommand>.Ascending(t => t.Id))
@@ -129,7 +130,7 @@ public class MainViewModel : ViewModel, IMainViewModel, IMainPluginsViewModel
 
     public ICommand MaximizeCommand { get; }
 
-    void Close()
+    async Task CloseAsync()
     {
         //if (Layout?.Saved ?? true)
         //{
@@ -137,28 +138,19 @@ public class MainViewModel : ViewModel, IMainViewModel, IMainPluginsViewModel
         //    return;
         //}
 
-        var result = MessageBoxManager
+        var result = await MessageBoxManager
             .GetMessageBoxStandard(
-                "Save your changes before exiting ?",
-                "Confirmation", ButtonEnum.OkCancel,
+                "Exit LittleBigMouse?",
+                "LittleBigMouse will stop controlling mouse transitions until it is started again.",
+                ButtonEnum.YesNo,
                 Icon.Question, WindowStartupLocation.CenterOwner
-
                 )
-            //Todo get rid of Result
-            .ShowAsync().Result;
+            .ShowAsync();
 
-        if (result == ButtonResult.Yes)
-        {
-            /* Todo avalonia*/
-            //Layout.Save();
-            Shutdown();
-        }
-
-        if (result == ButtonResult.No)
-        {
-            Shutdown();
-        }
+        if (ShouldShutdown(result)) Shutdown();
     }
+
+    public static bool ShouldShutdown(ButtonResult result) => result == ButtonResult.Yes;
 
     public void Shutdown()
     {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/LatestResourceSlot.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/LatestResourceSlot.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System;
+using System.Threading;
+
+namespace LittleBigMouse.Ui.Avalonia.MonitorFrame;
+
+/// <summary>
+/// Owns the result of the latest asynchronous operation. Results from older
+/// generations are rejected and disposed instead of replacing newer state.
+/// </summary>
+public sealed class LatestResourceSlot<T> : IDisposable where T : class
+{
+    readonly object _lock = new();
+    long _generation;
+    bool _disposed;
+    T? _current;
+
+    public long Begin() => Interlocked.Increment(ref _generation);
+
+    public bool TryReplace(long generation, T? resource)
+    {
+        T? previous = null;
+        var accepted = false;
+        lock (_lock)
+        {
+            if (!_disposed && generation == Volatile.Read(ref _generation))
+            {
+                previous = _current;
+                _current = resource;
+                accepted = true;
+                if (ReferenceEquals(previous, resource)) previous = null;
+            }
+            else if (ReferenceEquals(_current, resource))
+            {
+                resource = null;
+            }
+        }
+
+        DisposeResource(accepted ? previous : resource);
+        return accepted;
+    }
+
+    public void Dispose()
+    {
+        T? current;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            Interlocked.Increment(ref _generation);
+            current = _current;
+            _current = null;
+        }
+        DisposeResource(current);
+    }
+
+    static void DisposeResource(T? resource) => (resource as IDisposable)?.Dispose();
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModel.cs
@@ -13,12 +13,15 @@ using ReactiveUI;
 using System;
 using System.Diagnostics;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LittleBigMouse.Ui.Avalonia.MonitorFrame;
 
 public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextProvider, IMonitorFrameViewModel
 {
+   readonly LatestResourceSlot<IImage> _wallpapers = new();
+
    public MonitorFrameViewModel()
    {
       _rotated = this.WhenAnyValue(
@@ -95,13 +98,15 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
           (ratio, mmu, _) => mmu.ScaleWithLocation(ratio)
       ).Log(this, "_unrotated").ToProperty(this, e => e.Unrotated);
 
-      var cmd = ReactiveCommand.CreateFromTask<(string, WallpaperStyle, ColorRGB<double>)>(p => SetWallpaper(p.Item1, p.Item2, p.Item3));
-
       this.WhenAnyValue(
           e => e.Model.ActiveSource.Source.WallpaperPath,
           e => e.Model.ActiveSource.Source.WallpaperStyle,
           e => e.Model.ActiveSource.Source.BackgroundColor)
-          .InvokeCommand(cmd).DisposeWith(this);
+          .Subscribe(p =>
+          {
+             var generation = _wallpapers.Begin();
+             _ = SetWallpaperSafely(p.Item1, p.Item2, p.Item3, generation);
+          }).DisposeWith(this);
 
       this
           .WhenAnyValue(e => e.Model)
@@ -122,10 +127,8 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
 
       Disposer.OnDispose(() =>
       {
-         if (Wallpaper is IDisposable bmp)
-         {
-            bmp.Dispose();
-         }
+         _wallpapers.Dispose();
+         Wallpaper = null;
       });
    }
 
@@ -147,7 +150,8 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
       return new(r.X / shrink, r.Y / shrink, r.Width / shrink, r.Height / shrink);
    }
 
-   async Task SetWallpaper(string path, WallpaperStyle style, ColorRGB<double> color)
+   async Task SetWallpaper(
+      string path, WallpaperStyle style, ColorRGB<double> color, long generation)
    {
       Debug.Assert(Model?.ActiveSource?.Source != null);
 
@@ -155,7 +159,7 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
       // (its pixel bounds may also be stale/non-zero, which would produce a bogus crop).
       if (string.IsNullOrWhiteSpace(path) || !Model.ActiveSource.Source.AttachedToDesktop)
       {
-         ApplyWallpaper(null);
+         ApplyWallpaper(null, generation);
          return;
       }
 
@@ -167,7 +171,7 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
 
       if (r.Width < shrink || r.Height < shrink)
       {
-         ApplyWallpaper(null);
+         ApplyWallpaper(null, generation);
          return;
       }
 
@@ -190,24 +194,42 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
          _ => throw new ArgumentOutOfRangeException()
       };
 
-      ApplyWallpaper(bitmap);
+      ApplyWallpaper(bitmap, generation);
 
 #if DEBUG
       WallpaperRendererHelper.ImageSharpDebugStats();
 #endif
    }
 
+   async Task SetWallpaperSafely(
+      string path, WallpaperStyle style, ColorRGB<double> color, long generation)
+   {
+      try
+      {
+         await SetWallpaper(path, style, color, generation);
+      }
+      catch (Exception error)
+      {
+         Debug.WriteLine($"Wallpaper rendering failed: {error}");
+         ApplyWallpaper(null, generation);
+      }
+   }
+
    // The wallpaper renderers await ImageSharp I/O + Task.Run without capturing the UI context, so
    // the continuation here can resume off the UI thread. Assigning the UI-bound Wallpaper property
    // off-thread does not refresh the Image, so marshal the assignment back to the UI thread.
-   void ApplyWallpaper(IImage? bitmap)
+   void ApplyWallpaper(IImage? bitmap, long generation)
    {
-      if (global::Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
-         Wallpaper = bitmap;
-      else
-         global::Avalonia.Threading.Dispatcher.UIThread.Post(() => Wallpaper = bitmap);
-   }
+      void Apply()
+      {
+         if (_wallpapers.TryReplace(generation, bitmap)) Wallpaper = bitmap;
+      }
 
+      if (global::Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+         Apply();
+      else
+         global::Avalonia.Threading.Dispatcher.UIThread.Post(Apply);
+   }
 
    public IMonitorsLayoutPresenterViewModel? MonitorsPresenter { get;
       set => this.RaiseAndSetIfChanged(ref field, value);
@@ -238,7 +260,7 @@ public class MonitorFrameViewModel : ViewModel<PhysicalMonitor>, IMvvmContextPro
    readonly ObservableAsPropertyHelper<bool> _selected;
 
    public IImage? Wallpaper { get;
-      set => this.RaiseAndSetIfChanged(ref field, value);
+      private set => this.RaiseAndSetIfChanged(ref field, value);
    }
 
    public IFrameLocation Location { get;

--- a/LittleBigMouse.sln
+++ b/LittleBigMouse.sln
@@ -149,6 +149,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LittleBigMouse.Plugin.Vcp.Avalonia.Tests", "LittleBigMouse.Plugins\LittleBigMouse.Plugin.Vcp.Avalonia.Tests\LittleBigMouse.Plugin.Vcp.Avalonia.Tests.csproj", "{A9E377DB-32EF-4BF7-A96E-851C377A21EA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LittleBigMouse.Ui.Avalonia.Tests", "LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia.Tests\LittleBigMouse.Ui.Avalonia.Tests.csproj", "{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -710,6 +712,18 @@ Global
 		{A9E377DB-32EF-4BF7-A96E-851C377A21EA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A9E377DB-32EF-4BF7-A96E-851C377A21EA}.Release|x86.ActiveCfg = Release|Any CPU
 		{A9E377DB-32EF-4BF7-A96E-851C377A21EA}.Release|x86.Build.0 = Release|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|x64.ActiveCfg = Debug|x64
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|x64.Build.0 = Debug|x64
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|x64.ActiveCfg = Release|x64
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|x64.Build.0 = Release|x64
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -774,6 +788,7 @@ Global
 		{D1880E7E-C3C7-4065-90BF-B568E6DBFFF9} = {60F661FB-CF7A-A585-BA9C-7DA885772308}
 		{3F3568D1-1F1F-4382-9304-72973583891C} = {67C1648C-60F9-983A-F0CE-4DED081F4360}
 		{A9E377DB-32EF-4BF7-A96E-851C377A21EA} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{CE26BEB7-FCB0-455D-9242-A5F23F83E0C4} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2294431E-9ED9-4BB8-AEDA-305882A2919F}


### PR DESCRIPTION
Second extraction from #513: four independent fixes dug out of commits 8d2f7cc/6d5ccd8/7bd2ffe, without the mechanisms they were entangled with (injected-event resync, elevation rework, IPC transport — all reviewed separately).

## Rust hook

- **Strict `WM_MOUSEMOVE` filter**: the C++-inherited `(wParam & WM_MOUSEMOVE) != 0` matches every mouse message (they all carry bit 0x200 — `WM_LBUTTONDOWN` = 0x201, `WM_MOUSEWHEEL` = 0x20A…), so clicks and wheel events entered the engine as moves and a click landing on a border mid-crossing could be swallowed by the `LRESULT(1)` return. Exact match only, with a unit test. Taken **without** the `e.injected` flag from the PR's resync mechanism.
- **`exe_path_from_pid` hardened**: `PROCESS_QUERY_INFORMATION | PROCESS_VM_READ` is denied on elevated or anticheat-protected processes — exactly the games the exclusion list targets, which therefore could not be resolved. `PROCESS_QUERY_LIMITED_INFORMATION` is enough for `QueryFullProcessImageNameW`; a growing-buffer loop covers paths beyond MAX_PATH. Taken **without** the PR's `path_contains`/`foreground_process_path` (they conflict with the #515 exclusion matcher on master).
- **Examples gated `cfg(linux)`** so `cargo build --examples` works on Windows.

## UI Avalonia

- **Close button actually closes**: the confirmation dialog showed OkCancel buttons but tested `ButtonResult.Yes`/`No`, which OkCancel can never return — Close silently did nothing. It also blocked the UI thread on `ShowAsync().Result`. Now an async Yes/No dialog; the old "Save your changes" wording promised a save that has been commented out for years.
- **Wallpaper rendering races**: `InvokeCommand` drops values emitted while an execution is in flight, so during a display-change burst (resume, topology change) the final wallpaper could be lost, and a bitmap replaced by an older in-flight render was never disposed. `LatestResourceSlot` rejects and disposes stale generations instead.

New `LittleBigMouse.Ui.Avalonia.Tests` project (in the .sln, builds and runs on Linux), trimmed to the five tests covering these fixes — the PR's other tests depend on commits not taken.

## Tested

- Rust: `cargo test` 42/42, `cargo clippy` no new warnings (17 pre-existing on master), fmt-clean on touched files
- .NET: new UI test project 5/5 on Linux, full UI build clean
- The two hook fixes are `#[cfg(windows)]`: compile + runtime validation on Windows still needed (CI / manual)

## Windows test checklist

- Click and scroll on a monitor border while crossing: clicks must land, wheel must scroll, crossing feel unchanged
- Exclusion list with an elevated/anticheat game: the game path must now resolve (exclusion actually applies)
- Close button from the title bar: dialog appears, Yes exits, No/Escape stays
- Wallpaper thumbnails after suspend/resume or rapid display changes: latest wallpaper always shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)