### PR TITLE
CI: compile the installer on every build, not just on tags

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,7 +1,8 @@
 # Build LittleBigMouse: managed UI (net10 / Avalonia) + native hook daemon (x64,
 # Rust by default, C++ as opt-out).
-# - Push / PR on master: build everything, upload a portable artifact.
-# - Tag v*: additionally compile the InnoSetup installer and attach it to a
+# - Push / PR on master: build everything (installer included, as a smoke test),
+#   upload a portable artifact.
+# - Tag v*: additionally publish the installer as an artifact and attach it to a
 #   draft GitHub release for manual review before publishing.
 
 name: Build
@@ -93,10 +94,21 @@ jobs:
           !${{ env.UI_OUTPUT }}\runtimes\linux*\**
           !${{ env.UI_OUTPUT }}\runtimes\osx*\**
 
+    # Compiled on every build, not only on tags: the installer script breaks in ways
+    # the app build can't catch (ISCC aborts on a wildcard matching nothing, so
+    # dropping the last file of a kind from the output is enough), and a release tag
+    # is far too late to find out. Costs a few seconds. Only the two publishing
+    # steps below stay tag-only.
     - name: Compile installer (InnoSetup)
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" "/DAppVer=${{ steps.ver.outputs.version }}" "/DHookImpl=${{ env.HOOK_IMPL }}" LittleBigMouse.Setup\LittleBigMouse.iss
+        # Off a release tag there is no version to inject. Leave AppVer undefined
+        # instead of passing an empty one (ISCC rejects an empty AppVersion) and let
+        # the .iss fall back to the built exe's FileVersion.
+        $defines = @("/DHookImpl=${{ env.HOOK_IMPL }}")
+        if ("${{ steps.ver.outputs.version }}") { $defines += "/DAppVer=${{ steps.ver.outputs.version }}" }
+        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" @defines LittleBigMouse.Setup\LittleBigMouse.iss
+        # Also fails the step if ISCC somehow reported success without producing it.
+        Get-ChildItem LittleBigMouse.Setup\LittleBigMouse_*.exe | Select-Object Name, Length
 
     - name: Upload installer artifact
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
The InnoSetup step was gated on `startsWith(github.ref, 'refs/tags/v')`, so a
packaging regression stayed invisible on master and only surfaced when a release
tag was pushed.

That happened on 2026-07-29: 3c20d42 removed `colors.xml` from the build output
(the Layout and Vcp plugins copied it twice, failing `dotnet publish` with
NETSDK1152). It was the output's only `*.xml`, and `LittleBigMouse.iss` picked it
up with a `*.xml` glob — ISCC aborts when a wildcard matches nothing. The v5.5.2
CI failed while master was green, and the tag had to be moved after 1f7ff52.

ISCC now runs on every push and pull request. The steps that publish — *Upload
installer artifact* and *Create draft release* — stay tag-only, so nothing new is
uploaded or released.

### `/DAppVer` off a tag

`steps.ver.outputs.version` is empty outside a release build. Passing `/DAppVer=`
would still *define* `AppVer` (as an empty string), short-circuiting the
`#ifndef AppVer` fallback in `LittleBigMouse.iss` and leaving `AppVersion=` empty,
which Inno rejects. The flag is therefore omitted entirely and the existing
fallback applies: `GetVersionNumbersString` on the built exe. This also gets the
manual-local-compile path covered by CI for the first time.

The trailing `Get-ChildItem` doubles as an assertion (Actions' pwsh wrapper sets
`$ErrorActionPreference = 'stop'`) and as the only visible proof off a tag, since
the installer is not uploaded there.

### Verified

Dispatched on this branch — [run 30466822016](https://github.com/mgth/LittleBigMouse/actions/runs/30466822016), success:

```
Successful compile (16.484 sec). Resulting Setup program filename is:
D:\a\LittleBigMouse\LittleBigMouse\LittleBigMouse.Setup\LittleBigMouse_5.5.2.0.exe

Name                          Length
----                          ------
LittleBigMouse_5.5.2.0.exe  26673329
```

`Compile installer` succeeded; `Upload installer artifact` and `Create draft
release` were skipped. The `5.5.2.0` confirms the FileVersion fallback.

**Cost:** ISCC takes ~16s (solid LZMA2 over 26 MB). Total job 3 min, against
3 / 3 / 6 min for the last three master builds — within the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)