### PR TITLE
Panic shortcut: free a trapped cursor from the keyboard

### DIFF
--- a/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
@@ -86,6 +86,56 @@ pub fn receive_message(
     became_listening
 }
 
+/// The panic shortcut fired. Runs on the listener's own thread.
+///
+/// One thing, always: free the cursor and take the engine down. That is the whole of
+/// what can be decided without knowing anything — and knowing nothing is the point,
+/// because this runs when the UI may be unreachable behind the very cursor it is
+/// freeing, or not running at all.
+///
+/// What it should *mean* is the UI's to decide, and the UI is where the knowledge
+/// is. Previewing a layout? Then there is an experiment to throw away: it reloads
+/// the saved one and starts again. Not previewing? Then the layout that trapped the
+/// user is the one they committed to, and staying stopped is the answer — so the
+/// ordinary case needs no second press.
+///
+/// `Rescued` is broadcast before the unhook is requested, so a listening UI always
+/// sees it ahead of the `Stopped` the unhook produces. The other order would have
+/// the UI drop live preview on the stop and then find nothing left to act on.
+pub fn rescue_fired(shared: &'static Shared) {
+    eprintln!("[LittleBigMouse.Hook] rescue: freeing the cursor and stopping");
+    crate::platform::cursor::release_clip();
+    shared.broadcast(protocol::RESCUED);
+    hook::request_unhook(shared);
+    shared.paused.store(false, Ordering::SeqCst);
+}
+
+/// Adopt the panic shortcut a freshly loaded layout names, and tell the listener.
+/// It travels with the layout like every other daemon-side setting, so it arrives
+/// with the startup `LoadFromFile` too.
+fn adopt_rescue_shortcut(shared: &Shared, wanted: &str) {
+    let wanted = if wanted.trim().is_empty() {
+        crate::shortcut::DEFAULT
+    } else {
+        wanted
+    };
+    let changed = {
+        let mut current = shared
+            .rescue_shortcut
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if *current == wanted {
+            false
+        } else {
+            *current = wanted.to_string();
+            true
+        }
+    };
+    if changed {
+        hook::rescue_shortcut_changed(shared);
+    }
+}
+
 /// Sweep the last loaded layout with the edge prober and broadcast the report.
 /// Runs on a re-parsed private layout, so the live engine and its lock are
 /// never touched (the hook thread cannot be stalled by a probe).
@@ -151,6 +201,8 @@ fn load_layout(shared: &Shared, xml: &str, keep_hooked: bool) -> Option<LoadInfo
         // Recover from a poisoned lock (a prior panic under the lock): a fresh Load fully replaces
         // the layout and resets tracking, so it is exactly the right place to shrug off the poison —
         // this is what lets a Stop/Start (Load) heal crossing instead of staying broken.
+        // Before the move: the layout is about to be handed to the engine.
+        adopt_rescue_shortcut(shared, &layout.rescue_shortcut);
         shared
             .engine
             .lock()
@@ -420,6 +472,37 @@ mod tests {
 
         assert_eq!(shared.unhook_requests.load(Ordering::SeqCst), 1);
         assert!(!shared.want_hook.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn a_layout_carries_the_rescue_shortcut() {
+        // It travels with the layout like every other daemon-side setting, which is
+        // what gets it to a standalone daemon replaying Current.xml at boot.
+        let shared = Shared::new();
+        let line = LOAD_LINE.replace(
+            r#"<ZonesLayout Algorithm="Strait""#,
+            r#"<ZonesLayout RescueShortcut="Ctrl+Alt+F9" Algorithm="Strait""#,
+        );
+        replay(&shared, &format!("{line}\n"));
+
+        assert_eq!(
+            *shared.rescue_shortcut.lock().unwrap(),
+            "Ctrl+Alt+F9",
+            "the daemon must adopt what the layout names"
+        );
+    }
+
+    #[test]
+    fn a_layout_naming_no_shortcut_keeps_the_default() {
+        // Layouts written by an older UI have no such attribute; the rescue must
+        // still exist for them.
+        let shared = Shared::new();
+        replay(&shared, &format!("{LOAD_LINE}\n"));
+
+        assert_eq!(
+            *shared.rescue_shortcut.lock().unwrap(),
+            crate::shortcut::DEFAULT
+        );
     }
 
     #[test]

--- a/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
@@ -72,6 +72,12 @@ pub fn receive_message(
                 }
             }
             Command::Probe => probe_loaded(shared, server),
+            // Always reconciles, even when the text is unchanged: the answer is what
+            // the user is waiting for, and a re-registration is cheap.
+            Command::Shortcut(text) => {
+                adopt_rescue_shortcut(shared, &text);
+                hook::rescue_shortcut_changed(shared);
+            }
             Command::LoadFromFile(path) => {
                 load_from_file(shared, &path);
             }

--- a/LittleBigMouse-Hook-Rust/src/hook/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/mod.rs
@@ -20,12 +20,40 @@ use crate::shared::Shared;
 #[cfg(windows)]
 pub mod windows;
 #[cfg(windows)]
-pub use windows::{register_main_thread, request_hook, request_quit, request_unhook, run, spawn_watchdog};
+pub use windows::{
+    register_main_thread, request_hook, request_quit, request_unhook, run, spawn_watchdog,
+};
 
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::{register_main_thread, request_hook, request_quit, request_unhook, run, spawn_watchdog};
+
+/// Start the panic-shortcut listener: a global hotkey that frees a cursor trapped
+/// where no click can reach the UI. `on_fire` runs on the listener's own thread.
+///
+/// Linux gets nothing yet. There is no global shortcut without a portal, and reading
+/// one from evdev would mean opening the keyboard devices — the keylogging surface
+/// this design exists to avoid. Tracked in mgth/LittleBigMouse#526.
+pub fn spawn_rescue_key(shared: &'static Shared, on_fire: fn(&'static Shared)) {
+    #[cfg(windows)]
+    windows::rescue_key::spawn(shared, on_fire);
+    #[cfg(not(windows))]
+    {
+        let _ = (shared, on_fire);
+    }
+}
+
+/// Tell the listener the desired shortcut changed. Safe to call when it never
+/// started — it is a post to a thread id that is still zero.
+pub fn rescue_shortcut_changed(shared: &Shared) {
+    #[cfg(windows)]
+    windows::post_rescue_reconfigure(shared);
+    #[cfg(not(windows))]
+    {
+        let _ = shared;
+    }
+}
 
 /// Count of deduped mouse-move events the active backend has processed.
 /// Lightweight instrumentation (one relaxed increment) to observe the hook

--- a/LittleBigMouse-Hook-Rust/src/hook/windows/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/windows/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod display;
 pub mod mouse;
+pub mod rescue_key;
 pub mod win_events;
 
 use std::sync::atomic::Ordering;
@@ -310,6 +311,22 @@ pub fn request_quit(shared: &Shared) {
 
 fn break_loop(shared: &Shared) {
     post(shared, WM_BREAK_LOOP);
+}
+
+/// Poke the panic-shortcut listener so it re-reads the shortcut and reconciles its
+/// registration. Posted to its own thread, never to the pump.
+pub fn post_rescue_reconfigure(shared: &Shared) {
+    let tid = shared.rescue_tid.load(Ordering::SeqCst);
+    if tid != 0 {
+        unsafe {
+            let _ = PostThreadMessageW(
+                tid,
+                rescue_key::WM_RESCUE_RECONFIGURE,
+                WPARAM(0),
+                LPARAM(0),
+            );
+        }
+    }
 }
 
 fn post(shared: &Shared, message: u32) {

--- a/LittleBigMouse-Hook-Rust/src/hook/windows/rescue_key.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/windows/rescue_key.rs
@@ -1,0 +1,193 @@
+//! The panic shortcut listener.
+//!
+//! A cursor trapped on a screen it cannot leave puts every recovery the UI offers
+//! behind a click that cannot be made. This gives the keyboard a way in.
+//!
+//! Three deliberate choices:
+//!
+//! * **`RegisterHotKey`, not `WH_KEYBOARD_LL`.** The daemon already hooks the mouse
+//!   globally; a keyboard hook would mean seeing every keystroke on the desktop — a
+//!   keylogging surface that antivirus and anti-cheat notice, and that a mouse
+//!   utility has no business needing. This sees one combination and nothing else,
+//!   and Windows arbitrates collisions instead of leaving them silent.
+//!
+//! * **Its own thread, with its own message loop.** `WM_HOTKEY` is posted to the
+//!   queue of the thread that registered. Registering on the hook pump would make
+//!   the rescue depend on the pump it is rescuing you from — the one thing a rescue
+//!   path must never do.
+//!
+//! * **Held, not tapped.** Three modifiers are already hard to hit by accident, but
+//!   a shortcut that stops the mouse engine should ask to be meant.
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use windows::Win32::Foundation::HWND;
+use windows::Win32::System::Threading::GetCurrentThreadId;
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    GetAsyncKeyState, RegisterHotKey, UnregisterHotKey, HOT_KEY_MODIFIERS,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    DispatchMessageW, GetMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE, WM_APP,
+    WM_HOTKEY,
+};
+
+use crate::shared::Shared;
+use crate::shortcut::{Shortcut, MOD_ALT, MOD_CONTROL, MOD_SHIFT, MOD_WIN};
+
+/// Ask the listener to re-read the shortcut from `Shared` and re-register.
+/// Posted when a freshly loaded layout names a different one.
+pub const WM_RESCUE_RECONFIGURE: u32 = WM_APP + 2;
+
+/// Our hotkey id. Only meaningful within this thread.
+const HOTKEY_ID: i32 = 1;
+
+/// How long the combination must stay down. Long enough not to fire on a fumble,
+/// short enough that the two presses of a full escalation stay under three seconds.
+const HOLD: Duration = Duration::from_millis(900);
+
+/// How often the hold is re-checked. Fine enough that letting go feels immediate.
+const HOLD_POLL: Duration = Duration::from_millis(25);
+
+const VK_SHIFT: u32 = 0x10;
+const VK_CONTROL: u32 = 0x11;
+const VK_MENU: u32 = 0x12;
+const VK_LWIN: u32 = 0x5B;
+const VK_RWIN: u32 = 0x5C;
+
+/// Start the listener. `on_fire` runs on this thread, so it must not block on
+/// anything the hook pump owns.
+pub fn spawn(shared: &'static Shared, on_fire: fn(&'static Shared)) {
+    std::thread::spawn(move || {
+        shared
+            .rescue_tid
+            .store(unsafe { GetCurrentThreadId() }, Ordering::SeqCst);
+
+        let mut current = register_wanted(shared, None);
+
+        let mut msg = MSG::default();
+        loop {
+            let ret = unsafe { GetMessageW(&mut msg, None, 0, 0) };
+            match ret.0 {
+                -1 | 0 => break, // error, or WM_QUIT
+                _ => {}
+            }
+
+            match msg.message {
+                WM_HOTKEY => {
+                    if let Some(shortcut) = current {
+                        if held_long_enough(shortcut) {
+                            on_fire(shared);
+                        }
+                        // Auto-repeat queues a WM_HOTKEY per repeat while the
+                        // combination is down. Wait it out and drop them, or letting
+                        // go would fire the next step immediately.
+                        settle(shortcut);
+                    }
+                }
+                WM_RESCUE_RECONFIGURE => current = register_wanted(shared, current),
+                _ => unsafe {
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                },
+            }
+        }
+    });
+}
+
+/// Re-read the desired shortcut and reconcile the registration to it.
+/// Returns what is registered now.
+fn register_wanted(shared: &Shared, current: Option<Shortcut>) -> Option<Shortcut> {
+    let text = shared
+        .rescue_shortcut
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone();
+
+    let wanted = Shortcut::parse(&text);
+    if wanted == current {
+        return current;
+    }
+
+    if current.is_some() {
+        unsafe {
+            let _ = UnregisterHotKey(HWND::default(), HOTKEY_ID);
+        }
+    }
+
+    let Some(shortcut) = wanted else {
+        if !text.trim().is_empty() {
+            eprintln!("[LittleBigMouse.Hook] rescue shortcut \"{text}\" is not usable, ignored");
+        }
+        shared.rescue_registered.store(false, Ordering::SeqCst);
+        return None;
+    };
+
+    // A null HWND registers against this thread, which is where the message loop
+    // above is waiting.
+    let ok = unsafe {
+        RegisterHotKey(
+            HWND::default(),
+            HOTKEY_ID,
+            HOT_KEY_MODIFIERS(shortcut.modifiers),
+            shortcut.key,
+        )
+    }
+    .is_ok();
+
+    shared.rescue_registered.store(ok, Ordering::SeqCst);
+    if ok {
+        eprintln!("[LittleBigMouse.Hook] rescue shortcut registered: {text}");
+        Some(shortcut)
+    } else {
+        // Almost always another application owning the combination. Worth saying
+        // out loud: a rescue that silently does not exist is worse than none.
+        eprintln!("[LittleBigMouse.Hook] rescue shortcut \"{text}\" is already taken, NOT registered");
+        None
+    }
+}
+
+/// Was the whole combination held down for [`HOLD`]?
+fn held_long_enough(shortcut: Shortcut) -> bool {
+    let deadline = Instant::now() + HOLD;
+    while Instant::now() < deadline {
+        if !all_down(shortcut) {
+            return false;
+        }
+        std::thread::sleep(HOLD_POLL);
+    }
+    all_down(shortcut)
+}
+
+/// Wait for the combination to be let go, then drop the auto-repeat backlog.
+fn settle(shortcut: Shortcut) {
+    while all_down(shortcut) {
+        std::thread::sleep(HOLD_POLL);
+    }
+    let mut msg = MSG::default();
+    while unsafe { PeekMessageW(&mut msg, None, WM_HOTKEY, WM_HOTKEY, PM_REMOVE) }.as_bool() {}
+}
+
+fn all_down(shortcut: Shortcut) -> bool {
+    if !key_down(shortcut.key) {
+        return false;
+    }
+    let m = shortcut.modifiers;
+    if m & MOD_CONTROL != 0 && !key_down(VK_CONTROL) {
+        return false;
+    }
+    if m & MOD_ALT != 0 && !key_down(VK_MENU) {
+        return false;
+    }
+    if m & MOD_SHIFT != 0 && !key_down(VK_SHIFT) {
+        return false;
+    }
+    if m & MOD_WIN != 0 && !(key_down(VK_LWIN) || key_down(VK_RWIN)) {
+        return false;
+    }
+    true
+}
+
+fn key_down(vk: u32) -> bool {
+    unsafe { GetAsyncKeyState(vk as i32) as u16 & 0x8000 != 0 }
+}

--- a/LittleBigMouse-Hook-Rust/src/hook/windows/rescue_key.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/windows/rescue_key.rs
@@ -118,6 +118,7 @@ fn register_wanted(shared: &Shared, current: Option<Shortcut>) -> Option<Shortcu
     let Some(shortcut) = wanted else {
         if !text.trim().is_empty() {
             eprintln!("[LittleBigMouse.Hook] rescue shortcut \"{text}\" is not usable, ignored");
+            shared.broadcast(&crate::ipc::protocol::shortcut_unavailable(&text));
         }
         shared.rescue_registered.store(false, Ordering::SeqCst);
         return None;
@@ -143,6 +144,7 @@ fn register_wanted(shared: &Shared, current: Option<Shortcut>) -> Option<Shortcu
         // Almost always another application owning the combination. Worth saying
         // out loud: a rescue that silently does not exist is worse than none.
         eprintln!("[LittleBigMouse.Hook] rescue shortcut \"{text}\" is already taken, NOT registered");
+        shared.broadcast(&crate::ipc::protocol::shortcut_unavailable(&text));
         None
     }
 }

--- a/LittleBigMouse-Hook-Rust/src/ipc/protocol.rs
+++ b/LittleBigMouse-Hook-Rust/src/ipc/protocol.rs
@@ -102,6 +102,13 @@ pub const DESKTOP_CHANGED: &str = "<DaemonMessage><Event>DesktopChanged</Event><
 pub const SUSPENDED: &str = "<DaemonMessage><Event>Suspended</Event></DaemonMessage>\n";
 pub const RESUMED: &str = "<DaemonMessage><Event>Resumed</Event></DaemonMessage>\n";
 
+/// The panic shortcut ran: the cursor is free and the engine is coming down. Carries
+/// no payload on purpose — the daemon does not know what the rescue should mean, only
+/// that it happened, and knowing nothing is what lets it work with no UI reachable.
+/// Distinct from `Stopped`, which says the same thing without saying why, and why is
+/// the whole of what the UI acts on.
+pub const RESCUED: &str = "<DaemonMessage><Event>Rescued</Event></DaemonMessage>\n";
+
 pub const LOAD_FAILED: &str =
     "<DaemonMessage><Event>LoadFailed</Event><Payload>the layout could not be parsed</Payload></DaemonMessage>\n";
 

--- a/LittleBigMouse-Hook-Rust/src/ipc/protocol.rs
+++ b/LittleBigMouse-Hook-Rust/src/ipc/protocol.rs
@@ -21,6 +21,10 @@ pub enum Command {
     /// Sweep the loaded layout's edges with the engine and broadcast a
     /// `Probed` event carrying the report.
     Probe,
+    /// Adopt this panic shortcut now, without waiting for a layout to carry it.
+    /// Recording one in the options has to take effect there and then — and has to
+    /// say so when the combination is already owned by something else.
+    Shortcut(String),
     Quit,
     Unknown(String),
 }
@@ -63,6 +67,7 @@ fn command_from(node: Node) -> Option<Command> {
         "Stop" => Command::Stop,
         "State" => Command::State,
         "Probe" => Command::Probe,
+        "Shortcut" => Command::Shortcut(payload_string(node)),
         "Quit" => Command::Quit,
         other => Command::Unknown(other.to_string()),
     })
@@ -108,6 +113,17 @@ pub const RESUMED: &str = "<DaemonMessage><Event>Resumed</Event></DaemonMessage>
 /// Distinct from `Stopped`, which says the same thing without saying why, and why is
 /// the whole of what the UI acts on.
 pub const RESCUED: &str = "<DaemonMessage><Event>Rescued</Event></DaemonMessage>\n";
+
+/// The panic shortcut could not be registered — almost always another application
+/// already owning the combination. Said out loud rather than logged: a rescue that
+/// silently does not exist is worse than none, because the user only finds out at the
+/// moment they need it.
+pub fn shortcut_unavailable(shortcut: &str) -> String {
+    format!(
+        "<DaemonMessage><Event>ShortcutUnavailable</Event><Payload>{}</Payload></DaemonMessage>\n",
+        escape_xml(shortcut)
+    )
+}
 
 pub const LOAD_FAILED: &str =
     "<DaemonMessage><Event>LoadFailed</Event><Payload>the layout could not be parsed</Payload></DaemonMessage>\n";

--- a/LittleBigMouse-Hook-Rust/src/lib.rs
+++ b/LittleBigMouse-Hook-Rust/src/lib.rs
@@ -16,4 +16,5 @@ pub mod ipc;
 pub mod platform;
 pub mod priority;
 pub mod shared;
+pub mod shortcut;
 pub mod zones;

--- a/LittleBigMouse-Hook-Rust/src/main.rs
+++ b/LittleBigMouse-Hook-Rust/src/main.rs
@@ -65,6 +65,11 @@ fn main() {
         });
     }
 
+    // The way out when the cursor is trapped where no click can reach the UI. Its
+    // own thread by design — see hook::windows::rescue_key. Started before the pump
+    // so it is already listening if the very first layout confines the cursor.
+    hook::spawn_rescue_key(shared, daemon::rescue_fired);
+
     // Heal silent OS removal of the low-level mouse hook (Windows only; no-op elsewhere).
     hook::spawn_watchdog(shared);
 

--- a/LittleBigMouse-Hook-Rust/src/shared.rs
+++ b/LittleBigMouse-Hook-Rust/src/shared.rs
@@ -31,6 +31,17 @@ pub struct Shared {
     /// Thread id of the message pump, for `PostThreadMessageW`
     /// (C++ `Hooker::_currentThreadId`). Zero until the pump starts.
     pub pump_tid: AtomicU32,
+    /// Thread id of the panic-shortcut listener, for `PostThreadMessageW`. Zero
+    /// until it starts. Deliberately not the pump's: the rescue must not depend on
+    /// the thread it exists to rescue you from.
+    pub rescue_tid: AtomicU32,
+    /// Whether the panic shortcut is currently registered with the OS. False when
+    /// another application already owns the combination — the UI says so rather
+    /// than leaving the user with a rescue that does not exist.
+    pub rescue_registered: AtomicBool,
+    /// The panic shortcut as the layout spells it (`Ctrl+Alt+Shift+M`). Read by the
+    /// listener whenever it is asked to reconcile.
+    pub rescue_shortcut: Mutex<String>,
     /// How many times a `Load` has asked for the hook to come down. Taking it down
     /// tears the mouse, focus, desktop and display hooks apart and destroys the
     /// display window, so a `Load` that is immediately followed by a `Run` skips it —
@@ -65,6 +76,9 @@ impl Shared {
             suspended: AtomicBool::new(false),
             want_quit: AtomicBool::new(false),
             pump_tid: AtomicU32::new(0),
+            rescue_tid: AtomicU32::new(0),
+            rescue_registered: AtomicBool::new(false),
+            rescue_shortcut: Mutex::new(crate::shortcut::DEFAULT.to_string()),
             unhook_requests: AtomicU32::new(0),
             // C++ Hooker defaults, until a layout overrides them.
             priority: AtomicU8::new(Priority::Normal.as_u8()),

--- a/LittleBigMouse-Hook-Rust/src/shortcut.rs
+++ b/LittleBigMouse-Hook-Rust/src/shortcut.rs
@@ -1,0 +1,151 @@
+//! The panic shortcut, as it travels on the wire.
+//!
+//! A global shortcut is written the way a user reads it — `Ctrl+Alt+Shift+M` — and
+//! parsed here into the modifier bits and virtual-key code `RegisterHotKey` wants.
+//! Keeping the grammar in one place means the UI's recorder and the daemon's
+//! registrar cannot drift apart: whatever the UI writes, this is what decides.
+
+/// Modifier bits. Same values as the Win32 `MOD_*` constants, so the Windows
+/// registrar passes them straight through; duplicating the mapping there would only
+/// create somewhere for the two to disagree.
+pub const MOD_ALT: u32 = 0x0001;
+pub const MOD_CONTROL: u32 = 0x0002;
+pub const MOD_SHIFT: u32 = 0x0004;
+pub const MOD_WIN: u32 = 0x0008;
+
+/// What the daemon registers when the layout names no shortcut of its own. Three
+/// modifiers: unreachable by accident, and unlikely to be owned by anything else.
+pub const DEFAULT: &str = "Ctrl+Alt+Shift+M";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Shortcut {
+    pub modifiers: u32,
+    /// Win32 virtual-key code.
+    pub key: u32,
+}
+
+impl Shortcut {
+    /// Parse `Ctrl+Alt+Shift+M`. Case-insensitive, spaces ignored.
+    ///
+    /// Returns `None` for anything that would be unsafe or useless to register: no
+    /// key, an unknown key name, or no modifier at all. A bare key registered
+    /// globally would swallow that key for every application on the desktop, which
+    /// is not a thing a mouse utility gets to do by accident.
+    pub fn parse(text: &str) -> Option<Shortcut> {
+        let mut modifiers = 0;
+        let mut key = None;
+
+        for part in text.split('+') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            match part.to_ascii_lowercase().as_str() {
+                "ctrl" | "control" => modifiers |= MOD_CONTROL,
+                "alt" => modifiers |= MOD_ALT,
+                "shift" | "maj" => modifiers |= MOD_SHIFT,
+                "win" | "super" | "meta" | "cmd" => modifiers |= MOD_WIN,
+                // A second key name is a malformed shortcut, not a replacement.
+                _ if key.is_some() => return None,
+                _ => key = Some(virtual_key(part)?),
+            }
+        }
+
+        match (modifiers, key) {
+            (0, _) => None,
+            (_, Some(key)) => Some(Shortcut { modifiers, key }),
+            (_, None) => None,
+        }
+    }
+}
+
+/// Name to Win32 virtual-key code, over the set a shortcut may sensibly use.
+/// Deliberately closed: an open mapping would let the UI record a key the daemon
+/// cannot register, and the failure would surface far from its cause.
+fn virtual_key(name: &str) -> Option<u32> {
+    let lower = name.to_ascii_lowercase();
+
+    if lower.len() == 1 {
+        let c = lower.as_bytes()[0];
+        return match c {
+            b'a'..=b'z' => Some(0x41 + (c - b'a') as u32),
+            b'0'..=b'9' => Some(0x30 + (c - b'0') as u32),
+            _ => None,
+        };
+    }
+
+    if let Some(digits) = lower.strip_prefix('f') {
+        if let Ok(n) = digits.parse::<u32>() {
+            if (1..=24).contains(&n) {
+                return Some(0x70 + n - 1);
+            }
+        }
+        // Fall through: "f" prefixes nothing else in this table.
+    }
+
+    Some(match lower.as_str() {
+        "space" => 0x20,
+        "escape" | "esc" => 0x1B,
+        "enter" | "return" => 0x0D,
+        "tab" => 0x09,
+        "backspace" | "back" => 0x08,
+        "insert" | "ins" => 0x2D,
+        "delete" | "del" => 0x2E,
+        "home" => 0x24,
+        "end" => 0x23,
+        "pageup" | "prior" => 0x21,
+        "pagedown" | "next" => 0x22,
+        "left" => 0x25,
+        "up" => 0x26,
+        "right" => 0x27,
+        "down" => 0x28,
+        "pause" => 0x13,
+        "printscreen" | "print" => 0x2C,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_default() {
+        let s = Shortcut::parse(DEFAULT).expect("the default must always parse");
+        assert_eq!(s.modifiers, MOD_CONTROL | MOD_ALT | MOD_SHIFT);
+        assert_eq!(s.key, 0x4D); // 'M'
+    }
+
+    #[test]
+    fn is_case_and_space_insensitive() {
+        let spelled_out = Shortcut::parse("control + ALT + maj + m").expect("parse");
+        assert_eq!(spelled_out, Shortcut::parse(DEFAULT).unwrap());
+    }
+
+    #[test]
+    fn reads_the_key_families_it_offers() {
+        assert_eq!(Shortcut::parse("Ctrl+F12").unwrap().key, 0x7B);
+        assert_eq!(Shortcut::parse("Ctrl+F1").unwrap().key, 0x70);
+        assert_eq!(Shortcut::parse("Ctrl+7").unwrap().key, 0x37);
+        assert_eq!(Shortcut::parse("Win+Space").unwrap().key, 0x20);
+        assert_eq!(Shortcut::parse("Alt+PageDown").unwrap().key, 0x22);
+    }
+
+    #[test]
+    fn refuses_a_shortcut_with_no_modifier() {
+        // Registered globally, this would take the key away from every application
+        // on the desktop.
+        assert!(Shortcut::parse("M").is_none());
+        assert!(Shortcut::parse("F12").is_none());
+    }
+
+    #[test]
+    fn refuses_what_it_cannot_register() {
+        assert!(Shortcut::parse("").is_none());
+        assert!(Shortcut::parse("Ctrl+Alt").is_none(), "modifiers are not a key");
+        assert!(Shortcut::parse("Ctrl+NoSuchKey").is_none());
+        assert!(Shortcut::parse("Ctrl+F0").is_none());
+        assert!(Shortcut::parse("Ctrl+F25").is_none());
+        assert!(Shortcut::parse("Ctrl+A+B").is_none(), "two keys is malformed");
+    }
+}

--- a/LittleBigMouse-Hook-Rust/src/shortcut.rs
+++ b/LittleBigMouse-Hook-Rust/src/shortcut.rs
@@ -83,7 +83,44 @@ fn virtual_key(name: &str) -> Option<u32> {
         // Fall through: "f" prefixes nothing else in this table.
     }
 
+    if let Some(digit) = lower.strip_prefix("numpad") {
+        if let Ok(n) = digit.parse::<u32>() {
+            if n <= 9 {
+                return Some(0x60 + n);
+            }
+        }
+    }
+
+    if let Some(index) = lower.strip_prefix("oem") {
+        // OEM keys are positions, not characters: VK_OEM_3 is ` on a QWERTY board and
+        // ² on an AZERTY one. Registering the position is what makes a shortcut mean
+        // the same physical key whatever the layout says it prints.
+        if let Ok(n) = index.parse::<u32>() {
+            return match n {
+                1 => Some(0xBA),
+                2 => Some(0xBF),
+                3 => Some(0xC0),
+                4 => Some(0xDB),
+                5 => Some(0xDC),
+                6 => Some(0xDD),
+                7 => Some(0xDE),
+                8 => Some(0xDF),
+                102 => Some(0xE2),
+                _ => None,
+            };
+        }
+    }
+
     Some(match lower.as_str() {
+        "oemplus" => 0xBB,
+        "oemcomma" => 0xBC,
+        "oemminus" => 0xBD,
+        "oemperiod" => 0xBE,
+        "numpadmultiply" => 0x6A,
+        "numpadadd" => 0x6B,
+        "numpadsubtract" => 0x6D,
+        "numpaddecimal" => 0x6E,
+        "numpaddivide" => 0x6F,
         "space" => 0x20,
         "escape" | "esc" => 0x1B,
         "enter" | "return" => 0x0D,
@@ -129,6 +166,34 @@ mod tests {
         assert_eq!(Shortcut::parse("Ctrl+7").unwrap().key, 0x37);
         assert_eq!(Shortcut::parse("Win+Space").unwrap().key, 0x20);
         assert_eq!(Shortcut::parse("Alt+PageDown").unwrap().key, 0x22);
+    }
+
+    #[test]
+    fn reads_punctuation_and_the_numeric_keypad() {
+        // The half a French keyboard is made of. OEM keys name a position, not a
+        // character: Oem3 is ` on QWERTY and ² on AZERTY, and both register the same
+        // physical key. Every name here has to match ShortcutBox.KeyName exactly — that
+        // agreement is the contract, and nothing but these tests enforces it.
+        assert_eq!(Shortcut::parse("Ctrl+Oem1").unwrap().key, 0xBA);
+        assert_eq!(Shortcut::parse("Ctrl+Oem3").unwrap().key, 0xC0);
+        assert_eq!(Shortcut::parse("Ctrl+Oem7").unwrap().key, 0xDE);
+        assert_eq!(Shortcut::parse("Ctrl+Oem8").unwrap().key, 0xDF);
+        assert_eq!(Shortcut::parse("Ctrl+Oem102").unwrap().key, 0xE2);
+        assert_eq!(Shortcut::parse("Ctrl+OemPlus").unwrap().key, 0xBB);
+        assert_eq!(Shortcut::parse("Ctrl+OemComma").unwrap().key, 0xBC);
+        assert_eq!(Shortcut::parse("Ctrl+OemMinus").unwrap().key, 0xBD);
+        assert_eq!(Shortcut::parse("Ctrl+OemPeriod").unwrap().key, 0xBE);
+
+        assert_eq!(Shortcut::parse("Ctrl+NumPad0").unwrap().key, 0x60);
+        assert_eq!(Shortcut::parse("Ctrl+NumPad9").unwrap().key, 0x69);
+        assert_eq!(Shortcut::parse("Ctrl+NumPadMultiply").unwrap().key, 0x6A);
+        assert_eq!(Shortcut::parse("Ctrl+NumPadAdd").unwrap().key, 0x6B);
+        assert_eq!(Shortcut::parse("Ctrl+NumPadSubtract").unwrap().key, 0x6D);
+        assert_eq!(Shortcut::parse("Ctrl+NumPadDecimal").unwrap().key, 0x6E);
+        assert_eq!(Shortcut::parse("Ctrl+NumPadDivide").unwrap().key, 0x6F);
+
+        assert!(Shortcut::parse("Ctrl+Oem9").is_none());
+        assert!(Shortcut::parse("Ctrl+NumPad10").is_none());
     }
 
     #[test]

--- a/LittleBigMouse-Hook-Rust/src/zones/layout.rs
+++ b/LittleBigMouse-Hook-Rust/src/zones/layout.rs
@@ -36,6 +36,10 @@ pub struct ZonesLayout {
     pub algorithm: Algorithm,
     pub priority: Priority,
     pub priority_unhooked: Priority,
+    /// The panic shortcut, as the UI spells it (`Ctrl+Alt+Shift+M`). Travels with
+    /// the layout like every other daemon-side setting, so it reaches the daemon on
+    /// the startup replay too. Empty means "whatever the daemon defaults to".
+    pub rescue_shortcut: String,
     pub loop_x: bool,
     pub loop_y: bool,
     /// Zones of a virtual (foreign) layout, shown for inspection on another
@@ -69,6 +73,7 @@ impl Default for ZonesLayout {
             algorithm: Algorithm::Strait,
             priority: Priority::Normal,
             priority_unhooked: Priority::Above,
+            rescue_shortcut: String::new(),
             loop_x: false,
             loop_y: false,
             virtual_layout: false,
@@ -116,6 +121,7 @@ impl ZonesLayout {
         };
         layout.priority = Priority::parse(&get_string(el, "Priority"));
         layout.priority_unhooked = Priority::parse(&get_string(el, "PriorityUnhooked"));
+        layout.rescue_shortcut = get_string(el, "RescueShortcut");
 
         if let Some(main_zones) = child(el, "MainZones") {
             // Track (pixel bounds -> first ZoneId) for clone detection.

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DaemonProtocolTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DaemonProtocolTests.cs
@@ -18,6 +18,27 @@ public class DaemonProtocolTests
     }
 
     [Fact]
+    public void Rescued_IsUnderstood()
+    {
+        // The exact string the daemon sends (protocol::RESCUED). It carries no payload
+        // on purpose: the daemon does not know what the rescue should mean, only that
+        // it happened. Distinct from Stopped, which says the same thing without saying
+        // why — and why is the whole of what the UI acts on.
+        Assert.True(DaemonMessage.TryParse(
+            "<DaemonMessage><Event>Rescued</Event></DaemonMessage>", out var message));
+        Assert.Equal(LittleBigMouseEvent.Rescued, message.Event);
+    }
+
+    [Fact]
+    public void AnEventFromANewerDaemonIsRejectedRatherThanGuessed()
+    {
+        // Forward compatibility runs the other way too: the UI ignores what it does not
+        // know instead of mapping it onto something it does.
+        Assert.False(DaemonMessage.TryParse(
+            "<DaemonMessage><Event>SomethingNewerEntirely</Event></DaemonMessage>", out _));
+    }
+
+    [Fact]
     public void ProbeReport_RoundTripsThroughDaemonMessagePayload()
     {
         // Exact daemon wire shape: the report document is XML-escaped into the payload

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/ZonesLayoutFactory.cs
@@ -58,6 +58,8 @@ public static class ZonesLayoutFactory
         zones.AdjustPointer = layout.Options.AdjustPointer;
         zones.AdjustSpeed = layout.Options.AdjustSpeed;
 
+        zones.RescueShortcut = layout.Options.RescueShortcut;
+
         zones.Algorithm = layout.Options.Algorithm;
         zones.Priority = layout.Options.Priority;
         zones.PriorityUnhooked = layout.Options.PriorityUnhooked;

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -33,6 +33,7 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool AdjustSpeed { get; set; } = false;
       public string Algorithm { get; set; } = "Strait";
       public string BorderValues { get; set; } = "PerModel";
+      public string RescueShortcut { get; set; } = "Ctrl+Alt+Shift+M";
       public string Priority { get; set; } = "Normal";
       public string PriorityUnhooked { get; set; } = "Below";
       public bool IsUnaryRatio { get; set; } = false;
@@ -137,6 +138,14 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// make/model) or "PerMonitor" (each physical monitor keeps its own).
    /// </summary>
    string BorderValues { get; set; }
+
+   /// <summary>
+   /// The shortcut that frees a cursor trapped where no click can reach the UI, written
+   /// the way it reads: "Ctrl+Alt+Shift+M". Held for about a second rather than tapped.
+   /// Travels to the daemon with the layout, which is what registers it — see
+   /// LittleBigMouse-Hook-Rust/src/shortcut.rs for the grammar both sides obey.
+   /// </summary>
+   string RescueShortcut { get; set; }
 
 
    /// <summary>

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/CommandMessage.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/CommandMessage.cs
@@ -15,11 +15,31 @@ public class CommandMessage : IZonesSerializable
         Command = command;
         Payload = payload;
     }
+    /// <summary>
+    /// A command whose payload is plain text rather than a layout. A factory rather
+    /// than an overload: `new(command, null)` is already used for payload-less
+    /// commands, and a second two-argument constructor would make it ambiguous.
+    /// </summary>
+    public static CommandMessage WithText(LittleBigMouseCommand command, string text)
+        => new(command) { Text = text };
+
     public LittleBigMouseCommand Command { get; set; }
     public ZonesLayout? Payload { get; set; }
 
+    /// <summary>
+    /// Text payload, for the commands that carry one. Kept apart from
+    /// <see cref="Payload"/> because they land in the same place on the wire — the
+    /// daemon reads `Payload` either as an attribute or as an element — and a single
+    /// property could not be both a layout and a string.
+    /// </summary>
+    public string? Text { get; set; }
+
     public string Serialize()
     {
+        if (Payload is null && Text is not null)
+            return $@"<CommandMessage Command=""{Command}"" Payload=""{
+                System.Security.SecurityElement.Escape(Text)}""/>";
+
         return ZoneSerializer.Serialize(this,e => e.Command, e => e.Payload);
     }
 }

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/DaemonMessage.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/DaemonMessage.cs
@@ -42,6 +42,7 @@ public readonly record struct DaemonMessage(LittleBigMouseEvent Event, string Pa
                 "LoadFailed" => LittleBigMouseEvent.LoadFailed,
                 "Probed" => LittleBigMouseEvent.Probed,
                 "Rescued" => LittleBigMouseEvent.Rescued,
+                "ShortcutUnavailable" => LittleBigMouseEvent.ShortcutUnavailable,
                 _ => (LittleBigMouseEvent?)null,
             };
             if (daemonEvent is null) return false;

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/DaemonMessage.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/DaemonMessage.cs
@@ -41,6 +41,7 @@ public readonly record struct DaemonMessage(LittleBigMouseEvent Event, string Pa
                 "Loaded" => LittleBigMouseEvent.Loaded,
                 "LoadFailed" => LittleBigMouseEvent.LoadFailed,
                 "Probed" => LittleBigMouseEvent.Probed,
+                "Rescued" => LittleBigMouseEvent.Rescued,
                 _ => (LittleBigMouseEvent?)null,
             };
             if (daemonEvent is null) return false;

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/ILittleBigMouseService.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/ILittleBigMouseService.cs
@@ -52,13 +52,22 @@ public enum LittleBigMouseEvent
     // mean, only that it happened, and knowing nothing is what lets it work with no UI
     // reachable. Distinct from Stopped, which says the same thing without saying why.
     Rescued,
+    // The panic shortcut could not be registered — almost always another application
+    // already owning the combination. Payload is the combination as it was asked for.
+    // Reported rather than logged: a rescue that silently does not exist is worse than
+    // none, because the user only finds out when they need it.
+    ShortcutUnavailable,
 }
 public enum LittleBigMouseCommand
 {
     Load,
     Run,
     Stop,
-    Quit
+    Quit,
+    // Adopt a panic shortcut now. It also travels inside the layout — which is how a
+    // standalone daemon gets one at boot — but recording one in the options has to take
+    // effect there and then, and has to say so when the combination is already taken.
+    Shortcut
 }
 
 public interface ILittleBigMouseService

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/ILittleBigMouseService.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/ILittleBigMouseService.cs
@@ -47,6 +47,11 @@ public enum LittleBigMouseEvent
     // Edge-prober report (a <ProbeReport> document in the payload): emitted after every
     // virtual Load and on an explicit Probe command. See ProbeReport.TryParse.
     Probed,
+    // The panic shortcut ran: the daemon has freed a cursor the user could not free with
+    // the mouse, and is coming down. No payload — it does not know what the rescue should
+    // mean, only that it happened, and knowing nothing is what lets it work with no UI
+    // reachable. Distinct from Stopped, which says the same thing without saying why.
+    Rescued,
 }
 public enum LittleBigMouseCommand
 {

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/ZonesLayout.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/ZonesLayout.cs
@@ -16,6 +16,13 @@ namespace LittleBigMouse.Zoning
         /// follow, so a client's geometry can never capture the local mouse.
         /// </summary>
         public bool Virtual {get;set;}
+        /// <summary>
+        /// The panic shortcut, carried to the daemon like every other daemon-side
+        /// setting — which is what gets it to a standalone daemon replaying its startup
+        /// file. The daemon is what registers it; nothing here reads it back.
+        /// </summary>
+        public string RescueShortcut {get; set;} = "";
+
         public string Priority {get; set;}
         public string PriorityUnhooked {get; set;}
 
@@ -54,6 +61,7 @@ namespace LittleBigMouse.Zoning
                 e => e.LoopX,
                 e => e.LoopY,
                 e => e.Virtual,
+                e => e.RescueShortcut,
                 e => e.Priority,
                 e => e.PriorityUnhooked,
                 e => e.Algorithm,

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -28,6 +28,7 @@ public class GlobalOptionsDto
     public bool? DebugTools { get; set; }
     public bool? ShowMonitorActionWarning { get; set; }
     public string? BorderValues { get; set; }
+    public string? RescueShortcut { get; set; }
     public bool? HideTrayIcon { get; set; }
 
     /// <summary>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
@@ -146,6 +146,7 @@ public abstract class LayoutPersistence : ILayoutPersistence
         o.VcpControl = dto.VcpControl ?? o.VcpControl;
         o.ShowMonitorActionWarning = dto.ShowMonitorActionWarning ?? o.ShowMonitorActionWarning;
         o.BorderValues = dto.BorderValues ?? o.BorderValues;
+        o.RescueShortcut = dto.RescueShortcut ?? o.RescueShortcut;
         o.HideTrayIcon = dto.HideTrayIcon ?? o.HideTrayIcon;
     }
 
@@ -505,6 +506,7 @@ public abstract class LayoutPersistence : ILayoutPersistence
             VcpControl = o.VcpControl,
             ShowMonitorActionWarning = o.ShowMonitorActionWarning,
             BorderValues = o.BorderValues,
+            RescueShortcut = o.RescueShortcut,
             HideTrayIcon = o.HideTrayIcon,
             ExcludedDefaultsVersion = _excludedDefaultsVersion
         });

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/ShortcutBoxTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/ShortcutBoxTests.cs
@@ -1,0 +1,125 @@
+using Avalonia.Input;
+using LittleBigMouse.Ui.Avalonia.Controls;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The recorder writes a shortcut; the daemon reads it. They are in different
+/// languages and different processes, so the grammar between them is a contract with
+/// no compiler behind it — these tests are that compiler.
+/// <para>
+/// The other half lives in <c>LittleBigMouse-Hook-Rust/src/shortcut.rs</c>. A key
+/// added on one side and not the other is a shortcut the user can record and that
+/// quietly never fires, which they would discover at the worst possible moment.
+/// </para>
+/// </summary>
+public sealed class ShortcutBoxTests
+{
+    [Theory]
+    [InlineData(Key.M, "M")]
+    [InlineData(Key.A, "A")]
+    [InlineData(Key.Z, "Z")]
+    [InlineData(Key.D0, "0")]
+    [InlineData(Key.D7, "7")]
+    [InlineData(Key.F1, "F1")]
+    [InlineData(Key.F12, "F12")]
+    [InlineData(Key.F24, "F24")]
+    [InlineData(Key.Space, "Space")]
+    [InlineData(Key.Escape, null)]      // reserved: it cancels the recording
+    [InlineData(Key.Enter, "Enter")]
+    [InlineData(Key.Tab, "Tab")]
+    [InlineData(Key.Back, "Backspace")]
+    [InlineData(Key.Insert, "Insert")]
+    [InlineData(Key.Delete, "Delete")]
+    [InlineData(Key.Home, "Home")]
+    [InlineData(Key.End, "End")]
+    [InlineData(Key.PageUp, "PageUp")]
+    [InlineData(Key.PageDown, "PageDown")]
+    [InlineData(Key.Left, "Left")]
+    [InlineData(Key.Up, "Up")]
+    [InlineData(Key.Right, "Right")]
+    [InlineData(Key.Down, "Down")]
+    [InlineData(Key.Pause, "Pause")]
+    [InlineData(Key.PrintScreen, "PrintScreen")]
+    public void KeysAreNamedTheWayTheDaemonReadsThem(Key key, string? expected)
+    {
+        Assert.Equal(expected, ShortcutBox.KeyName(key));
+    }
+
+    [Theory]
+    // Punctuation and the keypad — half of what a French keyboard offers. Every string
+    // here must be one the daemon's parser reads (shortcut.rs::virtual_key); that
+    // agreement has no compiler behind it, only these two test files.
+    [InlineData(Key.OemSemicolon, "Oem1")]
+    [InlineData(Key.OemQuestion, "Oem2")]
+    [InlineData(Key.OemTilde, "Oem3")]
+    [InlineData(Key.OemOpenBrackets, "Oem4")]
+    [InlineData(Key.OemPipe, "Oem5")]
+    [InlineData(Key.OemCloseBrackets, "Oem6")]
+    [InlineData(Key.OemQuotes, "Oem7")]
+    [InlineData(Key.Oem8, "Oem8")]
+    [InlineData(Key.OemBackslash, "Oem102")]
+    [InlineData(Key.OemPlus, "OemPlus")]
+    [InlineData(Key.OemComma, "OemComma")]
+    [InlineData(Key.OemMinus, "OemMinus")]
+    [InlineData(Key.OemPeriod, "OemPeriod")]
+    [InlineData(Key.NumPad0, "NumPad0")]
+    [InlineData(Key.NumPad9, "NumPad9")]
+    [InlineData(Key.Multiply, "NumPadMultiply")]
+    [InlineData(Key.Add, "NumPadAdd")]
+    [InlineData(Key.Subtract, "NumPadSubtract")]
+    [InlineData(Key.Decimal, "NumPadDecimal")]
+    [InlineData(Key.Divide, "NumPadDivide")]
+    public void PunctuationAndKeypadAreRecordable(Key key, string expected)
+    {
+        Assert.Equal(expected, ShortcutBox.KeyName(key));
+    }
+
+    [Theory]
+    // Keys with no virtual-key mapping on the daemon's side. Recording one would
+    // produce a shortcut that cannot be registered, so it must not be recordable.
+    [InlineData(Key.LeftCtrl)]
+    [InlineData(Key.CapsLock)]
+    [InlineData(Key.NumLock)]
+    [InlineData(Key.VolumeUp)]
+    [InlineData(Key.MediaPlayPause)]
+    [InlineData(Key.ImeConvert)]
+    public void KeysTheDaemonCannotRegisterAreNotRecordable(Key key)
+    {
+        Assert.Null(ShortcutBox.KeyName(key));
+    }
+
+    [Fact]
+    public void ModifiersAlwaysReadInTheSameOrder()
+    {
+        // So the same combination produces the same string every time — otherwise a
+        // re-record would look like a change, and the daemon would re-register for
+        // nothing.
+        Assert.Equal(
+            new[] { "Ctrl", "Alt", "Shift", "Win" },
+            ShortcutBox.ModifierNames(
+                KeyModifiers.Shift | KeyModifiers.Meta | KeyModifiers.Control | KeyModifiers.Alt));
+
+        Assert.Equal(
+            new[] { "Ctrl", "Shift" },
+            ShortcutBox.ModifierNames(KeyModifiers.Shift | KeyModifiers.Control));
+    }
+
+    [Fact]
+    public void EveryModifierKeyIsRecognizedAsOne()
+    {
+        // Left and right alike: pressing one is the user still reaching for the key,
+        // not a combination to record.
+        foreach (var key in new[]
+                 {
+                     Key.LeftCtrl, Key.RightCtrl, Key.LeftAlt, Key.RightAlt,
+                     Key.LeftShift, Key.RightShift, Key.LWin, Key.RWin,
+                 })
+        {
+            Assert.True(ShortcutBox.IsModifier(key), $"{key} must not end a recording");
+        }
+
+        Assert.False(ShortcutBox.IsModifier(Key.M));
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -103,6 +103,21 @@
 				</Setter>
 			</ControlTheme>
 
+			<!-- The shortcut recorder is a button whose content IS its value: it shows the
+			     combination, and says what it is waiting for while it waits. Based on the
+			     Button theme so it looks like one; keyed on its own type so selectors
+			     written against ShortcutBox actually match it. -->
+			<ControlTheme x:Key="{x:Type controls:ShortcutBox}" TargetType="controls:ShortcutBox"
+			              BasedOn="{StaticResource {x:Type Button}}">
+				<Setter Property="HorizontalContentAlignment" Value="Center"/>
+				<Setter Property="Content" Value="{Binding $self.Shortcut}"/>
+				<Style Selector="^[IsRecording=True]">
+					<Setter Property="Content" Value="Press the combination…"/>
+					<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>
+					<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Accent}"/>
+				</Style>
+			</ControlTheme>
+
 		</ResourceDictionary>
 	</Application.Resources>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -89,7 +89,8 @@
 								<TextBlock Text="{TemplateBinding Header}"
 								           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
 								           FontSize="13" TextWrapping="Wrap"/>
-								<TextBlock Text="{TemplateBinding Description}"
+								<TextBlock x:Name="PART_Description"
+								           Text="{TemplateBinding Description}"
 								           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
 								           FontSize="12" TextWrapping="Wrap"
 								           IsVisible="{TemplateBinding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -217,6 +217,28 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
                     Dispatcher.UIThread.Invoke(() =>
                         DaemonLayoutInfo = string.IsNullOrEmpty(e.Payload) ? "load failed" : e.Payload);
                     break;
+                // The panic shortcut ran. Ending live preview is not cosmetic: the pump
+                // would otherwise hand the daemon back, within its next tick, the very
+                // geometry the user just escaped from.
+                // The panic shortcut ran: the daemon has freed the cursor and is coming
+                // down. That is all it can decide knowing nothing — and it deliberately
+                // knows nothing, because it must work with no UI reachable at all.
+                //
+                // What it means is ours. Previewing? Then there is an experiment to
+                // throw away: drop it, go back to the saved layout and start again.
+                // Not previewing? Then what trapped the user is what they committed to,
+                // and leaving the engine down is the right answer — no second press.
+                case LittleBigMouseEvent.Rescued:
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        var wasPreviewing = LiveUpdate;
+                        LiveUpdate = false;
+                        DaemonLayoutInfo = wasPreviewing
+                            ? "rescued: back to the saved layout"
+                            : "rescued: engine stopped";
+                        if (wasPreviewing) _ = AbandonPreviewAsync();
+                    });
+                    break;
                 case LittleBigMouseEvent.SettingsChanged:
                 case LittleBigMouseEvent.DisplayChanged:
                 case LittleBigMouseEvent.DesktopChanged:
@@ -224,8 +246,11 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
                 case LittleBigMouseEvent.Paused:
                 case LittleBigMouseEvent.Connected:
                     break;
+                // Anything else — including events a newer daemon knows about and this
+                // build does not — is not ours to react to. This used to throw, which
+                // made every Suspended, Resumed and Probed fault the handler.
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(e.Event), e.Event, null);
+                    break;
             }
             //Dispatcher.UIThread.Invoke(new Action(() =>
             //    Running = e.Event switch
@@ -370,6 +395,18 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
         {
             if (Model != null) _persistence.SaveEnabled(Model);
         });
+
+    /// <summary>
+    /// The panic shortcut interrupted a live preview: throw the experiment away and put
+    /// the engine back on the layout the user actually saved. Nothing is written — the
+    /// preview never was — so this is a pure reload plus a fresh start.
+    /// </summary>
+    async Task AbandonPreviewAsync()
+    {
+        await LoadAsync();
+        if (Model is null || Model.IsVirtual) return;
+        await _service.StartAsync(Model.ComputeZones());
+    }
 
     Task LoadAsync() =>
         Task.Run(() =>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ScrollConverters.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ScrollConverters.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+public static class ScrollConverters
+{
+    /// <summary>
+    /// True once a scroll viewer has moved off its top. For headers that stay put but
+    /// give up their explanation as soon as they stop being the thing you are looking
+    /// at.
+    /// </summary>
+    /// <remarks>
+    /// The few pixels of slack keep a pinned header from flickering between its two
+    /// shapes when the content sits a hair off zero — a scroll of one pixel is not a
+    /// scroll.
+    /// </remarks>
+    public static readonly FuncValueConverter<Vector, bool> IsScrolled = new(offset => offset.Y > 4);
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutBox.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutBox.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+/// <summary>
+/// Records a keyboard shortcut by having the user press it.
+/// <para>
+/// Typing one out is a trap: the daemon can only register what Windows understands, so
+/// a name it cannot map would be accepted here and fail silently over there, far from
+/// its cause. Pressing the combination cannot produce anything the keyboard cannot
+/// produce — and the writing-out is done here, once, in the grammar both sides obey
+/// (LittleBigMouse-Hook-Rust/src/shortcut.rs).
+/// </para>
+/// </summary>
+public class ShortcutBox : Button
+{
+    public static readonly StyledProperty<string> ShortcutProperty =
+        AvaloniaProperty.Register<ShortcutBox, string>(
+            nameof(Shortcut), defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<bool> IsRecordingProperty =
+        AvaloniaProperty.Register<ShortcutBox, bool>(nameof(IsRecording));
+
+    /// <summary>The combination, as it reads and as it travels: "Ctrl+Alt+Shift+M".</summary>
+    public string Shortcut
+    {
+        get => GetValue(ShortcutProperty);
+        set => SetValue(ShortcutProperty, value);
+    }
+
+    /// <summary>Waiting for a combination. Styling hangs off this.</summary>
+    public bool IsRecording
+    {
+        get => GetValue(IsRecordingProperty);
+        private set => SetValue(IsRecordingProperty, value);
+    }
+
+    // No StyleKeyOverride: the caption and the waiting state come from this control's
+    // own ControlTheme (App.axaml), which is looked up by type. Pointing the style key
+    // at Button would borrow Button's look and, with it, make every selector written
+    // against ShortcutBox miss — a blank button with no styling and no explanation.
+
+    public ShortcutBox()
+    {
+        Click += (_, _) => IsRecording = !IsRecording;
+        LostFocus += (_, _) => IsRecording = false;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (!IsRecording)
+        {
+            base.OnKeyDown(e);
+            return;
+        }
+
+        // Nothing reaches the button while recording — not Space or Enter, which would
+        // otherwise re-trigger Click and cancel the recording the user just started.
+        e.Handled = true;
+
+        // A modifier on its own is the user still reaching for the key.
+        if (IsModifier(e.Key)) return;
+
+        if (e.Key == Key.Escape)
+        {
+            IsRecording = false;
+            return;
+        }
+
+        var name = KeyName(e.Key);
+        if (name is null) return;
+
+        // At least one modifier, always. Registered globally, a bare key would be taken
+        // away from every application on the desktop — the daemon refuses one too, and
+        // refusing it here is what makes that refusal visible instead of silent.
+        var modifiers = ModifierNames(e.KeyModifiers).ToList();
+        if (modifiers.Count == 0) return;
+
+        Shortcut = string.Join("+", modifiers.Append(name));
+        IsRecording = false;
+    }
+
+    internal static bool IsModifier(Key key) => key
+        is Key.LeftCtrl or Key.RightCtrl
+        or Key.LeftAlt or Key.RightAlt
+        or Key.LeftShift or Key.RightShift
+        or Key.LWin or Key.RWin;
+
+    /// <summary>Modifiers in a fixed order, so the same combination always reads the same.</summary>
+    internal static IEnumerable<string> ModifierNames(KeyModifiers modifiers)
+    {
+        if (modifiers.HasFlag(KeyModifiers.Control)) yield return "Ctrl";
+        if (modifiers.HasFlag(KeyModifiers.Alt)) yield return "Alt";
+        if (modifiers.HasFlag(KeyModifiers.Shift)) yield return "Shift";
+        if (modifiers.HasFlag(KeyModifiers.Meta)) yield return "Win";
+    }
+
+    /// <summary>
+    /// The keys a shortcut may use, named as the daemon's parser reads them. Closed on
+    /// purpose, and it is the same closed set on both sides: a key recorded here that
+    /// the daemon cannot register would be a shortcut that quietly does not exist.
+    /// </summary>
+    internal static string? KeyName(Key key) => key switch
+    {
+        >= Key.A and <= Key.Z => key.ToString(),
+        >= Key.D0 and <= Key.D9 => key.ToString()[1..],
+        >= Key.F1 and <= Key.F24 => key.ToString(),
+        Key.Space => "Space",
+        Key.Enter => "Enter",
+        Key.Tab => "Tab",
+        Key.Back => "Backspace",
+        Key.Insert => "Insert",
+        Key.Delete => "Delete",
+        Key.Home => "Home",
+        Key.End => "End",
+        Key.PageUp => "PageUp",
+        Key.PageDown => "PageDown",
+        Key.Left => "Left",
+        Key.Up => "Up",
+        Key.Right => "Right",
+        Key.Down => "Down",
+        Key.Pause => "Pause",
+        Key.PrintScreen => "PrintScreen",
+
+        // Punctuation, by its position rather than by what it prints: the same physical
+        // key is ² on an AZERTY board and ` on a QWERTY one, and the daemon registers a
+        // position. Leaving these out amputated every non-alphanumeric key, which on a
+        // French keyboard is most of the interesting ones.
+        Key.OemSemicolon => "Oem1",
+        Key.OemQuestion => "Oem2",
+        Key.OemTilde => "Oem3",
+        Key.OemOpenBrackets => "Oem4",
+        Key.OemPipe => "Oem5",
+        Key.OemCloseBrackets => "Oem6",
+        Key.OemQuotes => "Oem7",
+        Key.Oem8 => "Oem8",
+        Key.OemBackslash => "Oem102",
+        Key.OemPlus => "OemPlus",
+        Key.OemComma => "OemComma",
+        Key.OemMinus => "OemMinus",
+        Key.OemPeriod => "OemPeriod",
+
+        >= Key.NumPad0 and <= Key.NumPad9 => key.ToString(),
+        Key.Multiply => "NumPadMultiply",
+        Key.Add => "NumPadAdd",
+        Key.Subtract => "NumPadSubtract",
+        Key.Decimal => "NumPadDecimal",
+        Key.Divide => "NumPadDivide",
+
+        _ => null,
+    };
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -264,6 +264,14 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     }
     string _borderValues = "PerModel";
 
+    [DataMember]
+    public string RescueShortcut
+    {
+        get => _rescueShortcut;
+        set => SetUnsavedValue(ref _rescueShortcut, value);
+    }
+    string _rescueShortcut = "Ctrl+Alt+Shift+M";
+
     public ObservableCollection<string> ExcludedList { get; } = new();
 
     public string GetConfigPath(string layoutId, bool create)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -416,8 +416,16 @@ public class MainService : ReactiveModel, IMainService
             case LittleBigMouseEvent.Loaded:
             case LittleBigMouseEvent.LoadFailed:
                 break;
+            // The panic shortcut ran. Its two steps announce themselves through the
+            // ordinary events as well — a restore reloads, a stop unhooks — so the tray
+            // icon is already right; the location control is what has to act.
+            case LittleBigMouseEvent.Rescued:
+                break;
+            // Anything else, including events only a newer daemon knows about, is not
+            // ours to reconcile. This used to throw, which faulted the handler on every
+            // Suspended, Resumed and Probed.
             default:
-                throw new ArgumentOutOfRangeException(nameof(args.Event), args.Event, null);
+                break;
         }
     }
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -240,6 +240,20 @@
 						</StackPanel>
 					</Border>
 
+					<Border Classes="SettingCard">
+						<StackPanel>
+							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Shield}"
+							                     Header="Rescue shortcut"
+							                     Description="Frees the cursor when it gets trapped where you cannot click. Hold it for about a second. One key plus at least one of Ctrl, Alt, Shift or Win.">
+								<controls:ShortcutBox Shortcut="{Binding Model.RescueShortcut, Mode=TwoWay, FallbackValue=''}"
+								                      MinWidth="170" HorizontalAlignment="Right"/>
+							</controls:SettingRow>
+							<TextBlock Classes="SettingWarning"
+							           Text="{Binding ShortcutWarning}"
+							           IsVisible="{Binding ShortcutWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+						</StackPanel>
+					</Border>
+
 					<TextBlock Classes="SectionHeader" Text="Layout"/>
 
 					<Border Classes="SettingCard">

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -10,7 +10,7 @@
              Background="Transparent"
              >
 	<Border Background="{DynamicResource Lbm.Brushes.Pane.Background}">
-		<Grid RowDefinitions="Auto,*">
+		<Grid RowDefinitions="Auto,Auto,*">
 
 			<Border Grid.Row="0" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Lbm.Brushes.Card.Separator}" Padding="18,12">
 				<Grid ColumnDefinitions="*,Auto">
@@ -28,24 +28,28 @@
 				</Grid>
 			</Border>
 
-			<ScrollViewer Grid.Row="1">
+			<!-- Stays put while the rest scrolls, and gives up its explanation as soon as it
+			     stops being what you are looking at — a line of thanks should not cost a
+			     third of the panel for the whole visit. -->
+			<Border Grid.Row="1" Classes="SettingCard PinnedCard"
+			        Classes.Compact="{Binding #SettingsScroll.Offset, Converter={x:Static controls:ScrollConverters.IsScrolled}}"
+			        Margin="16,10,16,0">
+				<controls:SettingRow Icon="{StaticResource Lbm.Icon.Coffee}"
+				                     Classes.Compact="{Binding #SettingsScroll.Offset, Converter={x:Static controls:ScrollConverters.IsScrolled}}"
+				                     Header="Support LittleBigMouse"
+				                     Description="Free and open source — if it's useful to you, consider buying me a coffee">
+					<Button Click="Kofi_OnClick" ToolTip.Tip="ko-fi.com/mgth">
+						<StackPanel Orientation="Horizontal" Spacing="6">
+							<Path Data="{StaticResource Lbm.Icon.Coffee}" Width="13" Height="13" Stretch="Uniform"
+							      Fill="{DynamicResource Lbm.Brushes.Text.Primary}" VerticalAlignment="Center"/>
+							<TextBlock Text="Ko-fi" VerticalAlignment="Center"/>
+						</StackPanel>
+					</Button>
+				</controls:SettingRow>
+			</Border>
+
+			<ScrollViewer Grid.Row="2" x:Name="SettingsScroll">
 				<StackPanel Margin="16,2,16,18">
-
-					<TextBlock Classes="SectionHeader" Text="Support"/>
-
-					<Border Classes="SettingCard">
-						<controls:SettingRow Icon="{StaticResource Lbm.Icon.Coffee}"
-						                     Header="Support LittleBigMouse"
-						                     Description="Free and open source — if it's useful to you, consider buying me a coffee">
-							<Button Click="Kofi_OnClick" ToolTip.Tip="ko-fi.com/mgth">
-								<StackPanel Orientation="Horizontal" Spacing="6">
-									<Path Data="{StaticResource Lbm.Icon.Coffee}" Width="13" Height="13" Stretch="Uniform"
-									      Fill="{DynamicResource Lbm.Brushes.Text.Primary}" VerticalAlignment="Center"/>
-									<TextBlock Text="Ko-fi" VerticalAlignment="Center"/>
-								</StackPanel>
-							</Button>
-						</controls:SettingRow>
-					</Border>
 
 					<TextBlock Classes="SectionHeader" Text="General"/>
 
@@ -153,7 +157,11 @@
 							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Algorithm}"
 							                     Header="Crossing algorithm"
 							                     Description="How the cursor jumps between screens"/>
-							<ListBox Classes="ChoiceCards" Margin="14,0,6,12"
+							<!-- AutoScrollToSelectedItem off: these lists hold two or three cards and are
+							     visible whole, so scrolling to the selection buys nothing — but the request
+							     travels up to the settings scroller, which then opens the panel part-way
+							     down instead of at the top. -->
+							<ListBox Classes="ChoiceCards" Margin="14,0,6,12" AutoScrollToSelectedItem="False"
 							         ItemsSource="{Binding AlgorithmList}"
 							         SelectedItem="{Binding SelectedAlgorithm}">
 								<ListBox.ItemTemplate>
@@ -277,7 +285,11 @@
 							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Ruler}"
 							                     Header="Border values"
 							                     Description="Where each monitor's bezel borders are stored"/>
-							<ListBox Classes="ChoiceCards" Margin="14,0,6,12"
+							<!-- AutoScrollToSelectedItem off: these lists hold two or three cards and are
+							     visible whole, so scrolling to the selection buys nothing — but the request
+							     travels up to the settings scroller, which then opens the panel part-way
+							     down instead of at the top. -->
+							<ListBox Classes="ChoiceCards" Margin="14,0,6,12" AutoScrollToSelectedItem="False"
 							         ItemsSource="{Binding BorderValuesList}"
 							         SelectedItem="{Binding SelectedBorderValues}">
 								<ListBox.ItemTemplate>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
@@ -12,14 +12,20 @@ using HLab.Base.ReactiveUI;
 using HLab.Mvvm.ReactiveUI;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Plugins;
+using Avalonia.Threading;
 using LittleBigMouse.Ui.Avalonia.Main;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using LittleBigMouse.Zoning;
 using ReactiveUI;
 
 namespace LittleBigMouse.Ui.Avalonia.Options;
 
 public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
 {
-    public LbmOptionsViewModel(IProcessesCollector collector, IMainService mainService)
+    public LbmOptionsViewModel(
+        IProcessesCollector collector,
+        IMainService mainService,
+        ILittleBigMouseClientService daemon)
     {
         // Turning a permission OFF must fix the current layout right away, not
         // wait for the next monitor move: compact resolves the existing overlaps
@@ -74,6 +80,28 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
             .Subscribe(p => Pattern = p?.Caption??"")
             .DisposeWith(this);
 
+        // The daemon is what registers the rescue shortcut, so it is the only one who
+        // knows whether the registration took. Reported rather than logged: a rescue
+        // that silently does not exist is worse than none, because the user only finds
+        // out at the moment they need it.
+        daemon.DaemonEventReceived += OnDaemonEvent;
+
+        // Send it as soon as it is recorded, not at the next Apply. It rides inside the
+        // layout too — that is what gets one to a standalone daemon at boot — but
+        // waiting for an Apply would mean recording a combination, seeing nothing
+        // happen, and having no way to tell "it works" from "something else owns it".
+        // Clearing the warning here makes it a fresh attempt: whatever comes back is
+        // about the combination now being asked for.
+        this.WhenAnyValue(e => e.Model.RescueShortcut)
+            .Where(shortcut => !string.IsNullOrWhiteSpace(shortcut))
+            .DistinctUntilChanged()
+            .Subscribe(shortcut =>
+            {
+                ShortcutWarning = "";
+                _ = daemon.SendShortcutAsync(shortcut);
+            })
+            .DisposeWith(this);
+
         collector.SeenProcesses
             .ToObservableChangeSet()
             .Transform(p => new SeenProcessViewModel(p,p, this))
@@ -81,6 +109,21 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
             .Subscribe()
             .DisposeWith(this);
     }
+
+    void OnDaemonEvent(object? sender, LittleBigMouseServiceEventArgs e)
+    {
+        if (e.Event != LittleBigMouseEvent.ShortcutUnavailable) return;
+        Dispatcher.UIThread.Post(() => ShortcutWarning =
+            $"{e.Payload} is already taken by another application — the rescue shortcut is NOT active.");
+    }
+
+    /// <summary>Empty while the rescue shortcut is registered and working.</summary>
+    public string ShortcutWarning
+    {
+        get => _shortcutWarning;
+        private set => this.RaiseAndSetIfChanged(ref _shortcutWarning, value);
+    }
+    string _shortcutWarning = "";
 
     void CompactWhenTurnedOff(
         System.Linq.Expressions.Expression<Func<LbmOptionsViewModel, bool>> option,

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/ILittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/ILittleBigMouseClientService.cs
@@ -40,4 +40,13 @@ public interface ILittleBigMouseClientService : ILittleBigMouseService
     /// the live-preview switch sends while the user edits.
     /// </summary>
     Task SendLiveAsync(ZonesLayout zonesLayout, CancellationToken token = default);
+
+    /// <summary>
+    /// Hand the daemon a panic shortcut to register now. It also travels inside the
+    /// layout, which is what gets one to a standalone daemon at boot — but a shortcut
+    /// recorded in the options has to take effect the moment it is recorded, and the
+    /// answer (it is already taken) has to come back while the user is still looking at
+    /// the setting rather than at the next Apply.
+    /// </summary>
+    Task SendShortcutAsync(string shortcut, CancellationToken token = default);
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -114,6 +114,11 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
     }
 
 
+    public Task SendShortcutAsync(string shortcut, CancellationToken token = default) =>
+        SendMessagesAsync(
+            [CommandMessage.WithText(LittleBigMouseCommand.Shortcut, shortcut ?? "")],
+            token, persist: false);
+
     // The topology epilogue runs on explicit Stop/Quit only — NOT on a Dead daemon: the
     // socket layer auto-relaunches the daemon and MainService auto-restarts the engine
     // (Connected→Stopped→Start), so restoring there would fight the recovery. A daemon

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -33,6 +33,15 @@
 		<Setter Property="Margin" Value="4,14,0,4"/>
 	</Style>
 
+	<!-- A setting that is not doing what it says. Inside the card, under the row it
+	     belongs to, because it is about that row and nothing else. -->
+	<Style Selector="TextBlock.SettingWarning">
+		<Setter Property="FontSize" Value="12"/>
+		<Setter Property="TextWrapping" Value="Wrap"/>
+		<Setter Property="Foreground" Value="{DynamicResource Lbm.Brushes.Badge.Virtual.Foreground}"/>
+		<Setter Property="Margin" Value="14,0,14,12"/>
+	</Style>
+
 	<Style Selector="Border.SettingCard">
 		<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Card.Background}"/>
 		<Setter Property="BorderBrush" Value="{DynamicResource Lbm.Brushes.Card.Border}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Styles/LbmStyles.axaml
@@ -9,6 +9,23 @@
 		<Setter Property="Padding" Value="44,8,14,10"/>
 	</Style>
 
+	<!-- A row that has stopped being what you are looking at: keep what it offers, drop
+	     the sentence explaining it. -->
+	<Style Selector="controls|SettingRow.Compact">
+		<Setter Property="Padding" Value="14,6"/>
+	</Style>
+	<Style Selector="controls|SettingRow.Compact /template/ TextBlock#PART_Description">
+		<Setter Property="IsVisible" Value="False"/>
+	</Style>
+
+	<!-- Pinned above the scroller rather than scrolling with it. The separator only
+	     appears once there is content passing underneath, so at rest the card looks like
+	     any other. -->
+	<Style Selector="Border.PinnedCard.Compact">
+		<Setter Property="CornerRadius" Value="8"/>
+		<Setter Property="BoxShadow" Value="0 2 8 0 #22000000"/>
+	</Style>
+
 	<Style Selector="controls|SettingRow ToggleSwitch">
 		<Setter Property="OnContent" Value="{x:Null}"/>
 		<Setter Property="OffContent" Value="{x:Null}"/>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Check the very nice video from Touble Chute (a very big thanks to him):
 - **Screen Looping**: Lets the cursor wrap around the desktop — leave the last screen and re-enter from the first, horizontally or vertically.
 - **Display Size Adjustments**: Allows for adjustments in the relative sizes of displays.
 - **Border Resistance**: Allow some resistance before crossing.
+- **Rescue Shortcut**: A keyboard way out when a layout leaves the cursor somewhere it cannot escape — the one recovery that does not need a click.
 - **Live Update**: Feel a layout while you edit it. Changes go straight to the mouse engine as you make them, without being saved, so you can try a resistance or a position with the real mouse instead of applying it and undoing it.
 - **Display Color and Brightness Balancing**: Offers control over color and brightness profiles of displays.
 - **Access to Display Debugging Information**: Provides detailed information from your displays and drivers.
@@ -165,6 +166,26 @@ Live update saves nothing: the button is still what keeps a layout, and **Undo**
 to the last saved one. Nothing about it survives closing the app either — a restarted
 engine comes back to the layout you last applied, never to something you were only trying
 out.
+
+### If the cursor gets trapped
+
+A layout can leave the cursor somewhere it cannot get out of — and then Undo, Stop and the
+tray menu are all behind a click you cannot make. **Hold `Ctrl+Alt+Shift+M` for about a
+second** and the mouse comes back:
+
+- while **live update** is on, the layout you were trying is thrown away and the engine
+  goes back to the one you saved;
+- otherwise the engine stops, and the mouse behaves the way Windows alone would until you
+  start it again.
+
+The combination is yours to change under **Options → Mouse → Rescue shortcut**: click it
+and press the one you want. If another application already owns that combination, the
+setting says so — a rescue you only discover is missing when you need it would be worse
+than none.
+
+Windows only for now. Wayland has no global shortcut without a portal, and reading one
+from evdev would mean opening the keyboard devices, which is a great deal more than a
+mouse utility should ask for.
 
 ## Support
 


### PR DESCRIPTION
Closes #526.

A cursor stuck on a screen it cannot leave puts every recovery LBM offers — Undo, Stop, the tray menu — behind a click that cannot be made. The eleven closed "cursor gets stuck" issues were all geometry bugs and were fixed as such; none of them left the user a way out *while it was happening*. Live update (#525) sharpens it, since an untested geometry now goes under the mouse deliberately, but the need stands on its own.

**Hold `Ctrl+Alt+Shift+M` for about a second.** Configurable under Options → Mouse.

## Who decides what

The daemon does one thing and always the same thing: release the clip, say so, take the hook down. It knows nothing about why, and that is the point — it has to work with no UI reachable behind the very cursor it is freeing, or with no UI running at all.

What the rescue should *mean* belongs to the UI, which is where the knowledge is:

- **previewing a layout** → there is an experiment to throw away: drop live update, reload the saved layout, start the engine again on it;
- **not previewing** → what trapped the user is what they committed to, and leaving the engine down is the answer.

So the ordinary case is over in one press. Nothing counts presses and there is no escalation window; the escalation falls out of the state.

`Rescued` is broadcast **before** the unhook is requested. The other order puts the resulting `Stopped` first, the UI drops live preview on that, and the `Rescued` behind it finds nothing left to act on — the reload never happens.

## Three deliberate choices in the listener

- **`RegisterHotKey`, not `WH_KEYBOARD_LL`.** The daemon already hooks the mouse globally; a keyboard hook would mean seeing every keystroke on the desktop — a keylogging surface that antivirus and anti-cheat notice, and that a mouse utility has no business needing. This sees one combination, and Windows arbitrates collisions instead of leaving them silent. Verified from another process: the combination answers `ERROR_HOTKEY_ALREADY_REGISTERED`.
- **Its own thread, with its own message loop.** `WM_HOTKEY` goes to the queue of the thread that registered; registering on the hook pump would make the rescue depend on the pump it is rescuing you from.
- **Held, not tapped**, with the auto-repeat backlog drained afterwards so letting go cannot fire a second time.

## Recording it

Pressed, not typed: the daemon can only register what Windows understands, so a name typed in and unmappable there would be accepted here and fail silently, far from its cause.

Sent the moment it is recorded, through a new `Shortcut` command, rather than riding to the daemon inside the next Apply. That was the first thing to get wrong — recording one and waiting for an Apply meant nothing was attempted, so nothing succeeded and nothing failed, and there was no way to tell "it works" from "something else owns it". It still travels inside the layout as well, which is what gets one to a standalone daemon replaying its startup file.

When `RegisterHotKey` refuses, the daemon says so and the options row says the combination is taken and the rescue is NOT active. A rescue that silently does not exist is worse than none, because the user only finds out at the moment they need it.

The key table covers letters, digits, function and navigation keys, **punctuation and the numeric keypad**. Without the last two, `Ctrl+²` could not be recorded at all — on a French keyboard that is most of the interesting keys. OEM keys are named by position rather than by what they print: `Oem3` is `` ` `` on QWERTY and `²` on AZERTY, and the position is what gets registered, so a shortcut means the same physical key whatever the layout says it prints. The button therefore reads `Ctrl+Oem7`, which is honest but not pretty — prettifying it needs a `MapVirtualKey` round-trip and can come later.

That grammar is a contract between two languages and two processes with no compiler behind it. `ShortcutBoxTests` and `shortcut.rs`'s tests are the compiler: every name locked on both sides, along with the refusals — a bare key (registering one globally would take it from every application on the desktop) and keys with no virtual-key code.

## Also fixed, because adding an event made it blocking

Both daemon event handlers ended in `default: throw new ArgumentOutOfRangeException`, and `Suspended`, `Resumed` and `Probed` have a case in neither — every sleep, resume and probe was faulting them from inside a `Dispatcher.Post`. An event stream you do not control is ignored, not refused; a daemon newer than its UI is a normal state of affairs.

## Not possible, and worth writing down

Two modifiers alone — both Shift keys together, say. `RegisterHotKey` takes modifiers plus a key, and there is no key in that. The only way round is a keyboard hook, which is the surface this design exists to avoid.

Linux gets nothing yet: no global shortcut without a portal, and reading one from evdev means opening the keyboard devices.

## Tests

105 + 60 + 113 + 5 managed, 56 Rust, clippy clean.