### PR TITLE
Show a shortcut the way the keyboard shows it

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/ShortcutBoxTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/ShortcutBoxTests.cs
@@ -106,6 +106,64 @@ public sealed class ShortcutBoxTests
             ShortcutBox.ModifierNames(KeyModifiers.Shift | KeyModifiers.Control));
     }
 
+    [Theory]
+    // The daemon's numbers (shortcut.rs::virtual_key), asserted here too. Only the
+    // position-named keys need one on this side, to turn back into a character for
+    // display — but a number that drifted would send the display and the registration
+    // to two different keys, and nothing else would notice.
+    [InlineData("Oem1", 0xBA)]
+    [InlineData("Oem2", 0xBF)]
+    [InlineData("Oem3", 0xC0)]
+    [InlineData("Oem4", 0xDB)]
+    [InlineData("Oem5", 0xDC)]
+    [InlineData("Oem6", 0xDD)]
+    [InlineData("Oem7", 0xDE)]
+    [InlineData("Oem8", 0xDF)]
+    [InlineData("Oem102", 0xE2)]
+    [InlineData("OemPlus", 0xBB)]
+    [InlineData("OemComma", 0xBC)]
+    [InlineData("OemMinus", 0xBD)]
+    [InlineData("OemPeriod", 0xBE)]
+    public void PositionNamesCarryTheDaemonsVirtualKeyCodes(string name, uint vk)
+    {
+        Assert.Equal(vk, ShortcutBox.VirtualKey(name));
+    }
+
+    [Fact]
+    public void OnlyPositionNamesHaveAVirtualKeyOnThisSide()
+    {
+        // The rest already read as themselves and are never translated for display.
+        Assert.Null(ShortcutBox.VirtualKey("M"));
+        Assert.Null(ShortcutBox.VirtualKey("F12"));
+        Assert.Null(ShortcutBox.VirtualKey("NumPad0"));
+        Assert.Null(ShortcutBox.VirtualKey("Oem9"));
+    }
+
+    [Fact]
+    public void ReadableLeavesEverythingItCannotImproveAlone()
+    {
+        // Layout-independent assertions only: what Oem7 prints is ² here and ' on the
+        // CI runner, so the test pins the shape, not the character.
+        Assert.Equal("Ctrl+Alt+Shift+M", ShortcutDisplay.Readably("Ctrl+Alt+Shift+M"));
+        Assert.Equal("Ctrl+F12", ShortcutDisplay.Readably("Ctrl+F12"));
+        Assert.Equal("Ctrl+NumPad0", ShortcutDisplay.Readably("Ctrl+NumPad0"));
+        Assert.Equal("", ShortcutDisplay.Readably(""));
+        Assert.Equal("", ShortcutDisplay.Readably(null));
+    }
+
+    [Fact]
+    public void ReadableTurnsAPositionIntoWhatTheKeyboardPrints()
+    {
+        var readable = ShortcutDisplay.Readably("Ctrl+Oem7");
+
+        Assert.StartsWith("Ctrl+", readable);
+        var key = readable["Ctrl+".Length..];
+
+        // One character on a layout that prints something there, the position name on
+        // one that does not — never blank, and never half-translated.
+        Assert.True(key.Length == 1 || key == "Oem7", $"unexpected rendering: {key}");
+    }
+
     [Fact]
     public void EveryModifierKeyIsRecognizedAsOne()
     {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml
@@ -111,7 +111,8 @@
 			<ControlTheme x:Key="{x:Type controls:ShortcutBox}" TargetType="controls:ShortcutBox"
 			              BasedOn="{StaticResource {x:Type Button}}">
 				<Setter Property="HorizontalContentAlignment" Value="Center"/>
-				<Setter Property="Content" Value="{Binding $self.Shortcut}"/>
+				<Setter Property="Content"
+				        Value="{Binding $self.Shortcut, Converter={x:Static controls:ShortcutDisplay.Readable}}"/>
 				<Style Selector="^[IsRecording=True]">
 					<Setter Property="Content" Value="Press the combination…"/>
 					<Setter Property="Background" Value="{DynamicResource Lbm.Brushes.Accent.Faint}"/>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutBox.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutBox.cs
@@ -155,4 +155,32 @@ public class ShortcutBox : Button
 
         _ => null,
     };
+
+    /// <summary>
+    /// The Win32 virtual-key code behind a position name, for the position-named keys
+    /// only — the ones <see cref="ShortcutDisplay"/> has to turn back into whatever
+    /// character the current layout prints on them.
+    /// <para>
+    /// These numbers are the daemon's too (shortcut.rs::virtual_key). They are asserted
+    /// on both sides for the same reason the names are: nothing else would notice them
+    /// drifting apart.
+    /// </para>
+    /// </summary>
+    internal static uint? VirtualKey(string name) => name switch
+    {
+        "Oem1" => 0xBA,
+        "Oem2" => 0xBF,
+        "Oem3" => 0xC0,
+        "Oem4" => 0xDB,
+        "Oem5" => 0xDC,
+        "Oem6" => 0xDD,
+        "Oem7" => 0xDE,
+        "Oem8" => 0xDF,
+        "Oem102" => 0xE2,
+        "OemPlus" => 0xBB,
+        "OemComma" => 0xBC,
+        "OemMinus" => 0xBD,
+        "OemPeriod" => 0xBE,
+        _ => null,
+    };
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutDisplay.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/ShortcutDisplay.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Avalonia.Data.Converters;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+/// <summary>
+/// Shows a shortcut the way the keyboard shows it.
+/// <para>
+/// A shortcut is stored, and registered, as a <em>position</em>: `Oem7` is the same
+/// physical key whatever the layout prints on it, which is what `RegisterHotKey` takes
+/// and what makes a recorded shortcut survive a layout change. Honest, and unreadable —
+/// nobody pressed "Oem7", they pressed <c>²</c>.
+/// </para>
+/// <para>
+/// So the position is what travels and the character is what is shown. Only the
+/// display changes: the stored value, the wire and the daemon are untouched, and a
+/// layout switch changes what is displayed without invalidating anything.
+/// </para>
+/// </summary>
+public static class ShortcutDisplay
+{
+    public static readonly FuncValueConverter<string?, string> Readable = new(Readably);
+
+    /// <summary>`Ctrl+Oem7` reads as `Ctrl+²` on an AZERTY board, `Ctrl+'` on a US one.</summary>
+    internal static string Readably(string? shortcut)
+    {
+        if (string.IsNullOrWhiteSpace(shortcut)) return "";
+
+        return string.Join("+", shortcut.Split('+').Select(part =>
+        {
+            var name = part.Trim();
+            // Only the position-named keys need translating. Everything else already
+            // reads as what it is — "M", "F12", "Space", "NumPad0".
+            if (!name.StartsWith("Oem", StringComparison.Ordinal)) return name;
+            return CharacterOf(name) ?? name;
+        }));
+    }
+
+    /// <summary>
+    /// What this key prints on the layout in force right now, or null when it prints
+    /// nothing — a key with no character is better named than shown blank.
+    /// </summary>
+    static string? CharacterOf(string name)
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+        if (ShortcutBox.VirtualKey(name) is not { } vk) return null;
+
+        try
+        {
+            // MAPVK_VK_TO_CHAR: the unshifted character, or 0 for none. The top bit
+            // flags a dead key, which still has a character worth showing.
+            var mapped = MapVirtualKeyW(vk, 2) & 0x7FFF;
+            if (mapped == 0) return null;
+
+            var c = (char)mapped;
+            return char.IsControl(c) || char.IsWhiteSpace(c) ? null : c.ToString();
+        }
+        catch (DllNotFoundException)
+        {
+            return null;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    static extern uint MapVirtualKeyW(uint uCode, uint uMapType);
+}


### PR DESCRIPTION
Follow-up to #528, which left the recorder displaying `Ctrl+Oem7`. Honest — that is what gets registered — but nobody pressed "Oem7", they pressed `²`.

It now reads `Ctrl+²` on an AZERTY board and `Ctrl+'` on a US one.

## Only the display changes

A shortcut is stored, sent and registered as a **position**. That is what `RegisterHotKey` takes, and it is what makes a recorded shortcut mean the same physical key after a layout change. Nothing about that moves here.

The character is looked up at display time with `MapVirtualKey(VK_TO_CHAR)`, so switching layouts changes what is shown without invalidating the setting, the wire, or the registration.

It falls back to the position name whenever there is no character to show — a key that prints nothing, a control character, a lookup that fails. Never a blank button, never half-translated. Keys that already read as themselves (`M`, `F12`, `Space`, `NumPad0`) are not put through it at all.

## The cost, stated

This adds a third table to keep in step: the virtual-key codes on the C# side have to be the daemon's. Drift there would point the display at one key and the registration at another, with nothing to notice — so they are asserted here as they already were in `shortcut.rs`.

The display tests assert shape rather than characters, since `Oem7` prints `²` on the author's keyboard and `'` on the CI runner: the result must be either a single character or the position name.

## Tests

129 in the UI suite (was 113); 105 + 60 + 5 elsewhere, 56 Rust — all unchanged.