### PR TITLE
Ask before leaving with an unsaved layout

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMainService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMainService.cs
@@ -15,6 +15,19 @@ public interface IMainService
 
     IMonitorsLayout MonitorsLayout {get; set;}
 
+    /// <summary>
+    /// The layout being edited is also being fed to the mouse engine as it is edited.
+    /// <para>
+    /// Set by the control that owns the switch, read on the way out: it is what decides
+    /// whether "Save" may be offered when leaving with an unsaved layout. Live update
+    /// means the geometry is the one driving the mouse right now, so saving it saves
+    /// something the user has felt — offering to save an untried one, in the hurry of a
+    /// dialog standing between them and leaving, is how a bad layout becomes the one
+    /// that loads at the next boot.
+    /// </para>
+    /// </summary>
+    bool LivePreview {get; set;}
+
     Task StartNotifierAsync();
 
     Task ShowControlAsync();

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -167,6 +167,11 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
 
         this.WhenAnyValue(e => e.LiveUpdate).Subscribe(live =>
         {
+            // Told to the service because leaving is decided there, and because only
+            // live update makes an unsaved layout safe to offer to save: it is the one
+            // driving the mouse, so it has been felt.
+            _mainService.LivePreview = live;
+
             if (live)
             {
                 // The daemon is holding the last applied layout, not ours: make the

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/UnsavedChangesDialog.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/UnsavedChangesDialog.axaml
@@ -1,0 +1,44 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="LittleBigMouse.Ui.Avalonia.Controls.UnsavedChangesDialog"
+        Title="Unsaved layout"
+        Width="480"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource Lbm.Brushes.Pane.Background}">
+
+	<StackPanel Margin="24,20" Spacing="14">
+
+		<StackPanel Orientation="Horizontal" Spacing="12">
+			<Path Data="{StaticResource Lbm.Icon.Warning}"
+			      Fill="#E0A030" Width="26" Height="26" Stretch="Uniform"
+			      VerticalAlignment="Center"/>
+			<TextBlock x:Name="HeadingText"
+			           Text="Your layout has not been saved"
+			           FontSize="16" FontWeight="SemiBold"
+			           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+			           VerticalAlignment="Center" TextWrapping="Wrap"/>
+		</StackPanel>
+
+		<TextBlock x:Name="BodyText" TextWrapping="Wrap" FontSize="13"
+		           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+
+		<!-- Only shown when live update is on. Saving a layout nobody has tried, in the
+		     hurry of a dialog that stands between the user and leaving, is exactly how a
+		     bad geometry becomes the one that loads at the next boot. -->
+		<TextBlock x:Name="SaveNote" TextWrapping="Wrap" FontSize="12"
+		           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"
+		           IsVisible="False"
+		           Text="Live update is on, so this layout is the one currently driving the mouse — saving it keeps what you have been feeling."/>
+
+		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+			<Button x:Name="CancelButton" Content="Cancel" Click="OnCancelClick" IsCancel="True"/>
+			<Button x:Name="ContinueButton" Content="Keep unsaved" Click="OnContinueClick"/>
+			<Button x:Name="SaveButton" Content="Save" Click="OnSaveClick"
+			        IsVisible="False" IsDefault="True"/>
+		</StackPanel>
+
+	</StackPanel>
+</Window>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/UnsavedChangesDialog.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/UnsavedChangesDialog.axaml.cs
@@ -1,0 +1,102 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace LittleBigMouse.Ui.Avalonia.Controls;
+
+/// <summary>What the user decided on the way out.</summary>
+public enum UnsavedChoice
+{
+    /// <summary>Stay. Nothing happens.</summary>
+    Cancel,
+    /// <summary>Go, leaving the layout unsaved.</summary>
+    Continue,
+    /// <summary>Save the layout first. Only ever offered when it has been tried.</summary>
+    Save,
+}
+
+/// <summary>
+/// Asked on the way out when the layout has not been saved.
+/// <para>
+/// <b>Save is not always on offer.</b> It appears only while live update is running,
+/// because that is the only state in which the layout has actually been felt — it is
+/// the one driving the mouse right now. Offering to save an untried geometry, in the
+/// hurry of a dialog standing between the user and leaving, is how a layout nobody
+/// wanted becomes the one that loads at the next boot.
+/// </para>
+/// <para>
+/// The wording differs by exit: closing the window keeps the edits (the layout lives
+/// on past the window, and comes back with it from the tray), quitting loses them.
+/// </para>
+/// </summary>
+public partial class UnsavedChangesDialog : Window
+{
+    UnsavedChoice _choice = UnsavedChoice.Cancel;
+
+    public UnsavedChangesDialog()
+    {
+        InitializeComponent();
+    }
+
+    void OnCancelClick(object? sender, RoutedEventArgs e) => Close();
+
+    void OnContinueClick(object? sender, RoutedEventArgs e)
+    {
+        _choice = UnsavedChoice.Continue;
+        Close();
+    }
+
+    void OnSaveClick(object? sender, RoutedEventArgs e)
+    {
+        _choice = UnsavedChoice.Save;
+        Close();
+    }
+
+    /// <param name="leaving">
+    /// True when LittleBigMouse is exiting rather than just closing its window. It
+    /// decides both the warning and the wording of the third button, because it decides
+    /// whether the edits survive.
+    /// </param>
+    /// <param name="canSave">
+    /// Live update is running, so the layout has been tried and saving it is saving
+    /// something known.
+    /// </param>
+    public static Task<UnsavedChoice> ShowAsync(Window? owner, bool leaving, bool canSave)
+    {
+        var dialog = new UnsavedChangesDialog();
+
+        dialog.BodyText.Text = leaving
+            ? "Your changes to the layout will be lost. The mouse engine keeps the layout you last applied."
+            : "Your changes stay in LittleBigMouse and come back with the window, but they are not saved: they are lost if LittleBigMouse exits or the computer restarts. The mouse engine keeps the layout you last applied.";
+
+        dialog.ContinueButton.Content = leaving ? "Lose changes" : "Keep unsaved";
+
+        dialog.SaveButton.IsVisible = canSave;
+        dialog.SaveNote.IsVisible = canSave;
+        // Nothing to default to when there is nothing safe to recommend: leaving is a
+        // choice the user has to make, not one to fall into by pressing Enter.
+        if (!canSave) dialog.ContinueButton.IsDefault = true;
+
+        return dialog.ShowChoiceAsync(owner);
+    }
+
+    async Task<UnsavedChoice> ShowChoiceAsync(Window? owner)
+    {
+        if (owner != null)
+        {
+            await ShowDialog(owner);
+        }
+        else
+        {
+            // Quitting from the tray with no window open: nothing to be modal to.
+            var closed = new TaskCompletionSource();
+            Closed += (_, _) => closed.TrySetResult();
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            Topmost = true;
+            Show();
+            await closed.Task;
+        }
+
+        return _choice;
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -39,6 +39,7 @@ using HLab.UserNotification;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.DisplayLayout.Monitors.Extensions;
 using LittleBigMouse.Plugins;
+using LittleBigMouse.Ui.Avalonia.Controls;
 using LittleBigMouse.Ui.Avalonia.Options;
 using LittleBigMouse.Platform.Windows;
 using LittleBigMouse.Ui.Avalonia.Remote;
@@ -222,11 +223,60 @@ public class MainService : ReactiveModel, IMainService
 
         _mainWindow.Closed += (s, a) => _mainWindow = null!;
 
+        // Closing the window is not leaving — the layout lives on the service and comes
+        // back with the window — but it is the gesture that reads as "done", and the
+        // moment to say the configuration was never saved. Closing has to be cancelled
+        // to ask, then repeated once answered.
+        var closeConfirmed = false;
+        _mainWindow.Closing += async (s, e) =>
+        {
+            if (closeConfirmed || s is not Window window) return;
+
+            e.Cancel = true;
+            if (!await ConfirmLeavingAsync(window, leaving: false)) return;
+
+            closeConfirmed = true;
+            window.Close();
+        };
+
         _mainWindow.Show();
 
         return Task.CompletedTask;
     }
 
+
+    /// <inheritdoc/>
+    public bool LivePreview { get; set; }
+
+    /// <summary>
+    /// Is there anything to lose? The layout carries the flag for its whole subtree, so
+    /// this is the same question the Save button answers.
+    /// </summary>
+    bool HasUnsavedLayout => MonitorsLayout is { IsVirtual: false, Saved: false };
+
+    /// <summary>
+    /// Stand between the user and leaving, but only when leaving costs something.
+    /// Returns false when they chose to stay.
+    /// </summary>
+    async Task<bool> ConfirmLeavingAsync(Window? owner, bool leaving)
+    {
+        if (!HasUnsavedLayout) return true;
+
+        var choice = await UnsavedChangesDialog.ShowAsync(owner, leaving, canSave: LivePreview);
+
+        switch (choice)
+        {
+            case UnsavedChoice.Cancel:
+                return false;
+            case UnsavedChoice.Save:
+                // Only reachable under live update, so this writes the geometry that is
+                // driving the mouse at this moment — never one nobody has tried.
+                await Task.Run(() => _layoutPersistence.Save((MonitorsLayout)MonitorsLayout));
+                return true;
+            default:
+                return true;
+        }
+    }
 
     public async Task StartNotifierAsync()
     {
@@ -279,6 +329,9 @@ public class MainService : ReactiveModel, IMainService
 
     async Task QuitAsync()
     {
+        // The one place the edits are actually lost.
+        if (!await ConfirmLeavingAsync(_mainWindow, leaving: true)) return;
+
         // TODO : it should not append by sometimes the QuitAsync does not return
         var t = Task.Delay(5000).ContinueWith(t => Dispatcher.UIThread.BeginInvokeShutdown(DispatcherPriority.Normal));
         await _littleBigMouseClientService.QuitAsync();

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml
@@ -248,7 +248,7 @@
 						</StackPanel>
 					</Border>
 
-					<Border Classes="SettingCard">
+					<Border Classes="SettingCard" IsVisible="{Binding RescueShortcutSupported}">
 						<StackPanel>
 							<controls:SettingRow Icon="{StaticResource Lbm.Icon.Shield}"
 							                     Header="Rescue shortcut"

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LbmOptionsViewModel.cs
@@ -93,6 +93,8 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         // Clearing the warning here makes it a fresh attempt: whatever comes back is
         // about the combination now being asked for.
         this.WhenAnyValue(e => e.Model.RescueShortcut)
+            // Nothing registers it off Windows, so nothing needs telling.
+            .Where(_ => RescueShortcutSupported)
             .Where(shortcut => !string.IsNullOrWhiteSpace(shortcut))
             .DistinctUntilChanged()
             .Subscribe(shortcut =>
@@ -116,6 +118,15 @@ public class LbmOptionsViewModel : ViewModel<ILayoutOptions>
         Dispatcher.UIThread.Post(() => ShortcutWarning =
             $"{e.Payload} is already taken by another application — the rescue shortcut is NOT active.");
     }
+
+    /// <summary>
+    /// Whether there is a rescue shortcut to configure. Windows only for now: the
+    /// daemon registers it with RegisterHotKey, and Wayland has no global shortcut
+    /// without a portal — reading one from evdev would mean opening the keyboard
+    /// devices, which is the keylogging surface the design avoids. Hidden rather than
+    /// shown dead, so a Linux build has nothing that looks broken.
+    /// </summary>
+    public bool RescueShortcutSupported => OperatingSystem.IsWindows();
 
     /// <summary>Empty while the rescue shortcut is registered and working.</summary>
     public string ShortcutWarning

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ and press the one you want. If another application already owns that combination
 setting says so — a rescue you only discover is missing when you need it would be worse
 than none.
 
-Windows only for now. Wayland has no global shortcut without a portal, and reading one
-from evdev would mean opening the keyboard devices, which is a great deal more than a
-mouse utility should ask for.
+Windows only for now — the setting is not shown elsewhere. Wayland has no global
+shortcut without a portal, and reading one from evdev would mean opening the keyboard
+devices, which is a great deal more than a mouse utility should ask for.
 
 ## Support
 


### PR DESCRIPTION
Nothing stood between a user and losing their edits. Closing the window or quitting with an unsaved layout now asks first: **Cancel**, **Save**, or leave.

## Save is not always on offer

It appears **only while live update is running**, because that is the only state in which the layout has actually been felt — it is the one driving the mouse at that moment.

Offering to save an untried geometry, in the hurry of a dialog standing between someone and leaving, is how a layout nobody wanted becomes the one that loads at the next boot. Without live update the choice is Cancel or leave, and "leave" is what Enter falls on: there is nothing safe to recommend.

## The two exits are not the same thing

| | third button | why |
|---|---|---|
| Closing the window | **Keep unsaved** | The layout belongs to the service, not the window: the edits come back with it from the tray. Lost only if LittleBigMouse exits or the machine restarts. |
| Quitting | **Lose changes** | This is the one place the edits actually go. |

Closing cannot wait on an answer, so it is cancelled, the question asked, and the close repeated once answered.

`IMainService` gains `LivePreview`, set by the control that owns the switch — the one thing the service lacked to decide what to offer on the way out.

## Tests

129 + 105 + 60 + 5 managed, 56 Rust, unchanged. The dialog itself is behaviour a human has to see; the decision it encodes (what is offered, and what the buttons say) is the part worth reading in the diff.