### PR TITLE
Keep the offsets when placing monitors from the system layout

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/ForceCompactTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/ForceCompactTests.cs
@@ -163,11 +163,22 @@ public class ForceCompactTests
         layout.UpdatePhysicalMonitors();
         layout.SetLocationsFromSystemConfiguration();
 
-        // P | S | H side by side, bottom-aligned like their pixel bounds.
+        // P | S | H side by side.
         Assert.Equal(700, middle.DepthProjection.X, 2);
         Assert.Equal(1400, tv.DepthProjection.X, 2);
+
+        // S has P's pitch, so sharing the same pixel rows puts it at the same height.
         Assert.Equal(400, middle.DepthProjection.Bounds.Bottom, 2);
-        Assert.Equal(400, tv.DepthProjection.Bounds.Bottom, 2);
+
+        // The TV does not, and it used to be asserted bottom-aligned with the others.
+        // That was arbitrary: the three span identical pixel rows, so their tops match
+        // exactly as much as their bottoms do, and a 920mm panel cannot have both. It
+        // was also not reversible — pushing that arrangement back through
+        // PixelLocationSolver did not return these pixel bounds. It is now centred on
+        // what it shares with its neighbour, which is the rule the solver inverts:
+        // 460mm of TV either side of the 200mm midpoint of S.
+        Assert.Equal(200, middle.DepthProjection.Bounds.Y + middle.DepthProjection.Bounds.Height / 2, 2);
+        Assert.Equal(200, tv.DepthProjection.Bounds.Y + tv.DepthProjection.Bounds.Height / 2, 2);
     }
 
     [Fact]

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PlaceFromSystemTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PlaceFromSystemTests.cs
@@ -1,0 +1,225 @@
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.DisplayLayout.Monitors.Extensions;
+using Xunit.Abstractions;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// Placing monitors from the system's pixel configuration.
+/// <para>
+/// Two ways in, and they had better agree: a first run with nothing stored places
+/// everything from scratch, and the "Place from windows config" menu item does the
+/// same thing on demand. A user who does not recognize their desktop on first launch,
+/// clicks the button, and gets something better has been shown a worse answer for no
+/// reason they can see.
+/// </para>
+/// </summary>
+public class PlaceFromSystemTests(ITestOutputHelper output)
+{
+    static PhysicalMonitor AddMonitor(MonitorsLayout layout, string id,
+        double widthMm, double heightMm,
+        double pixelX, double pixelY, double pixelWidth, double pixelHeight,
+        bool primary = false)
+    {
+        var model = new PhysicalMonitorModel($"PNP_{id}");
+        model.PhysicalSize.Width = widthMm;
+        model.PhysicalSize.Height = heightMm;
+        model.PhysicalSize.LeftBorder = 0;
+        model.PhysicalSize.TopBorder = 0;
+        model.PhysicalSize.RightBorder = 0;
+        model.PhysicalSize.BottomBorder = 0;
+
+        var monitor = new PhysicalMonitor(id, layout, model);
+        var source = new DisplaySource($"{id}-src") { AttachedToDesktop = true, Primary = primary };
+        source.InPixel.Set(new Rect(new Point(pixelX, pixelY), new Size(pixelWidth, pixelHeight)));
+
+        var physicalSource = new PhysicalSource($"{id}-dev", monitor, source);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        layout.AddOrUpdatePhysicalSource(physicalSource);
+        return monitor;
+    }
+
+    /// <summary>
+    /// Three monitors side by side in pixels, of different sizes and DPI — the shape
+    /// LittleBigMouse exists for. Every monitor starts where a freshly built layout
+    /// starts them: at the origin, stacked.
+    /// </summary>
+    static MonitorsLayout ThreeInARow()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        AddMonitor(layout, "LEFT", 520, 320, -1920, 0, 1920, 1080);
+        AddMonitor(layout, "MAIN", 600, 340, 0, 0, 2560, 1440, primary: true);
+        AddMonitor(layout, "RIGHT", 700, 400, 2560, 0, 1920, 1080);
+        return layout;
+    }
+
+    static string Describe(MonitorsLayout layout) => string.Join(" | ",
+        layout.PhysicalMonitors
+            .OrderBy(m => m.Id)
+            .Select(m => $"{m.Id}@({m.DepthProjection.X:F1},{m.DepthProjection.Y:F1})"));
+
+    /// <summary>
+    /// A real desktop, read off the machine this was written on: two 1440p panels side
+    /// by side with the second hanging 219 px lower, and a 1280x720 TV — big and
+    /// coarse — to their right. The vertical offset is what a row of top-aligned test
+    /// monitors never exercises, and it is the ordinary case: nobody bolts their
+    /// screens to a shelf.
+    /// </summary>
+    static MonitorsLayout RealDesktop()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        AddMonitor(layout, "MAIN", 600, 340, 0, 0, 2560, 1440, primary: true);
+        AddMonitor(layout, "SIDE", 600, 340, 2560, -219, 2560, 1440);
+        AddMonitor(layout, "TV", 1650, 920, 5120, 0, 1280, 720);
+        return layout;
+    }
+
+    [Fact]
+    public void PlacingTwiceLandsWherePlacingOnceDid_OnARealDesktop()
+    {
+        var layout = RealDesktop();
+
+        layout.SetLocationsFromSystemConfiguration();
+        var once = Describe(layout);
+        output.WriteLine($"once:  {once}");
+
+        layout.SetLocationsFromSystemConfiguration();
+        var twice = Describe(layout);
+        output.WriteLine($"twice: {twice}");
+
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void ARealDesktopKeepsItsOrderAndItsOffset()
+    {
+        var layout = RealDesktop();
+        layout.SetLocationsFromSystemConfiguration();
+        output.WriteLine(Describe(layout));
+
+        var main = layout.PhysicalMonitors.Single(m => m.Id == "MAIN");
+        var side = layout.PhysicalMonitors.Single(m => m.Id == "SIDE");
+        var tv = layout.PhysicalMonitors.Single(m => m.Id == "TV");
+
+        Assert.True(main.DepthProjection.X < side.DepthProjection.X, $"MAIN left of SIDE: {Describe(layout)}");
+        Assert.True(side.DepthProjection.X < tv.DepthProjection.X, $"SIDE left of TV: {Describe(layout)}");
+
+        // SIDE's top edge is 219 px above MAIN's (Windows Y grows downward). On a panel
+        // 1440 px tall and 340 mm high that is 219 * 340 / 1440 = 51.7 mm up — the two
+        // screens still overlap over most of their height. Anything near a full screen
+        // height means the offset was not carried across at all.
+        var expected = -219.0 * 340.0 / 1440.0;
+        var actual = side.DepthProjection.Y - main.DepthProjection.Y;
+        output.WriteLine($"offset: expected {expected:F1} mm, got {actual:F1} mm");
+
+        Assert.True(Math.Abs(actual - expected) < 5.0,
+            $"SIDE sits {actual:F1} mm from MAIN, expected {expected:F1} mm: {Describe(layout)}");
+    }
+
+    /// <summary>
+    /// The property the perpendicular rule exists for: place from the system, push the
+    /// result back to the system, and land on the pixel configuration you started from.
+    /// <para>
+    /// Without it the two directions disagreed, so every pass through the pair moved the
+    /// desktop a little further from where it began.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void PlacingFromTheSystemAndBackIsANoOp()
+    {
+        var layout = RealDesktop();
+        layout.SetLocationsFromSystemConfiguration();
+        output.WriteLine(Describe(layout));
+
+        var solved = PixelLocationSolver.Solve(
+            [.. layout.PhysicalMonitors.Select(m => new PixelPlacementMonitor(
+                m.Id,
+                m.DepthProjection.Bounds,
+                m.DepthProjection.OutsideBounds,
+                new Size(m.ActiveSource.Source.InPixel.Bounds.Width, m.ActiveSource.Source.InPixel.Bounds.Height),
+                m.ActiveSource.Source.Primary))]);
+
+        // Both sides are anchored on the primary, so compare against the system's own
+        // pixel positions relative to it.
+        var primaryPx = layout.PhysicalMonitors
+            .Single(m => m.ActiveSource.Source.Primary).ActiveSource.Source.InPixel.Bounds;
+
+        foreach (var monitor in layout.PhysicalMonitors)
+        {
+            var px = monitor.ActiveSource.Source.InPixel.Bounds;
+            var expected = new Point(px.X - primaryPx.X, px.Y - primaryPx.Y);
+            var actual = solved[monitor.Id];
+            output.WriteLine($"{monitor.Id}: system ({expected.X},{expected.Y}) -> solved ({actual.X},{actual.Y})");
+
+            Assert.True(Math.Abs(actual.X - expected.X) <= 1, $"{monitor.Id} X: {actual.X} vs {expected.X}");
+            Assert.True(Math.Abs(actual.Y - expected.Y) <= 1, $"{monitor.Id} Y: {actual.Y} vs {expected.Y}");
+        }
+    }
+
+    [Fact]
+    public void PlacingTwiceLandsWherePlacingOnceDid()
+    {
+        // The startup path places from scratch; the menu item places again over the
+        // result. Both call the same method, so the only way they can disagree is if
+        // the method's answer depends on where the monitors already were — and then
+        // "what you get on first launch" is not "what the button gives you".
+        var layout = ThreeInARow();
+
+        layout.SetLocationsFromSystemConfiguration();
+        var once = Describe(layout);
+        output.WriteLine($"once:  {once}");
+
+        layout.SetLocationsFromSystemConfiguration();
+        var twice = Describe(layout);
+        output.WriteLine($"twice: {twice}");
+
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void PlacingKeepsThePixelOrderOfTheDesktop()
+    {
+        // Whatever the millimetre widths, three monitors laid out left to right in the
+        // system must come out left to right here. This is the weakest possible reading
+        // of "matches the Windows configuration", and the one a user checks first.
+        var layout = ThreeInARow();
+
+        layout.SetLocationsFromSystemConfiguration();
+        output.WriteLine(Describe(layout));
+
+        var left = layout.PhysicalMonitors.Single(m => m.Id == "LEFT");
+        var main = layout.PhysicalMonitors.Single(m => m.Id == "MAIN");
+        var right = layout.PhysicalMonitors.Single(m => m.Id == "RIGHT");
+
+        Assert.True(left.DepthProjection.X < main.DepthProjection.X,
+            $"LEFT must stay left of MAIN: {Describe(layout)}");
+        Assert.True(main.DepthProjection.X < right.DepthProjection.X,
+            $"MAIN must stay left of RIGHT: {Describe(layout)}");
+    }
+
+    [Fact]
+    public void PlacingLeavesNoOverlapAndNoGap()
+    {
+        // Monitors adjacent in pixels are adjacent in millimetres: edge to edge, which
+        // is the whole point of deriving the physical layout from the system one.
+        var layout = ThreeInARow();
+
+        layout.SetLocationsFromSystemConfiguration();
+        output.WriteLine(Describe(layout));
+
+        var ordered = layout.PhysicalMonitors.OrderBy(m => m.DepthProjection.X).ToList();
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            var previous = ordered[i - 1].DepthProjection.OutsideBounds;
+            var current = ordered[i].DepthProjection.OutsideBounds;
+            Assert.True(Math.Abs(current.Left - previous.Right) < 0.001,
+                $"{ordered[i].Id} should touch {ordered[i - 1].Id}: {Describe(layout)}");
+        }
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
@@ -91,6 +91,11 @@ public static class MonitorsLocationsFromSystemExtensions
                     // adjacency rule tested (e.g. P|S|H side by side: H aligned on P
                     // by Y equality used to be swallowed before S could claim it).
                     var adjacent = false;
+                    // Which axis the contact is on. The other one is not a matter of
+                    // luck: it is computed below, and must not be left to whichever
+                    // alignment equality happens to hold.
+                    var horizontalContact = false;
+                    var verticalContact = false;
 
                     //     __
                     //  __| A
@@ -100,6 +105,7 @@ public static class MonitorsLocationsFromSystemExtensions
                     {
                         screenToPlace.DepthProjection.X = placedScreen.DepthProjection.OutsideBounds.Right + screenToPlace.DepthProjection.LeftBorder;
                         adjacent = true;
+                        horizontalContact = true;
                     }
                     //B |___|_
                     //A  |    |
@@ -107,6 +113,7 @@ public static class MonitorsLocationsFromSystemExtensions
                     {
                         screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.OutsideBounds.Bottom + screenToPlace.DepthProjection.TopBorder;
                         adjacent = true;
+                        verticalContact = true;
                     }
 
                     //     __
@@ -118,6 +125,7 @@ public static class MonitorsLocationsFromSystemExtensions
                         screenToPlace.DepthProjection.X = placedScreen.DepthProjection.OutsideBounds.Left -
                             screenToPlace.DepthProjection.OutsideBounds.Width + screenToPlace.DepthProjection.LeftBorder;
                         adjacent = true;
+                        horizontalContact = true;
                     }
 
                     //A |___|_
@@ -128,6 +136,7 @@ public static class MonitorsLocationsFromSystemExtensions
                         screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.OutsideBounds.Top -
                             screenToPlace.DepthProjection.OutsideBounds.Height + screenToPlace.DepthProjection.TopBorder;
                         adjacent = true;
+                        verticalContact = true;
                     }
 
 
@@ -166,10 +175,24 @@ public static class MonitorsLocationsFromSystemExtensions
                         screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.Bounds.Bottom -
                                                screenToPlace.DepthProjection.Bounds.Height;
                     }
+                    // The offset along the contact edge. Last, so it overrides the
+                    // alignment equalities above: those only fire on an exact match, and
+                    // a monitor sitting 219px higher than its neighbour matches none of
+                    // them — it used to keep whatever it had and be shoved by the
+                    // compact, landing a whole screen height away.
+                    if (horizontalContact) PlaceAlongEdge(placedScreen, screenToPlace, vertical: true);
+                    if (verticalContact) PlaceAlongEdge(placedScreen, screenToPlace, vertical: false);
+
                     if (adjacent)
                     {
                         unplacedScreens.Remove(screenToPlace);
-                        layout.ForceCompact();
+                        // No compacting here. Every monitor not yet reached is still
+                        // stacked at the origin, so a compact run mid-walk resolves
+                        // overlaps against screens that have no position yet — and shoves
+                        // the ones just placed correctly out of the way. It is why
+                        // running this twice used to give a better answer than running it
+                        // once: the second pass started from a layout that was already
+                        // spread out, so the same compacts found nothing to do.
                         todo.Enqueue(screenToPlace);
                     }
                 }
@@ -181,5 +204,76 @@ public static class MonitorsLocationsFromSystemExtensions
         }
 
         layout.UpdatePhysicalMonitors();
+    }
+
+    /// <summary>
+    /// Position <paramref name="toPlace"/> along the edge it shares with
+    /// <paramref name="placed"/> — the axis the contact is not on.
+    /// <para>
+    /// Exactly the inverse of <see cref="PixelLocationSolver"/>'s rule, and deliberately
+    /// so: there, the physical midpoint of the shared span projects to the same pixel on
+    /// both monitors. Here the same invariant is solved the other way round, which is
+    /// what makes "apply to system" and "place from system" round-trip instead of
+    /// drifting a little further apart on each pass.
+    /// </para>
+    /// <para>
+    /// The midpoint is taken in MILLIMETRE space, as the inverse takes it, and that
+    /// makes it implicit: the shared span depends on the position being solved for. It
+    /// is settled by iterating from a pixel-space estimate — the overlap only shifts
+    /// when one monitor's span stops covering the other's end, so a couple of passes
+    /// reach the fixed point and further ones change nothing. Taking the pixel midpoint
+    /// instead is closed-form and tempting, and it round-trips perfectly right up until
+    /// two monitors have very different pitches, which is the case this whole file
+    /// exists for.
+    /// </para>
+    /// </summary>
+    static void PlaceAlongEdge(PhysicalMonitor placed, PhysicalMonitor toPlace, bool vertical)
+    {
+        var placedPx = placed.ActiveSource.Source.InPixel.Bounds;
+        var toPlacePx = toPlace.ActiveSource.Source.InPixel.Bounds;
+
+        // Pixels map to the panel, not to the bezel around it.
+        var placedMm = placed.DepthProjection.Bounds;
+        var toPlaceMm = toPlace.DepthProjection.Bounds;
+
+        var (placedPxLo, placedPxSize) = vertical
+            ? (placedPx.Y, placedPx.Height)
+            : (placedPx.X, placedPx.Width);
+        var (toPlacePxLo, toPlacePxSize) = vertical
+            ? (toPlacePx.Y, toPlacePx.Height)
+            : (toPlacePx.X, toPlacePx.Width);
+        var (placedMmLo, placedMmSize) = vertical
+            ? (placedMm.Y, placedMm.Height)
+            : (placedMm.X, placedMm.Width);
+        var toPlaceMmSize = vertical ? toPlaceMm.Height : toPlaceMm.Width;
+
+        // A monitor reporting no pixels has nothing to be proportional to.
+        if (placedPxSize <= 0 || toPlacePxSize <= 0) return;
+
+        var pitchPlaced = placedMmSize / placedPxSize;
+        var pitchToPlace = toPlaceMmSize / toPlacePxSize;
+
+        // Seed from the pixel-space midpoint: always defined, and already the answer
+        // whenever the two spans cover each other.
+        var sharedPxLo = Math.Max(placedPxLo, toPlacePxLo);
+        var sharedPxHi = Math.Min(placedPxLo + placedPxSize, toPlacePxLo + toPlacePxSize);
+        var midPx = (sharedPxLo + sharedPxHi) / 2;
+        var mm = placedMmLo
+                 + (midPx - placedPxLo) * pitchPlaced
+                 - (midPx - toPlacePxLo) * pitchToPlace;
+
+        // Then settle on the millimetre-space midpoint, which is what the inverse uses.
+        // Four passes: the overlap can only change while the estimate crosses a span
+        // end, and each pass fixes the estimate that follows from the current one.
+        for (var pass = 0; pass < 4; pass++)
+        {
+            var mid = (Math.Max(placedMmLo, mm) + Math.Min(placedMmLo + placedMmSize, mm + toPlaceMmSize)) / 2;
+            var next = mid - pitchToPlace * (placedPxLo - toPlacePxLo + (mid - placedMmLo) / pitchPlaced);
+            if (Math.Abs(next - mm) < 1e-9) break;
+            mm = next;
+        }
+
+        if (vertical) toPlace.DepthProjection.Y = mm;
+        else toPlace.DepthProjection.X = mm;
     }
 }


### PR DESCRIPTION
Two monitors side by side with the second hanging 219 px higher came out **stacked a whole screen height apart**. Two separate faults, and between them they are why the first layout a user is shown never matched what *Place from windows config* gave them a moment later.

Measured on a real desktop — two 1440p panels, the second 219 px up, and a 1280×720 TV:

| | before | after |
|---|---|---|
| second panel | −340.0 mm (a full screen height: stacked above) | −51.7 mm |

`219 × 340 / 1440 = 51.7` is the answer.

## The offset was never computed

The placement rules only ever recognised **exact equalities** — edge against edge, or tops/bottoms matching to the pixel. A monitor adjacent on one axis but offset by an arbitrary amount on the other matched the adjacency rule and none of the alignment ones, so it kept whatever coordinate it happened to have and the compact pass shoved it somewhere.

## ForceCompact ran inside the walk

Every monitor not yet reached is still stacked at the origin, so compacting mid-walk resolves overlaps against screens that have no position yet — and pushes the ones just placed correctly out of the way.

That is the whole of why running the placement twice gave a better answer than running it once: the second pass started from a layout already spread out, so the same compacts found nothing to do. **The button was never better than the startup path; it just ran second.** One compact at the end, which is what catches monitors with no adjacency at all.

## The rule, and a wrong turn worth recording

The new perpendicular rule is the exact inverse of `PixelLocationSolver`: the physical midpoint of the shared span projects to the same pixel on both monitors. So *apply to system* and *place from system* round-trip instead of drifting further apart on each pass — asserted on the real desktop:

```
MAIN: system (0,0)       -> solved (0,0)
SIDE: system (2560,-219) -> solved (2560,-219)
TV:   system (5120,0)    -> solved (5120,-0)
```

Taking that midpoint in **pixel** space is closed-form and tempting, and it round-trips perfectly until two monitors have very different pitches — which is the case this file exists for. The TV drifted 115 px. In **millimetre** space, as the inverse takes it, the shared span depends on the position being solved for; it is settled by iterating from the pixel-space estimate, which is already the answer whenever the two spans cover each other.

## One existing assertion changed

`SystemPlacement_SideBySidePixels_StaysSideBySideInMm` wanted three monitors bottom-aligned while spanning identical pixel rows. Their tops match exactly as much as their bottoms do, and a 920 mm panel cannot have both — the choice was arbitrary, and that arrangement did not survive a round trip. The TV is now centred on what it shares with its neighbour.

## Tests

Six new (`PlaceFromSystemTests`): the offset itself, placing twice landing where placing once did — on a simple row and on the real desktop — pixel order, contact, and the round trip. 111 in the DisplayLayout suite; 129 + 60 + 5 elsewhere, 56 Rust.