### PR TITLE
Avalonia 12.1.1

### DIFF
--- a/HLab.Sys/HLab.Sys.Argyll/HLab.Sys.Argyll.csproj
+++ b/HLab.Sys/HLab.Sys.Argyll/HLab.Sys.Argyll.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Avalonia" Version="12.1.0" />
+	  <PackageReference Include="Avalonia" Version="12.1.1" />
 	  <PackageReference Include="ReactiveUI" Version="23.2.28" />
   </ItemGroup>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
@@ -49,8 +49,8 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="8.0.0-preview.7.23375.6" />


### PR DESCRIPTION
> **Needs mgth/HLab.Avalonia#4 — merge together.** The submodule pointer here moves to a commit that only exists on that branch.

Taken now rather than at the next release, so it gets a whole cycle of use before it ships to anyone. Builds clean, all four suites pass, the app runs.

## What is in it

**Popups now position on the screen containing their anchor point** ([#21750](https://github.com/AvaloniaUI/Avalonia/pull/21750)) — for a tool whose entire subject is multi-monitor geometry, that is the change to keep an eye on. Plus custom hit-test, `Grid`, `ComboBox`, `ListBox` and `TextBox` fixes.

**`ToolTip.ShouldUseOverlayLayer`** ([#21830](https://github.com/AvaloniaUI/Avalonia/pull/21830)) renders a tooltip inside its parent window instead of a top-level of its own. When #528 went in, the answer to "can a tooltip be made not to swallow clicks?" was no — verified against 12.1.0's API surface, where nothing on `ToolTip` touches hit testing. Two days later 12.1.1 shipped exactly that knob: with no separate window, there is no window for the OS to route the click to.

The placement and 700 ms delay put in for #528 stay as they are here. They work, and swapping a working fix for an untried one on the same branch as a dependency bump would muddle what is being tested. Worth trying on top once this has settled.

## Not bumped

`Avalonia.Controls.DataGrid` stays at 12.1.0 — it publishes on its own cadence, has no 12.1.1, and asks for `Avalonia >= 12.1.0`, which 12.1.1 satisfies. It is pulled transitively by half the plugin projects, so bumping it blindly fails the restore.

The `HLab.Localization.Avalonia2` and `HLab.Notify.Avalonia` projects still sit on 11.x and are untouched: neither is in the solution.

## Tests

111 + 129 + 60 + 5 managed, 56 Rust.