### PR TITLE
displays: converge key-name decoding on the fixed WinReg helper

### DIFF
--- a/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/Factory/MonitorDeviceHelper.cs
@@ -2,7 +2,6 @@
 using HLab.Sys.Monitors;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -599,7 +598,7 @@ public static class MonitorDeviceHelper
 
                 try
                 {
-                    var hKeyName = GetRegistryKeyName(hEdidRegKey);
+                    var hKeyName = GetHKeyName(hEdidRegKey);
                     if (string.IsNullOrEmpty(hKeyName)) continue;
 
                     using var key = RegistryKey(hKeyName, 1);
@@ -634,43 +633,6 @@ public static class MonitorDeviceHelper
         }
 
         return null;
-    }
-
-    static string GetRegistryKeyName(nint hKey)
-    {
-        var status = Wdm.ZwQueryKey(hKey, Wdm.KeyInformationClass.KeyNameInformation,
-            0, 0, out var needed);
-        if (status == 0 || needed < sizeof(uint)) return string.Empty;
-
-        var buffer = Marshal.AllocHGlobal(needed);
-        try
-        {
-            var capacity = needed;
-            status = Wdm.ZwQueryKey(hKey, Wdm.KeyInformationClass.KeyNameInformation,
-                buffer, capacity, out var returned);
-            if (status != 0 || returned < sizeof(uint) || returned > capacity)
-                return string.Empty;
-
-            var bytes = new byte[returned];
-            Marshal.Copy(buffer, bytes, 0, returned);
-            return DecodeKeyNameInformation(bytes);
-        }
-        finally
-        {
-            Marshal.FreeHGlobal(buffer);
-        }
-    }
-
-    /// <summary>Decode byte-counted KEY_NAME_INFORMATION without unmanaged over-read.</summary>
-    public static string DecodeKeyNameInformation(ReadOnlySpan<byte> buffer)
-    {
-        if (buffer.Length < sizeof(uint)) return string.Empty;
-        var nameLength = BitConverter.ToUInt32(buffer[..sizeof(uint)]);
-        if ((nameLength & 1) != 0 || nameLength > buffer.Length - sizeof(uint))
-            throw new InvalidDataException("Invalid KEY_NAME_INFORMATION byte length.");
-
-        return Encoding.Unicode.GetString(
-            buffer.Slice(sizeof(uint), checked((int)nameLength)));
     }
 
     /// <summary>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/WindowsMonitorSafetyTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/WindowsMonitorSafetyTests.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using HLab.Geo;
+using HLab.Sys.Windows.API;
 using HLab.Sys.Windows.Monitors;
-using HLab.Sys.Windows.Monitors.Factory;
 using LittleBigMouse.DisplayLayout.Dimensions;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Platform.Windows;
@@ -20,10 +20,10 @@ public class WindowsMonitorSafetyTests
         BitConverter.TryWriteBytes(data.AsSpan(), (uint)name.Length);
         name.CopyTo(data, sizeof(uint));
 
-        Assert.Equal(path, MonitorDeviceHelper.DecodeKeyNameInformation(data));
+        Assert.Equal(path, WinReg.DecodeKeyNameInformation(data));
 
         BitConverter.TryWriteBytes(data.AsSpan(), (uint)(name.Length + 2));
-        Assert.Throws<InvalidDataException>(() => MonitorDeviceHelper.DecodeKeyNameInformation(data));
+        Assert.Throws<InvalidDataException>(() => WinReg.DecodeKeyNameInformation(data));
     }
 
     [Fact]


### PR DESCRIPTION
Supprime le doublon local de décodage de nom de clé de registre dans `MonitorDeviceHelper`, en convergeant sur le helper durci de `HLab.Core` (`WinReg.GetHKeyName` / `WinReg.DecodeKeyNameInformation`).

Le décodage borné de `KEY_NAME_INFORMATION` issu de la revue de #513 vit désormais dans HLab.Core, donc tous les appelants de `RegistryKey(nint)` bénéficient du correctif, pas seulement `GetEdid`.

### Détails

- `MonitorDeviceHelper.GetEdid` appelle `GetHKeyName` (résolu via le `using static ...WinReg;` déjà présent).
- Les 39 lignes du doublon local (`GetRegistryKeyName` + `DecodeKeyNameInformation`) sont supprimées.
- `WindowsMonitorSafetyTests` pointe sur `WinReg.DecodeKeyNameInformation`.
- Deux `using` devenus morts du fait de la suppression sont retirés (`System.IO`, `HLab.Sys.Windows.Monitors.Factory`).

**Pas de bump de sous-module** : `HLab.Core` reste sur `7b6aeec`, qui contient déjà le helper.

### Différence de comportement à noter

La version partagée est plus stricte sur la passe de dimensionnement : elle exige `STATUS_BUFFER_TOO_SMALL` (0xC0000023) là où le doublon local se contentait de `status != 0` avant d'allouer. C'est un durcissement, pas une simple déduplication.

### Vérification

- `dotnet build LittleBigMouse-Linux.slnf` : 0 erreur (avertissements préexistants uniquement).
- `dotnet test LittleBigMouse.DisplayLayout.Tests` : 111/111 réussis.

Le code touché est Windows-only à l'exécution ; la compilation croisée et le test unitaire de décodage sont la couverture maximale possible sur Linux — le chemin `ZwQueryKey` lui-même n'est pas exercé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)