### PR TITLE
Revise warning about littlebigmouse.com affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > ## 🌐 New: [littlebigmouse.mgth.fr](https://littlebigmouse.mgth.fr/) — the official website
 > Little Big Mouse now has a home of its own: **[littlebigmouse.mgth.fr](https://littlebigmouse.mgth.fr/)** — what it does, downloads, and guides, always in sync with this repository.
 >
-> ⚠️ Please note that **littlebigmouse.com is not affiliated with this project**. We don't operate that site, don't know who does, and can't vouch for anything it publishes. The only official sources for Little Big Mouse are this repository — with its [Releases](https://github.com/mgth/LittleBigMouse/releases) page — and [littlebigmouse.mgth.fr](https://littlebigmouse.mgth.fr/).
+> ⚠️ Warning! Note that **littlebigmouse.com is not affiliated with this project**. It is used to distribute malware. We don't operate that site, don't know who does, and can't vouch for anything it publishes. The only official sources for Little Big Mouse are this repository — with its [Releases](https://github.com/mgth/LittleBigMouse/releases) page — and [littlebigmouse.mgth.fr](https://littlebigmouse.mgth.fr/).
 
 > [!TIP]
 > ## 🐧 New: Little Big Mouse is on the AUR


### PR DESCRIPTION
I accidentally downloaded what I thought was a LittleBigMouse installer from that website and it stole my discord credentials, using them to spam all my servers and also Facebook Messenger chats with Mr. Beast crypto scam links. Not sure if it makes a difference, but a stronger warning might save somebody else from my fate.