### PR TITLE
Sign Windows releases with SignPath Foundation

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -3,6 +3,11 @@
 #   a smoke test), upload a portable artifact.
 # - Tag v*: additionally publish the installer as an artifact and attach it to a
 #   draft GitHub release for manual review before publishing.
+#
+# Releases are Authenticode-signed by SignPath Foundation when the SignPath
+# variables are configured; see SIGNING.md. Until they are, the tag build keeps
+# drafting the unsigned release exactly as before, so merging this cannot strand a
+# release behind an approval that has not landed yet.
 
 name: Build
 
@@ -100,8 +105,25 @@ jobs:
         name: LittleBigMouse-installer
         path: LittleBigMouse.Setup\LittleBigMouse_*.exe
 
+    # Signing input for the release job below. Same exclusions as the portable:
+    # the linux/osx runtime folders are dead weight in a Windows installer and
+    # would only slow the round-trip to SignPath.
+    - name: Upload application for release signing
+      if: startsWith(github.ref, 'refs/tags/v') && vars.SIGNPATH_PROJECT_SLUG != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: LittleBigMouse-unsigned-win-x64
+        path: |
+          ${{ env.UI_OUTPUT }}
+          !${{ env.UI_OUTPUT }}\runtimes\linux*\**
+          !${{ env.UI_OUTPUT }}\runtimes\osx*\**
+        retention-days: 2
+
+    # Only drafts the unsigned installer while SignPath is not configured yet.
+    # Once the variables are set the signed release job below owns the draft, and
+    # this step stands down so a tag can never produce two drafts.
     - name: Create draft release
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v') && vars.SIGNPATH_PROJECT_SLUG == ''
       uses: softprops/action-gh-release@v2
       with:
         draft: true
@@ -115,3 +137,144 @@ jobs:
         # keep it when hand-editing the release body).
         body: |
           💜 If Little Big Mouse is useful to you, consider [sponsoring the project](https://github.com/sponsors/mgth).
+
+  # Windows 11 Smart App Control refuses unsigned installers outright, with no
+  # "run anyway" to click through (issue #535). Signing gives every release one
+  # stable publisher identity, which is what reputation actually accrues to.
+  #
+  # The installer has to be recompiled here rather than reusing the one the build
+  # job made: signing the setup .exe alone would leave the binaries *inside* it
+  # unsigned, and those are what Windows checks once they are on disk.
+  release:
+    name: Sign and draft release
+    if: startsWith(github.ref, 'refs/tags/v') && vars.SIGNPATH_PROJECT_SLUG != ''
+    needs: build
+    runs-on: windows-latest
+    permissions:
+      # SignPath reads the run's artifacts to fetch the signing input; the draft
+      # release needs write. Nothing else is granted.
+      actions: read
+      contents: write
+
+    steps:
+    - name: Checkout (with submodules)
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Derive version from tag
+      id: ver
+      run: |
+        $v = "${{ github.ref_name }}" -replace '^v',''
+        "version=$v" >> $env:GITHUB_OUTPUT
+
+    - name: Download unsigned application
+      uses: actions/download-artifact@v4
+      with:
+        name: LittleBigMouse-unsigned-win-x64
+        path: artifacts\unsigned-app
+
+    # Re-uploaded from this job because the SignPath action signs an artifact of
+    # the run it is invoked from, and needs its id.
+    - name: Upload application signing input
+      id: signing-input-app
+      uses: actions/upload-artifact@v4
+      with:
+        name: LittleBigMouse-signing-input-${{ github.run_id }}
+        path: artifacts\unsigned-app
+        retention-days: 2
+
+    - name: Sign application binaries
+      # Pinned by digest, not by tag: this is the one third-party action in the
+      # workflow, and the only step that is handed the signing token.
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: ${{ vars.SIGNPATH_APPLICATION_ARTIFACT_CONFIGURATION_SLUG }}
+        github-artifact-id: ${{ steps.signing-input-app.outputs.artifact-id }}
+        wait-for-completion: true
+        # The Foundation release policy gates on a human approving the request,
+        # and the action's 10-minute default expires long before that happens.
+        wait-for-completion-timeout-in-seconds: 3600
+        output-artifact-directory: artifacts\signed-app
+
+    # A signing request can come back "successful" having signed nothing that
+    # matters, so assert on the two executables Windows will actually judge.
+    - name: Verify signed binaries
+      id: signed
+      run: |
+        $ui = Get-ChildItem artifacts\signed-app -Recurse -Filter LittleBigMouse.Ui.Avalonia.exe | Select-Object -First 1
+        if (-not $ui) { throw 'SignPath returned no signed UI executable' }
+        $dir = $ui.Directory.FullName
+        foreach ($target in @($ui.FullName, (Join-Path $dir 'LittleBigMouse.Hook.exe'))) {
+          if (-not (Test-Path -LiteralPath $target)) { throw "Missing signed binary: $target" }
+          $sig = Get-AuthenticodeSignature -LiteralPath $target
+          if ($sig.Status -ne 'Valid') { throw "$target signature: $($sig.StatusMessage)" }
+          $publisher = $sig.SignerCertificate.GetNameInfo('SimpleName', $false)
+          if ($publisher -ne 'SignPath Foundation') { throw "$target signed by '$publisher'" }
+        }
+        "dir=$dir" >> $env:GITHUB_OUTPUT
+
+    - name: Compile installer from signed binaries
+      run: |
+        & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+          "/DAppVer=${{ steps.ver.outputs.version }}" `
+          "/DSourceDir=${{ steps.signed.outputs.dir }}" `
+          LittleBigMouse.Setup\LittleBigMouse.iss
+        Get-ChildItem LittleBigMouse.Setup\LittleBigMouse_*.exe | Select-Object Name, Length
+
+    - name: Upload installer signing input
+      id: signing-input-installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: LittleBigMouse-installer-signing-input-${{ github.run_id }}
+        path: LittleBigMouse.Setup\LittleBigMouse_*.exe
+        retention-days: 2
+
+    - name: Sign installer
+      # Pinned by digest, not by tag: this is the one third-party action in the
+      # workflow, and the only step that is handed the signing token.
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: ${{ vars.SIGNPATH_INSTALLER_ARTIFACT_CONFIGURATION_SLUG }}
+        github-artifact-id: ${{ steps.signing-input-installer.outputs.artifact-id }}
+        wait-for-completion: true
+        wait-for-completion-timeout-in-seconds: 3600
+        output-artifact-directory: artifacts\signed-installer
+
+    - name: Verify signed installer
+      run: |
+        $name = "LittleBigMouse_${{ steps.ver.outputs.version }}.exe"
+        $installer = Get-ChildItem artifacts\signed-installer -Recurse -Filter $name | Select-Object -First 1
+        if (-not $installer) { throw "SignPath returned no $name" }
+        $sig = Get-AuthenticodeSignature -LiteralPath $installer.FullName
+        if ($sig.Status -ne 'Valid') { throw "Installer signature: $($sig.StatusMessage)" }
+        $publisher = $sig.SignerCertificate.GetNameInfo('SimpleName', $false)
+        if ($publisher -ne 'SignPath Foundation') { throw "Installer signed by '$publisher'" }
+        New-Item artifacts\release -ItemType Directory -Force | Out-Null
+        Copy-Item $installer.FullName "artifacts\release\$name"
+
+    - name: Create draft release
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: true
+        # Bare numeric version, as in the unsigned path above.
+        name: ${{ steps.ver.outputs.version }}
+        # The installer and nothing else: the in-app updater downloads assets[0],
+        # so any extra asset sorting ahead of it (an SBOM, a checksum file) would
+        # be handed to every existing user as if it were the setup .exe.
+        files: artifacts\release\LittleBigMouse_*.exe
+        generate_release_notes: true
+        body: |
+          💜 If Little Big Mouse is useful to you, consider [sponsoring the project](https://github.com/sponsors/mgth).
+
+          The installer and the binaries it carries are Authenticode-signed by SignPath Foundation.
+
+          Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).

--- a/LittleBigMouse.Setup/LittleBigMouse.iss
+++ b/LittleBigMouse.Setup/LittleBigMouse.iss
@@ -1,9 +1,17 @@
 ﻿; -- LittleBigMouse.iss --
+; SourceDir is where the packaged binaries are read from. It defaults to the local
+; build output, so a manual compile keeps working unchanged; the release workflow
+; overrides it (ISCC /DSourceDir=...) to point at the binaries SignPath sent back,
+; because the installer has to carry the *signed* exe and dlls, not the build ones.
+#ifndef SourceDir
+  #define SourceDir "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0"
+#endif
+
 ; AppVer is normally passed by CI from the git tag (ISCC /DAppVer=5.3.0-beta.2)
 ; so betas are distinguishable in Programs & Features and in the installer name.
 ; Falls back to the built exe's numeric FileVersion for a manual local compile.
 #ifndef AppVer
-  #define AppVer GetVersionNumbersString('..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\LittleBigMouse.Ui.Avalonia.exe')
+  #define AppVer GetVersionNumbersString(SourceDir + '\LittleBigMouse.Ui.Avalonia.exe')
 #endif
 
 ; The hook daemon is staged into the UI output before the installer is compiled,
@@ -31,13 +39,13 @@ CloseApplications=force
 RestartApplications=no
 
 [Files]
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.dll"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
+Source: "{#SourceDir}\*.exe"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
+Source: "{#SourceDir}\*.dll"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
 ; No *.xml line here: the build output has not contained one since the Layout and
 ; Vcp plugins stopped copying their unused colors.xml, and ISCC aborts the compile
 ; on a wildcard that matches nothing. Add it back with the file, if one ever needs
 ; shipping again.
-Source: "..\LittleBigMouse.Ui\LittleBigMouse.Ui.Avalonia\bin\x64\Release\net10.0\*.json"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
+Source: "{#SourceDir}\*.json"; DestDir: "{app}"; Check: Is64BitInstallMode; Flags: recursesubdirs ignoreversion
 
 ;Source: "..\bin\x86\Release\net10.0\*.exe"; DestDir: "{app}"; Check: not Is64BitInstallMode
 ;Source: "..\bin\x86\Release\net10.0\*.dll"; DestDir: "{app}"; Check: not Is64BitInstallMode

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,51 @@
+# Privacy
+
+Little Big Mouse collects no analytics and sends no telemetry. There is no crash reporter, no usage reporting, and no server operated by this project. Everything the application knows about your displays, your pointer and your layout stays on your computer.
+
+## When it uses the network
+
+Three cases, all of them either initiated by you or announced here:
+
+- **Update check** (Windows only) — the application asks the public GitHub Releases API, `https://api.github.com/repos/Mgth/LittleBigMouse/releases`, whether a newer version exists. It sends no information about you or your machine beyond what any HTTP request reveals: your IP address and a `LittleBigMouse` user agent. GitHub's privacy terms apply to that request. On Linux the check is disabled entirely — your package manager owns updates.
+- **Smart-TV discovery** — when you use the monitor control features, the application sends SSDP multicast on your local network (`239.255.255.250:1900`) and probes the devices that answer. Samsung Tizen sets are probed on `http://<tv>:8001/api/v2/`, Hisense VIDAA sets on their device descriptor endpoint.
+- **Smart-TV control** — pairing and commands travel to the television over your local network, by WebSocket (Samsung) or MQTT (Hisense).
+
+Smart-TV traffic never leaves your network. Nothing is relayed through a third party.
+
+The installer additionally downloads the .NET 10 Runtime from Microsoft's `aka.ms` channel link if it is missing, and you download releases from GitHub yourself.
+
+## What is stored, and where
+
+**Windows**
+
+- `HKCU\SOFTWARE\Mgth\LittleBigMouse` — layout options, monitor positions and border settings.
+- `%LOCALAPPDATA%\Mgth\LittleBigMouse` — `Current.xml` (the active layout), `Excluded.txt`, and the UI log.
+- `%APPDATA%\LittleBigMouse\hisense-vidaa.json` and the Samsung equivalent in the configuration directory — smart-TV addresses and pairing tokens.
+- A Windows Task Scheduler entry named `LittleBigMouse_<your account>`, if you enable start-on-logon. It is removed with the setting.
+
+**Linux**
+
+- `~/.config/LittleBigMouse/` — `options.json`, `models.json`, `layouts/`, `window.json`, `samsung-tizen.json`, `wallpaper.json`.
+- `~/.local/share/LittleBigMouse/` — `Current.xml`, `Excluded.txt`, `ui.log`, `wallpapers/`.
+
+`Excluded.txt` holds the list of applications excluded from mouse handling, as fragments of executable paths (`\steamapps\`, `/Games/`, and whatever you add). It is seeded with defaults and only ever grows by your choice. No history of what you ran is kept: nothing records which applications were seen, only which ones you excluded.
+
+## Smart-TV credentials are not encrypted
+
+Pairing tokens for Samsung Tizen and Hisense VIDAA televisions are stored **in plain text**, as JSON, in the locations above.
+
+On Linux and other Unix systems the Samsung store is created with owner-only permissions (`0600`). On Windows the file carries no protection beyond the ACL of your user profile, and the Hisense store is not permission-restricted on any platform.
+
+These tokens authorise control of a television on your own network — changing input, volume, power. They are not accounts, and they carry no payment or identity data. Still, anything running as you can read them, and they are not protected against another user with access to your profile directory. If that matters in your situation, do not pair a television.
+
+## What is never done
+
+Little Big Mouse does not read your files, your keystrokes or your screen content. It handles pointer coordinates and display geometry, and — for the exclusion feature — the executable path of the window under the cursor, which it compares against your exclusion list and does not store.
+
+Logs, layouts and diagnostics leave your machine only if you choose to copy or attach them yourself, for example to a GitHub issue.
+
+## Removing everything
+
+Uninstall through Programs & Features (Windows) or your package manager (Linux), then delete the directories listed above to remove the remaining settings.
+
+Questions about any of this belong in the [issue tracker](https://github.com/mgth/LittleBigMouse/issues).

--- a/README.md
+++ b/README.md
@@ -206,6 +206,6 @@ Little Big Mouse collects no analytics and sends no telemetry; what it stores an
 - **HLab Project**: Little Big Mouse depends on the HLab project for its functionality. Check out the [HLab](https://github.com/mgth/HLab.Core) and [HLab.Avalonia](https://github.com/mgth/HLab.Avalonia) repositories for more information.
 - **MouseKeyboardActivityMonitor**: Inspired by the [MouseKeyboardActivityMonitor](https://github.com/gmamaladze/globalmousekeyhook) project.
 - **Task Scheduler Managed Wrapper**: Utilizes the [Task Scheduler Managed Wrapper](https://github.com/dahall/TaskScheduler) for scheduling tasks.
-- **SignPath Foundation**: Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+- **SignPath Foundation**: Free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).
 
 Thank you for using Little Big Mouse!

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ devices, which is a great deal more than a mouse utility should ask for.
 
 If you encounter any issues or have suggestions for improvements, please open an issue on our [Issues](https://github.com/mgth/LittleBigMouse/issues) page. We appreciate your feedback and are always looking to improve the tool.
 
+How releases are signed, and how to check a download you just made, is documented in [SIGNING.md](SIGNING.md).
+
 **We Welcome Contributions**: Your help is invaluable! Whether it's reporting bugs, suggesting new features, or submitting pull requests, we encourage you to get involved. Your contributions can make a significant difference in the development and improvement of Little Big Mouse. **First time?** Check out [This guide](https://github.com/firstcontributions/first-contributions) to get started.
 
 ## Acknowledgements
@@ -204,5 +206,6 @@ If you encounter any issues or have suggestions for improvements, please open an
 - **HLab Project**: Little Big Mouse depends on the HLab project for its functionality. Check out the [HLab](https://github.com/mgth/HLab.Core) and [HLab.Avalonia](https://github.com/mgth/HLab.Avalonia) repositories for more information.
 - **MouseKeyboardActivityMonitor**: Inspired by the [MouseKeyboardActivityMonitor](https://github.com/gmamaladze/globalmousekeyhook) project.
 - **Task Scheduler Managed Wrapper**: Utilizes the [Task Scheduler Managed Wrapper](https://github.com/dahall/TaskScheduler) for scheduling tasks.
+- **SignPath Foundation**: Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
 
 Thank you for using Little Big Mouse!

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ devices, which is a great deal more than a mouse utility should ask for.
 
 If you encounter any issues or have suggestions for improvements, please open an issue on our [Issues](https://github.com/mgth/LittleBigMouse/issues) page. We appreciate your feedback and are always looking to improve the tool.
 
-How releases are signed, and how to check a download you just made, is documented in [SIGNING.md](SIGNING.md).
+Little Big Mouse collects no analytics and sends no telemetry; what it stores and the few cases where it uses the network are set out in the [privacy policy](PRIVACY.md). How releases are signed, and how to check a download you just made, is documented in [SIGNING.md](SIGNING.md).
 
 **We Welcome Contributions**: Your help is invaluable! Whether it's reporting bugs, suggesting new features, or submitting pull requests, we encourage you to get involved. Your contributions can make a significant difference in the development and improvement of Little Big Mouse. **First time?** Check out [This guide](https://github.com/firstcontributions/first-contributions) to get started.
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -4,6 +4,28 @@ Windows releases are Authenticode-signed through the free [SignPath Foundation](
 
 Signing exists because Windows 11 Smart App Control blocks unsigned installers outright, with no way for the user to override it ([#535](https://github.com/mgth/LittleBigMouse/issues/535)). It is not an instant fix — a certificate gives every release one stable publisher identity, and Microsoft's reputation for that identity builds up over subsequent releases.
 
+This file doubles as the project's code signing policy, which the SignPath Foundation program requires published.
+
+## Team roles
+
+| Role | Who | What they may do |
+| --- | --- | --- |
+| Author | anyone | Open a pull request. Authors cannot merge their own work or trigger a signature. |
+| Reviewer | [@mgth](https://github.com/mgth) | Approve and merge pull requests into `master`. |
+| Approver | [@mgth](https://github.com/mgth) | Push a `v*` tag and approve the signing request in SignPath. |
+
+Multi-factor authentication is required on the GitHub and SignPath accounts of everyone holding a Reviewer or Approver role.
+
+Only releases built by the workflow in this repository, from this repository's own sources, are ever submitted for signing. Nothing is signed from a local machine.
+
+## Third-party components
+
+Little Big Mouse ships third-party binaries it does not build: the .NET runtime libraries, Avalonia, and the NuGet and crates.io dependencies listed in the project files and in `LittleBigMouse-Hook-Rust/Cargo.lock`. Those are signed as part of the packaged application where the signing policy allows it; upstream projects are encouraged to obtain their own signatures rather than rely on ours. No third-party binary is signed on behalf of its author.
+
+## User data
+
+Little Big Mouse collects no analytics and sends no telemetry. What it stores, and the only cases where it reaches the network, are described in [PRIVACY.md](PRIVACY.md). The application can be removed through Programs & Features, or by the uninstaller in the install directory.
+
 ## One-time SignPath setup
 
 1. Apply for Little Big Mouse at SignPath Foundation and connect the `mgth/LittleBigMouse` repository through the SignPath GitHub App.

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -55,4 +55,4 @@ The draft release carries the installer and nothing else, deliberately: the in-a
 Get-AuthenticodeSignature .\LittleBigMouse_5.6.1.exe | Format-List Status, SignerCertificate
 ```
 
-Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+Free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -1,0 +1,36 @@
+# Release signing
+
+Windows releases are Authenticode-signed through the free [SignPath Foundation](https://signpath.org/) program. No private key or certificate lives in this repository or in GitHub Actions: the workflow uploads the build output to SignPath and gets signed files back.
+
+Signing exists because Windows 11 Smart App Control blocks unsigned installers outright, with no way for the user to override it ([#535](https://github.com/mgth/LittleBigMouse/issues/535)). It is not an instant fix — a certificate gives every release one stable publisher identity, and Microsoft's reputation for that identity builds up over subsequent releases.
+
+## One-time SignPath setup
+
+1. Apply for Little Big Mouse at SignPath Foundation and connect the `mgth/LittleBigMouse` repository through the SignPath GitHub App.
+2. Add an *application* artifact configuration: root is the GitHub artifact ZIP, signing `LittleBigMouse.Ui.Avalonia.exe`, `LittleBigMouse.Hook.exe` and the eligible DLLs it contains.
+3. Add an *installer* artifact configuration: root is the GitHub artifact ZIP, signing `LittleBigMouse_*.exe`.
+4. Add a release signing policy using the SignPath Foundation certificate.
+5. Store the API token as the `SIGNPATH_API_TOKEN` Actions **secret**, and add these Actions **variables**:
+   - `SIGNPATH_ORGANIZATION_ID`
+   - `SIGNPATH_PROJECT_SLUG`
+   - `SIGNPATH_SIGNING_POLICY_SLUG`
+   - `SIGNPATH_APPLICATION_ARTIFACT_CONFIGURATION_SLUG`
+   - `SIGNPATH_INSTALLER_ARTIFACT_CONFIGURATION_SLUG`
+
+`SIGNPATH_PROJECT_SLUG` is the switch. While it is unset, a `v*` tag drafts the unsigned installer exactly as it did before; once it is set, the signed release job takes over and the unsigned path stands down. Nothing has to be merged or reverted on the day the SignPath application is approved.
+
+## What the tag build does
+
+Signing the setup `.exe` alone would leave the binaries inside it unsigned, and those are the ones Windows judges once they are installed on disk. So the binaries are signed first, then the installer is **recompiled** from the signed files (`ISCC /DSourceDir=...`) and signed in turn.
+
+Both stages fail closed: the workflow asserts that `LittleBigMouse.Ui.Avalonia.exe`, `LittleBigMouse.Hook.exe` and the installer each carry a `Valid` signature whose simple publisher name is exactly `SignPath Foundation`. A signing request that comes back successful without having signed those files stops the release.
+
+The draft release carries the installer and nothing else, deliberately: the in-app updater downloads `assets[0]`, so an extra asset sorting ahead of it would be handed to existing users in place of the setup program.
+
+## Verifying a download
+
+```powershell
+Get-AuthenticodeSignature .\LittleBigMouse_5.6.1.exe | Format-List Status, SignerCertificate
+```
+
+Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).


### PR DESCRIPTION
Closes #535.

## Why

Windows 11 Smart App Control blocks the installer outright, and unlike SmartScreen it offers no "run anyway" for the user to click through. The cause is not a 5.6.0 regression — I checked the certificate table in both PEs:

| Release | Certificate table (RVA/size) |
|---|---|
| `LittleBigMouse_5.4.1.exe` | `0 / 0` — unsigned |
| `LittleBigMouse_5.6.0.exe` | `0 / 0` — unsigned |

Same Inno Setup version, same section layout. 5.4.1 simply had six weeks and ~7000 downloads to accumulate reputation; 5.6.0 is an unknown hash with no signature to attach reputation to.

Signing is not an instant fix, and this PR should not be read as one: an OV certificate gives every release **one stable publisher identity**, and Microsoft's reputation accrues to that identity over subsequent releases. Immediate unblocking still needs a submission to Microsoft Security Intelligence.

## What it does

On a `v*` tag: sign the build output via SignPath Foundation → verify → **recompile** the installer from the signed files → sign the installer → verify → draft the release.

The recompile is the point. Signing the setup `.exe` alone would leave `LittleBigMouse.Ui.Avalonia.exe` and `LittleBigMouse.Hook.exe` unsigned *inside* it, and those are what Windows judges once they are on disk. Hence the new `SourceDir` define in the `.iss`: the release job points it at the signed files, a local compile keeps reading the build output exactly as before.

Both stages fail closed on a publisher that is not `SignPath Foundation`, or a signature that is not `Valid` — a signing request can report success having signed nothing that matters.

## Three things worth reviewing

**`SIGNPATH_PROJECT_SLUG` is the switch.** While it is unset, a tag drafts the unsigned release exactly as it does today; once set, the signed job takes over and the unsigned path stands down. Without this, merging would block every release until the Foundation application is approved.

**The draft carries the installer and nothing else.** `ApplicationUpdaterViewModel.CheckVersion` downloads `assets[0]`. An SBOM asset named `LittleBigMouse_x.y.z.cdx.json` sorts *before* `.exe`, so attaching the full bundle would hand every existing user a JSON file to execute in place of the setup program. The release name also stays the bare numeric version rather than `github.ref_name`.

**Deliberately out of scope**, still sitting in the pr-513 work: CycloneDX SBOM, checksums, provenance attestation, self-contained publish, and the updater hardening in `ReleaseUpdateSecurity.cs`. Attestation adds no release asset and is the easy next candidate.

## Verification

- SignPath action input names checked against `action.yml` at v2.2; pinned by digest (`b9d91ead`, confirmed to be that tag) since it is the only third-party action and the only step handed the token.
- Its default completion timeout is 10 minutes, too short for a Foundation policy that waits on a human approval — raised to 3600s.
- **The `.iss` change is not compiled in this PR's authoring**; CI compiles the installer on every push since 9acd036, so this PR's own build validates it.
- The signing path itself cannot be exercised until SignPath is configured.

Blocking next step, outside the code: apply for the project at SignPath Foundation, then set `SIGNPATH_API_TOKEN` and the five variables listed in `SIGNING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)