### PR TITLE
Give the hook daemon a Windows version resource

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -60,8 +60,32 @@ jobs:
         dotnet build $env:UI_PROJECT @buildArgs
 
     # windows-latest ships a stable Rust toolchain preinstalled, so no install step.
+    # LBM_VERSION is to build.rs what -p:Version is to the managed build: off a tag
+    # it stays empty and the version resource falls back to Directory.Build.props.
     - name: Build hook (Rust, release)
+      env:
+        LBM_VERSION: ${{ steps.ver.outputs.version }}
       run: cargo build --release --manifest-path $env:HOOK_RUST_PROJECT
+
+    # The hook shipped with no VERSIONINFO at all until build.rs was added, and the
+    # failure mode is silent: a missing crate, a target without a resource compiler,
+    # or a props file that stops parsing all leave a nameless exe that still builds
+    # and still runs. Assert on the artifact rather than trust the build script.
+    - name: Verify hook version resource
+      run: |
+        $exe = 'LittleBigMouse-Hook-Rust\target\release\lbm-hook.exe'
+        $info = (Get-Item $exe).VersionInfo
+        if ($info.ProductName -ne 'Little Big Mouse') {
+          throw "hook ProductName is '$($info.ProductName)', expected 'Little Big Mouse'"
+        }
+        if ($info.FileVersion -notmatch '^\d+\.\d+\.\d+') {
+          throw "hook FileVersion is '$($info.FileVersion)', expected a numeric version"
+        }
+        if ("${{ steps.ver.outputs.version }}" -and
+            $info.FileVersion -ne "${{ steps.ver.outputs.version }}") {
+          throw "hook FileVersion is '$($info.FileVersion)', expected the tag version"
+        }
+        "hook: $($info.ProductName) $($info.FileVersion)"
 
     - name: Stage hook next to UI output
       # Cargo can't emit a target named with a '.', so the Rust binary is built as

--- a/LittleBigMouse-Hook-Rust/Cargo.lock
+++ b/LittleBigMouse-Hook-Rust/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "windows",
+ "winresource",
  "x11rb",
  "zbus",
 ]
@@ -723,6 +724,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +862,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,12 +899,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1219,6 +1250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/LittleBigMouse-Hook-Rust/Cargo.toml
+++ b/LittleBigMouse-Hook-Rust/Cargo.toml
@@ -31,6 +31,17 @@ slotmap = "1"
 # Local IPC server (named pipe / UDS): async accept loop, bounded queues.
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 
+# Embeds the VERSIONINFO resource (see build.rs). Not under a
+# [target.'cfg(windows)'] table on purpose: build-dependencies are resolved
+# against the *host*, so gating it that way would break a Linux host
+# cross-compiling to Windows. build.rs decides at run time instead, on
+# CARGO_CFG_TARGET_OS, and does nothing off Windows.
+[build-dependencies]
+winresource = "0.1.31"
+# Reads <Version> out of Directory.Build.props. A substring search is not enough:
+# that file mentions "<Version>" inside its own comment, ahead of the real element.
+roxmltree = "0.20"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/LittleBigMouse-Hook-Rust/build.rs
+++ b/LittleBigMouse-Hook-Rust/build.rs
@@ -1,0 +1,112 @@
+// Stamp a Windows VERSIONINFO resource onto the hook daemon.
+//
+// rustc emits none by default, so LittleBigMouse.Hook.exe has been shipping with
+// no product name, no version and no copyright at all, sitting next to a UI exe
+// that carries all three. Users see the gap in the file properties and in Task
+// Manager, and a code-signing artifact configuration that constrains product and
+// version metadata (SignPath does) has nothing to match against.
+//
+// Everything here is a no-op off Windows: the Linux build must stay unaffected.
+
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=LBM_VERSION");
+
+    // Cargo builds this crate for Linux too; only a Windows target gets a resource.
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let version = resolve_version();
+    let (major, minor, patch, build) = numeric_version(&version);
+    let packed = (u64::from(major) << 48)
+        | (u64::from(minor) << 32)
+        | (u64::from(patch) << 16)
+        | u64::from(build);
+
+    let mut res = winresource::WindowsResource::new();
+    res.set("ProductName", "Little Big Mouse");
+    res.set("FileDescription", "Little Big Mouse hook daemon");
+    res.set("CompanyName", "Mathieu GRENET");
+    res.set("LegalCopyright", "Copyright (C) Mathieu GRENET");
+    // The shipped name, not the cargo target name: the binary is built as
+    // lbm-hook.exe and renamed during staging (see the [[bin]] note in Cargo.toml).
+    res.set("OriginalFilename", "LittleBigMouse.Hook.exe");
+    res.set("InternalName", "LittleBigMouse.Hook");
+    // Strings keep the full version ("5.6.1", or "5.7.0-beta.1"); the fixed-info
+    // fields below are numeric-only and carry the same value with the
+    // pre-release suffix dropped.
+    res.set("FileVersion", &version);
+    res.set("ProductVersion", &version);
+    res.set_version_info(winresource::VersionInfo::FILEVERSION, packed);
+    res.set_version_info(winresource::VersionInfo::PRODUCTVERSION, packed);
+
+    if let Err(e) = res.compile() {
+        // Failing the build here would take the Windows hook down over metadata.
+        // Warn loudly instead; CI asserts on the resource separately.
+        println!("cargo:warning=could not embed version resource: {e}");
+    }
+}
+
+/// LBM_VERSION (release CI, from the git tag) > Directory.Build.props (the
+/// repo's single source of truth for the version) > the crate version.
+///
+/// Reading the props file is what keeps the hook from drifting: the .NET side
+/// takes its version from there, and nothing would otherwise stop this crate
+/// from shipping 0.1.0 inside a 5.6.0 installer.
+fn resolve_version() -> String {
+    if let Ok(v) = env::var("LBM_VERSION") {
+        let v = v.trim();
+        if !v.is_empty() {
+            return v.to_owned();
+        }
+    }
+
+    let props = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("Directory.Build.props");
+    println!("cargo:rerun-if-changed={}", props.display());
+
+    if let Some(v) = fs::read_to_string(&props)
+        .ok()
+        .and_then(|s| version_element(&s))
+    {
+        return v;
+    }
+
+    // Standalone checkout of the crate (no props file next to it).
+    env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_owned())
+}
+
+/// Text of the `<Version>` element in an MSBuild props file.
+///
+/// Parsed rather than substring-matched: Directory.Build.props documents itself
+/// with a comment that spells out "<Version>" several lines above the real
+/// element, and a `find("<Version>")` happily returns the comment instead.
+fn version_element(xml: &str) -> Option<String> {
+    let doc = roxmltree::Document::parse(xml).ok()?;
+    let text = doc
+        .descendants()
+        .find(|n| n.is_element() && n.has_tag_name("Version"))?
+        .text()?
+        .trim();
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
+/// "5.6.1-beta.2" -> (5, 6, 1, 0). VERSIONINFO's fixed part is four u16s, so the
+/// pre-release suffix is dropped and missing components read as zero.
+fn numeric_version(version: &str) -> (u16, u16, u16, u16) {
+    let mut parts = version
+        .split('-')
+        .next()
+        .unwrap_or("")
+        .split('.')
+        .map(|p| p.trim().parse::<u16>().unwrap_or(0));
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}


### PR DESCRIPTION
Groundwork for #535 / #536, but a fix in its own right.

## The gap

`rustc` emits no `VERSIONINFO` resource and nothing in this crate supplied one, so `LittleBigMouse.Hook.exe` has been shipping with **no product name, no version and no copyright at all** — installed right next to a UI exe that carries all three. It is visible in the file properties dialog and in Task Manager.

It also matters for signing: a SignPath artifact configuration can constrain product and version metadata, and there is nothing here for it to match against.

## What it does

`build.rs` stamps the resource. The version comes from `LBM_VERSION` when CI sets it from the tag, otherwise from `Directory.Build.props`.

Reading the props file is the point of the change. It is already documented as the single source of truth for the managed version, and without it this crate would keep announcing its own `0.1.0` from inside a 5.6.0 installer — exactly the drift a signing policy would reject, discovered at release time.

Two details worth a look:

- **Parsed with `roxmltree`, not substring-matched.** `Directory.Build.props` names `<Version>` inside its own comment several lines above the real element, so `find("<Version>")` returns the comment body. My first attempt did exactly that and produced `FILEVERSION 0, 0, 0, 0` with a paragraph of prose as the `FileVersion` string. `roxmltree` is already a dependency of this crate.
- **`winresource` is in plain `[build-dependencies]`, not under `cfg(windows)`.** Build dependencies resolve against the *host*, so gating it that way silently breaks a Linux host cross-compiling to Windows. `build.rs` returns early on `CARGO_CFG_TARGET_OS` instead; the Linux build is untouched.

String fields keep the full version (`5.7.0-beta.1`); the fixed part of `VERSIONINFO` is four `u16`s, so the numeric fields carry the same version with the pre-release suffix dropped.

## Verification

Cross-compiled to `x86_64-pc-windows-gnu` and read back out of the PE:

| Build | `FILEVERSION` | `ProductName` |
|---|---|---|
| default (from `Directory.Build.props`) | `5.6.0.0` | Little Big Mouse |
| `LBM_VERSION=5.7.0-beta.1` | `5.7.0.0` | Little Big Mouse |

The Linux `cargo build` is unchanged.

That local check used mingw `windres`; CI builds MSVC and goes through `rc.exe`, which is a different resource compiler — so **this PR's own run is the first real test of that path**. The new "Verify hook version resource" step asserts on the built exe rather than on the build script, because every failure mode here is silent: a missing resource compiler, a props file that stops parsing, all leave a nameless exe that still builds and still runs.

## Note on the managed side

The UI csproj sets no `<Product>`/`<Company>`, so MSBuild defaults `ProductName` to the assembly name: `LittleBigMouse.Ui.Avalonia`, where the hook now says `Little Big Mouse`. If the SignPath artifact configuration ends up enforcing one product name across all signed binaries, those need setting too. I left it out deliberately — the natural home is `Directory.Build.props`, and that would also restamp the HLab submodule assemblies, which is your call rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)