### PR TITLE
Encrypt smart-TV pairing tokens at rest

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/SecretStorageTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/SecretStorageTests.cs
@@ -70,8 +70,23 @@ public class SecretStorageTests : IDisposable
         Assert.ThrowsAny<CryptographicException>(() => protector.Unprotect(tampered));
     }
 
+    /// <summary>
+    /// What a protector rooted somewhere else can read follows the scope of the key, and that
+    /// scope differs per platform — so assert both rather than skip the one that does not fit.
+    /// <para>
+    /// Unix keys on the file's own directory: another directory is another key, and the payload
+    /// must be refused. Windows keys on the logon credentials through DPAPI, where the location
+    /// plays no part at all — the same user reads it back wherever it sits. Asserting the Unix
+    /// answer everywhere is what made this fail on Windows while the code was doing exactly what
+    /// it says it does.
+    /// </para>
+    /// <para>
+    /// The isolation DPAPI does buy is between user accounts, and a test running as a single
+    /// account cannot exercise it. Nothing here should be read as covering it.
+    /// </para>
+    /// </summary>
     [Fact]
-    public void PayloadFromAnotherKeyIsRejected()
+    public void WhatAnotherLocationCanReadFollowsTheKeyScope()
     {
         var mine = SecretProtector.ForFile(At("data.json"));
         var envelope = mine.Protect("token");
@@ -79,7 +94,14 @@ public class SecretStorageTests : IDisposable
         var elsewhere = Directory.CreateDirectory(At("other")).FullName;
         var theirs = SecretProtector.ForFile(Path.Combine(elsewhere, "data.json"));
 
-        Assert.ThrowsAny<CryptographicException>(() => theirs.Unprotect(envelope));
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("token", theirs.Unprotect(envelope));
+        }
+        else
+        {
+            Assert.ThrowsAny<CryptographicException>(() => theirs.Unprotect(envelope));
+        }
     }
 
     [Fact]

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/SecretStorageTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/SecretStorageTests.cs
@@ -1,0 +1,277 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
+using LittleBigMouse.Plugins;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// Pairing tokens are credentials: they must not be legible on disk, and the files written in
+/// clear by 5.6.0 and earlier must survive the upgrade rather than silently losing pairings.
+/// </summary>
+public class SecretStorageTests : IDisposable
+{
+    readonly string _directory = Path.Combine(
+        Path.GetTempPath(), "lbm-secret-tests", Guid.NewGuid().ToString("N"));
+
+    public SecretStorageTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+
+    string At(string name) => Path.Combine(_directory, name);
+
+    // -- SecretProtector ---------------------------------------------------------------
+
+    [Fact]
+    public void ProtectedPayloadRoundTripsAndHidesThePlainText()
+    {
+        var protector = SecretProtector.ForFile(At("data.json"));
+        var envelope = protector.Protect("""{"Token":"pairing-token-1234"}""");
+
+        Assert.True(SecretProtector.IsProtected(envelope));
+        Assert.DoesNotContain("pairing-token-1234", envelope);
+        Assert.Equal("""{"Token":"pairing-token-1234"}""", protector.Unprotect(envelope));
+    }
+
+    [Fact]
+    public void ProtectIsNotDeterministic()
+    {
+        var protector = SecretProtector.ForFile(At("data.json"));
+
+        // Same token twice must not produce the same bytes, or the file would leak that a
+        // pairing was re-saved unchanged.
+        Assert.NotEqual(protector.Protect("token"), protector.Protect("token"));
+    }
+
+    [Fact]
+    public void ClearTextIsNotMistakenForAnEnvelope()
+    {
+        Assert.False(SecretProtector.IsProtected("""{"SAM123":{"Token":"secret"}}"""));
+        Assert.False(SecretProtector.IsProtected(""));
+    }
+
+    [Fact]
+    public void TamperedPayloadIsRejectedRatherThanDecoded()
+    {
+        var protector = SecretProtector.ForFile(At("data.json"));
+        var envelope = protector.Protect("token");
+
+        // Flip a bit in the base64 body; AES-GCM's tag has to notice.
+        var body = envelope[(envelope.LastIndexOf('.') + 1)..];
+        var bytes = Convert.FromBase64String(body);
+        bytes[^1] ^= 0x01;
+        var tampered = envelope[..(envelope.LastIndexOf('.') + 1)] + Convert.ToBase64String(bytes);
+
+        Assert.ThrowsAny<CryptographicException>(() => protector.Unprotect(tampered));
+    }
+
+    [Fact]
+    public void PayloadFromAnotherKeyIsRejected()
+    {
+        var mine = SecretProtector.ForFile(At("data.json"));
+        var envelope = mine.Protect("token");
+
+        var elsewhere = Directory.CreateDirectory(At("other")).FullName;
+        var theirs = SecretProtector.ForFile(Path.Combine(elsewhere, "data.json"));
+
+        Assert.ThrowsAny<CryptographicException>(() => theirs.Unprotect(envelope));
+    }
+
+    [Fact]
+    public void PayloadFromAnUnreadableSchemeIsRejected()
+    {
+        var protector = SecretProtector.ForFile(At("data.json"));
+
+        // A DPAPI envelope read on Unix, or anything from a future version: refuse it, never
+        // hand back a plausible-looking string.
+        Assert.ThrowsAny<CryptographicException>(
+            () => protector.Unprotect("LBM1.rot13." + Convert.ToBase64String("token"u8.ToArray())));
+        Assert.ThrowsAny<CryptographicException>(() => protector.Unprotect("LBM1.no-separator-body"));
+        Assert.ThrowsAny<CryptographicException>(() => protector.Unprotect("plain text"));
+    }
+
+    [Fact]
+    public void KeyFileIsOwnerOnlyAndReused()
+    {
+        if (OperatingSystem.IsWindows()) return; // DPAPI; no key file exists to check.
+
+        var protector = SecretProtector.ForFile(At("data.json"));
+        var envelope = protector.Protect("token");
+
+        var keyFile = At("secrets.key");
+        Assert.True(File.Exists(keyFile));
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(keyFile));
+
+        // A second protector over the same directory reuses the key rather than replacing it.
+        Assert.Equal("token", SecretProtector.ForFile(At("data.json")).Unprotect(envelope));
+    }
+
+    [Fact]
+    public void LooseKeyFilePermissionsAreNarrowedOnRead()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var keyFile = At("secrets.key");
+        SecretProtector.ForFile(At("data.json")).Protect("token");
+        File.SetUnixFileMode(keyFile, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        SecretProtector.ForFile(At("data.json")).Protect("token");
+
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(keyFile));
+    }
+
+    // -- Samsung Tizen -----------------------------------------------------------------
+
+    [Fact]
+    public void SamsungTokenIsNotLegibleOnDisk()
+    {
+        var path = At("samsung-tizen.json");
+        new SamsungTizenSettingsStore(path).Save(new SamsungTizenConfiguration
+        {
+            MonitorId = "SAM123",
+            IpAddress = "192.168.1.42",
+            Token = "pairing-token-1234",
+        });
+
+        var onDisk = File.ReadAllText(path);
+        Assert.True(SecretProtector.IsProtected(onDisk));
+        Assert.DoesNotContain("pairing-token-1234", onDisk);
+        Assert.DoesNotContain("192.168.1.42", onDisk);
+
+        Assert.Equal("pairing-token-1234", new SamsungTizenSettingsStore(path).Get("SAM123")!.Token);
+    }
+
+    [Fact]
+    public void SamsungClearTextFileIsReadOnceThenRewrittenEncrypted()
+    {
+        var path = At("samsung-tizen.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(new Dictionary<string, SamsungTizenConfiguration>
+        {
+            ["SAM123"] = new() { MonitorId = "SAM123", IpAddress = "192.168.1.42", Token = "legacy-token" },
+        }));
+
+        // Reading is enough to trigger the migration: the pairing survives...
+        Assert.Equal("legacy-token", new SamsungTizenSettingsStore(path).Get("SAM123")!.Token);
+
+        // ...and the clear-text copy is gone from the file.
+        var onDisk = File.ReadAllText(path);
+        Assert.True(SecretProtector.IsProtected(onDisk));
+        Assert.DoesNotContain("legacy-token", onDisk);
+
+        Assert.Equal("legacy-token", new SamsungTizenSettingsStore(path).Get("SAM123")!.Token);
+    }
+
+    [Fact]
+    public void SamsungUndecryptableFileStartsFreshInsteadOfThrowing()
+    {
+        var path = At("samsung-tizen.json");
+        File.WriteAllText(path, "LBM1.aesgcm." + Convert.ToBase64String(new byte[64]));
+
+        var store = new SamsungTizenSettingsStore(path);
+        Assert.Null(store.Get("SAM123"));
+
+        // Still usable afterwards — the user re-pairs and it saves.
+        store.Save(new SamsungTizenConfiguration { MonitorId = "SAM123", Token = "fresh" });
+        Assert.Equal("fresh", new SamsungTizenSettingsStore(path).Get("SAM123")!.Token);
+    }
+
+    // -- Hisense VIDAA -----------------------------------------------------------------
+
+    [Fact]
+    public void HisenseTokensAreNotLegibleOnDisk()
+    {
+        var path = At("hisense-vidaa.json");
+        new HisenseVidaaSettingsStore(path).Save(new HisenseVidaaConfiguration
+        {
+            MonitorId = "HIS123",
+            IpAddress = "192.168.1.43",
+            AccessToken = "access-token-1234",
+            RefreshToken = "refresh-token-5678",
+        });
+
+        var onDisk = File.ReadAllText(path);
+        Assert.True(SecretProtector.IsProtected(onDisk));
+        Assert.DoesNotContain("access-token-1234", onDisk);
+        Assert.DoesNotContain("refresh-token-5678", onDisk);
+
+        var loaded = new HisenseVidaaSettingsStore(path).Get("HIS123")!;
+        Assert.Equal("access-token-1234", loaded.AccessToken);
+        Assert.Equal("refresh-token-5678", loaded.RefreshToken);
+    }
+
+    [Fact]
+    public void HisenseRoundTripDoesNotShareMutableInstances()
+    {
+        var path = At("hisense-vidaa.json");
+        var store = new HisenseVidaaSettingsStore(path);
+        var configuration = new HisenseVidaaConfiguration { MonitorId = "HIS123", AccessToken = "secret" };
+
+        store.Save(configuration);
+        configuration.AccessToken = "changed";
+
+        Assert.Equal("secret", store.Get("HIS123")!.AccessToken);
+        Assert.Equal("secret", new HisenseVidaaSettingsStore(path).Get("HIS123")!.AccessToken);
+    }
+
+    [Fact]
+    public void HisenseClearTextFileIsReadOnceThenRewrittenEncrypted()
+    {
+        var path = At("hisense-vidaa.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(new Dictionary<string, HisenseVidaaConfiguration>
+        {
+            ["HIS123"] = new() { MonitorId = "HIS123", AccessToken = "legacy-token" },
+        }));
+
+        Assert.Equal("legacy-token", new HisenseVidaaSettingsStore(path).Get("HIS123")!.AccessToken);
+
+        var onDisk = File.ReadAllText(path);
+        Assert.True(SecretProtector.IsProtected(onDisk));
+        Assert.DoesNotContain("legacy-token", onDisk);
+    }
+
+    [Fact]
+    public void HisenseFileOutsideTheConfigDirectoryIsMovedIntoItAndRemoved()
+    {
+        // The shape of a Windows upgrade: 5.6.0 wrote to %APPDATA%\LittleBigMouse, LbmPaths
+        // says %LOCALAPPDATA%\Mgth\LittleBigMouse.
+        var legacy = Path.Combine(Directory.CreateDirectory(At("legacy")).FullName, "hisense-vidaa.json");
+        var path = At("hisense-vidaa.json");
+        File.WriteAllText(legacy, JsonSerializer.Serialize(new Dictionary<string, HisenseVidaaConfiguration>
+        {
+            ["HIS123"] = new() { MonitorId = "HIS123", AccessToken = "legacy-token" },
+        }));
+
+        Assert.Equal("legacy-token", new HisenseVidaaSettingsStore(path, legacy).Get("HIS123")!.AccessToken);
+
+        Assert.True(File.Exists(path));
+        Assert.True(SecretProtector.IsProtected(File.ReadAllText(path)));
+        Assert.False(File.Exists(legacy));
+
+        // The store no longer needs the legacy path at all.
+        Assert.Equal("legacy-token", new HisenseVidaaSettingsStore(path).Get("HIS123")!.AccessToken);
+    }
+
+    [Fact]
+    public void HisenseLegacyFileIsIgnoredOnceTheRealOneExists()
+    {
+        var legacy = Path.Combine(Directory.CreateDirectory(At("legacy")).FullName, "hisense-vidaa.json");
+        var path = At("hisense-vidaa.json");
+
+        new HisenseVidaaSettingsStore(path).Save(new HisenseVidaaConfiguration
+        {
+            MonitorId = "HIS123", AccessToken = "current",
+        });
+        File.WriteAllText(legacy, JsonSerializer.Serialize(new Dictionary<string, HisenseVidaaConfiguration>
+        {
+            ["HIS123"] = new() { MonitorId = "HIS123", AccessToken = "stale" },
+        }));
+
+        Assert.Equal("current", new HisenseVidaaSettingsStore(path, legacy).Get("HIS123")!.AccessToken);
+        Assert.True(File.Exists(legacy));
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDevice.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDevice.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using LittleBigMouse.Plugins;
+
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
 public sealed record HisenseVidaaDevice(string IpAddress, string Name = "Hisense VIDAA", string ModelName = "", string MacAddress = "", int? ProtocolVersion = null, string Brand = "his")
@@ -6,7 +8,7 @@ public sealed record HisenseVidaaDevice(string IpAddress, string Name = "Hisense
     public static bool IsValidAddress(string value) => System.Net.IPAddress.TryParse(value?.Trim(), out var ip) && ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork;
 }
 
-public sealed class HisenseVidaaConfiguration
+public sealed class HisenseVidaaConfiguration : IMonitorSetting
 {
     public string MonitorId { get; set; } = "";
     public string IpAddress { get; set; } = "";

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaSettingsStore.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaSettingsStore.cs
@@ -1,34 +1,43 @@
 #nullable enable
-using System.Text.Json;
+using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
-public sealed class HisenseVidaaSettingsStore
+/// <summary>
+/// Holds the VIDAA access and refresh tokens, encrypted — see
+/// <see cref="EncryptedJsonStore{T}"/> for what that does and does not buy.
+/// </summary>
+public sealed class HisenseVidaaSettingsStore : EncryptedJsonStore<HisenseVidaaConfiguration>
 {
-    readonly string _path;
-    Dictionary<string, HisenseVidaaConfiguration>? _items;
+    const string FileName = "hisense-vidaa.json";
 
     public HisenseVidaaSettingsStore()
+        : this(Path.Combine(LbmPaths.ConfigDir, FileName), LegacyFilePath)
     {
-        var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LittleBigMouse");
-        Directory.CreateDirectory(dir);
-        _path = Path.Combine(dir, "hisense-vidaa.json");
     }
-    public HisenseVidaaConfiguration? Get(string id)
+
+    public HisenseVidaaSettingsStore(string filePath) : this(filePath, null)
     {
-        Load();
-        return _items!.TryGetValue(id, out var c) ? Clone(c) : null;
     }
-    public void Save(HisenseVidaaConfiguration c)
+
+    /// <remarks>
+    /// Internal on purpose: the public constructors have to stay shaped like
+    /// <c>SamsungTizenSettingsStore</c>'s, since the container resolves both by picking the
+    /// greediest constructor it can satisfy and neither takes a registered service.
+    /// </remarks>
+    internal HisenseVidaaSettingsStore(string filePath, string? legacyFilePath)
+        : base("Hisense/VIDAA", filePath, legacyFilePath)
     {
-        Load(); _items![c.MonitorId] = Clone(c);
-        File.WriteAllText(_path, JsonSerializer.Serialize(_items, new JsonSerializerOptions { WriteIndented = true }));
     }
-    void Load()
-    {
-        if (_items is not null) return;
-        try { _items = File.Exists(_path) ? JsonSerializer.Deserialize<Dictionary<string, HisenseVidaaConfiguration>>(File.ReadAllText(_path)) : []; }
-        catch { _items = []; }
-    }
-    static HisenseVidaaConfiguration Clone(HisenseVidaaConfiguration c) => new() { MonitorId=c.MonitorId, IpAddress=c.IpAddress, MacAddress=c.MacAddress, ControllerMacAddress=c.ControllerMacAddress, DeviceUuid=c.DeviceUuid, ClientCertificatePath=c.ClientCertificatePath, ClientKeyPath=c.ClientKeyPath, ClientCertificatePassword=c.ClientCertificatePassword, Brand=c.Brand, ProtocolVersion=c.ProtocolVersion, AuthMethod=c.AuthMethod, ClientId=c.ClientId, MqttUsername=c.MqttUsername, AccessToken=c.AccessToken, RefreshToken=c.RefreshToken, AccessTokenIssuedAt=c.AccessTokenIssuedAt, RefreshTokenIssuedAt=c.RefreshTokenIssuedAt, AccessTokenDurationDays=c.AccessTokenDurationDays, RefreshTokenDurationDays=c.RefreshTokenDurationDays, LegacyAuthorized=c.LegacyAuthorized, KeyMacro=c.KeyMacro };
+
+    /// <summary>
+    /// Up to 5.6.0 this store ignored <see cref="LbmPaths"/> and built its own path, which put
+    /// the file outside the configured configuration directory on Windows
+    /// (<c>%APPDATA%</c> rather than <c>%LOCALAPPDATA%\Mgth</c>). On Unix the two resolve to
+    /// the same <c>~/.config/LittleBigMouse</c> unless XDG_CONFIG_HOME says otherwise.
+    /// </summary>
+    static string LegacyFilePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "LittleBigMouse", FileName);
+
+    protected override HisenseVidaaConfiguration Clone(HisenseVidaaConfiguration c) => new() { MonitorId=c.MonitorId, IpAddress=c.IpAddress, MacAddress=c.MacAddress, ControllerMacAddress=c.ControllerMacAddress, DeviceUuid=c.DeviceUuid, ClientCertificatePath=c.ClientCertificatePath, ClientKeyPath=c.ClientKeyPath, ClientCertificatePassword=c.ClientCertificatePassword, Brand=c.Brand, ProtocolVersion=c.ProtocolVersion, AuthMethod=c.AuthMethod, ClientId=c.ClientId, MqttUsername=c.MqttUsername, AccessToken=c.AccessToken, RefreshToken=c.RefreshToken, AccessTokenIssuedAt=c.AccessTokenIssuedAt, RefreshTokenIssuedAt=c.RefreshTokenIssuedAt, AccessTokenDurationDays=c.AccessTokenDurationDays, RefreshTokenDurationDays=c.RefreshTokenDurationDays, LegacyAuthorized=c.LegacyAuthorized, KeyMacro=c.KeyMacro };
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<AvaloniaResource Include="Assets\**" />
+		<InternalsVisibleTo Include="LittleBigMouse.Plugin.Vcp.Avalonia.Tests" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDevice.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDevice.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Net;
+using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 
@@ -21,7 +22,7 @@ public sealed record SamsungTizenDevice(
 }
 
 /// <summary>Persisted association between an EDID monitor and one Tizen network device.</summary>
-public sealed class SamsungTizenConfiguration
+public sealed class SamsungTizenConfiguration : IMonitorSetting
 {
     public string MonitorId { get; set; } = "";
     public string IpAddress { get; set; } = "";

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenSettingsStore.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenSettingsStore.cs
@@ -1,87 +1,25 @@
 #nullable enable
-using System.Text.Json;
 using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 
 /// <summary>
-/// Atomic, plugin-owned storage. The remote token only authorizes this application on
-/// the display's local network; on Unix the file is nevertheless restricted to its owner.
+/// The Samsung remote token only authorizes this application on the display's local network,
+/// but it is a credential all the same, so it is stored encrypted — see
+/// <see cref="EncryptedJsonStore{T}"/> for what that does and does not buy.
 /// </summary>
-public sealed class SamsungTizenSettingsStore
+public sealed class SamsungTizenSettingsStore : EncryptedJsonStore<SamsungTizenConfiguration>
 {
-    static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
-    readonly object _lock = new();
-    readonly string _filePath;
-    Dictionary<string, SamsungTizenConfiguration>? _settings;
-
     public SamsungTizenSettingsStore()
         : this(Path.Combine(LbmPaths.ConfigDir, "samsung-tizen.json"))
     {
     }
 
-    public SamsungTizenSettingsStore(string filePath) => _filePath = filePath;
-
-    public SamsungTizenConfiguration? Get(string monitorId)
+    public SamsungTizenSettingsStore(string filePath) : base("Samsung/Tizen", filePath)
     {
-        lock (_lock)
-        {
-            EnsureLoaded();
-            return _settings!.TryGetValue(monitorId, out var value) ? Clone(value) : null;
-        }
     }
 
-    public void Save(SamsungTizenConfiguration configuration)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.MonitorId);
-
-        lock (_lock)
-        {
-            EnsureLoaded();
-            _settings![configuration.MonitorId] = Clone(configuration);
-            SaveLocked();
-        }
-    }
-
-    void EnsureLoaded()
-    {
-        if (_settings is not null) return;
-
-        try
-        {
-            _settings = File.Exists(_filePath)
-                ? JsonSerializer.Deserialize<Dictionary<string, SamsungTizenConfiguration>>(
-                    File.ReadAllText(_filePath), JsonOptions) ?? []
-                : [];
-        }
-        catch (Exception e)
-        {
-            Console.Error.WriteLine($"Samsung/Tizen settings unreadable, starting fresh: {e.Message}");
-            _settings = [];
-        }
-    }
-
-    void SaveLocked()
-    {
-        try
-        {
-            var directory = Path.GetDirectoryName(_filePath);
-            if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
-
-            var temporary = _filePath + ".tmp";
-            File.WriteAllText(temporary, JsonSerializer.Serialize(_settings, JsonOptions));
-            File.Move(temporary, _filePath, overwrite: true);
-
-            if (!OperatingSystem.IsWindows())
-                File.SetUnixFileMode(_filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-        }
-        catch (Exception e)
-        {
-            Console.Error.WriteLine($"Samsung/Tizen settings not saved: {e.Message}");
-        }
-    }
-
-    static SamsungTizenConfiguration Clone(SamsungTizenConfiguration source) => new()
+    protected override SamsungTizenConfiguration Clone(SamsungTizenConfiguration source) => new()
     {
         MonitorId = source.MonitorId,
         IpAddress = source.IpAddress,

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/EncryptedJsonStore.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/EncryptedJsonStore.cs
@@ -1,0 +1,162 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace LittleBigMouse.Plugins;
+
+/// <summary>A stored setting identified by the monitor it belongs to.</summary>
+public interface IMonitorSetting
+{
+    string MonitorId { get; }
+}
+
+/// <summary>
+/// Atomic, plugin-owned storage for per-monitor settings that carry a credential — smart-TV
+/// pairing tokens today. The whole file is encrypted by <see cref="SecretProtector"/>, and on
+/// Unix restricted to its owner as well.
+///
+/// Two migrations run on the first read and are then invisible: a file still in clear, as
+/// 5.6.0 and earlier wrote it, is rewritten encrypted; a file found at
+/// <c>legacyFilePath</c> is moved to where <see cref="LbmPaths"/> says it belongs and the old
+/// copy deleted.
+///
+/// A file that cannot be read — lost key, another account's DPAPI blob, corruption — costs
+/// the user a re-pairing rather than leaving the feature stuck: the store starts empty and
+/// carries on. That is the right trade for a token authorising volume and input on a
+/// television, and would not be for anything harder to re-obtain.
+/// </summary>
+public abstract class EncryptedJsonStore<T> where T : class, IMonitorSetting
+{
+    static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    readonly object _lock = new();
+    readonly string _label;
+    readonly string _filePath;
+    readonly string? _legacyFilePath;
+    readonly SecretProtector _protector;
+    Dictionary<string, T>? _items;
+
+    /// <param name="label">Names this store in the messages it writes to standard error.</param>
+    /// <param name="legacyFilePath">
+    /// Where a previous version of the application left this file. Read once, then removed, if
+    /// <paramref name="filePath"/> does not exist yet. Null for a store that should never look
+    /// outside the path it was given.
+    /// </param>
+    protected EncryptedJsonStore(string label, string filePath, string? legacyFilePath = null)
+    {
+        _label = label;
+        _filePath = filePath;
+        _legacyFilePath = legacyFilePath;
+        _protector = SecretProtector.ForFile(filePath);
+    }
+
+    /// <summary>
+    /// A private copy. Callers hold on to what they save and to what they read, and these
+    /// settings are mutable, so neither may share an instance with the dictionary.
+    /// </summary>
+    protected abstract T Clone(T item);
+
+    public T? Get(string monitorId)
+    {
+        lock (_lock)
+        {
+            EnsureLoaded();
+            return _items!.TryGetValue(monitorId, out var item) ? Clone(item) : null;
+        }
+    }
+
+    public void Save(T item)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(item.MonitorId);
+
+        lock (_lock)
+        {
+            EnsureLoaded();
+            _items![item.MonitorId] = Clone(item);
+            SaveLocked();
+        }
+    }
+
+    void EnsureLoaded()
+    {
+        if (_items is not null) return;
+
+        var source = _filePath;
+        var movedFromLegacy = false;
+
+        if (!File.Exists(source) && _legacyFilePath is not null
+            && !SamePath(_legacyFilePath, _filePath) && File.Exists(_legacyFilePath))
+        {
+            source = _legacyFilePath;
+            movedFromLegacy = true;
+        }
+
+        var wasInClear = false;
+        try
+        {
+            if (File.Exists(source))
+            {
+                var content = File.ReadAllText(source);
+                wasInClear = !SecretProtector.IsProtected(content);
+                if (!wasInClear) content = _protector.Unprotect(content);
+
+                _items = JsonSerializer.Deserialize<Dictionary<string, T>>(content, JsonOptions) ?? [];
+            }
+            else _items = [];
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"{_label} settings unreadable, starting fresh: {e.Message}");
+            _items = [];
+            wasInClear = false;
+            movedFromLegacy = false;
+        }
+
+        if (!wasInClear && !movedFromLegacy) return;
+
+        // Drop the old file only once the encrypted copy is on disk — and only if we actually
+        // read it from elsewhere. Leaving it behind would leave the tokens in clear, which is
+        // the whole point of this.
+        if (!SaveLocked() || !movedFromLegacy) return;
+
+        try
+        {
+            File.Delete(source);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"{_label} settings moved to {_filePath} but {source} could not be removed: {e.Message}");
+        }
+    }
+
+    bool SaveLocked()
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+
+            // The temporary file holds ciphertext, so the window before the move and the
+            // chmod below exposes nothing.
+            var temporary = _filePath + ".tmp";
+            File.WriteAllText(temporary, _protector.Protect(JsonSerializer.Serialize(_items, JsonOptions)));
+            File.Move(temporary, _filePath, overwrite: true);
+
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(_filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"{_label} settings not saved: {e.Message}");
+            return false;
+        }
+    }
+
+    static bool SamePath(string a, string b) => string.Equals(
+        Path.GetFullPath(a), Path.GetFullPath(b),
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/LittleBigMouse.Plugins.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/LittleBigMouse.Plugins.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- DPAPI, for SecretProtector. Windows-only at runtime — the calls are guarded by
+         OperatingSystem.IsWindows() and the package is inert on other systems. -->
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\HLab.Core\HLab.Mvvm.Annotations\HLab.Mvvm.Annotations.csproj" />
     <ProjectReference Include="..\..\LittleBigMouse.Core\LittleBigMouse.DisplayLayout\LittleBigMouse.DisplayLayout.csproj" />
   </ItemGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/SecretProtector.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/SecretProtector.cs
@@ -1,0 +1,201 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LittleBigMouse.Plugins;
+
+/// <summary>
+/// Encrypts small secrets — smart-TV pairing tokens — before they reach the disk.
+///
+/// Windows uses DPAPI in <see cref="DataProtectionScope.CurrentUser"/> scope: the key is
+/// derived from the logon credentials, so nothing extra has to be stored and another account
+/// cannot read the file even with access to the profile directory. Unix has no equivalent
+/// service, so a 32-byte random key lives in a <c>0600</c> file next to the data and the
+/// payload is sealed with AES-GCM.
+///
+/// What this buys, on both systems: the token no longer sits in clear in a backup, a synced
+/// profile, or a config directory someone widened the permissions on. What it does not buy:
+/// protection from code running as you, which can read the key file — or ask DPAPI — exactly
+/// as this application does. PRIVACY.md states the same limit.
+///
+/// Envelopes are self-describing (<c>LBM1.&lt;scheme&gt;.&lt;base64&gt;</c>), so a file
+/// carried to a machine that cannot read it fails loudly instead of silently decoding to
+/// rubbish, and files written in clear by 5.6.0 and earlier stay recognisable for migration.
+/// </summary>
+public sealed class SecretProtector
+{
+    const string Prefix = "LBM1.";
+    const string DpapiScheme = "dpapi";
+    const string AesGcmScheme = "aesgcm";
+
+    const int KeyLength = 32;
+    const int NonceLength = 12; // AesGcm.NonceByteSizes.MaxSize
+    const int TagLength = 16;   // AesGcm.TagByteSizes.MaxSize
+
+    readonly string _keyFilePath;
+    readonly object _keyLock = new();
+    byte[]? _key;
+
+    public SecretProtector(string keyFilePath) => _keyFilePath = keyFilePath;
+
+    /// <summary>
+    /// The protector guarding <paramref name="dataFilePath"/>: on Unix its key sits beside the
+    /// data, so every store in the configuration directory shares one key file — and a store
+    /// pointed at a temporary directory (tests) gets its own, never touching the real profile.
+    /// </summary>
+    public static SecretProtector ForFile(string dataFilePath)
+        => new(Path.Combine(
+            Path.GetDirectoryName(Path.GetFullPath(dataFilePath))!, "secrets.key"));
+
+    /// <summary>Whether <paramref name="content"/> is one of our envelopes rather than clear text.</summary>
+    public static bool IsProtected(string content) => content.StartsWith(Prefix, StringComparison.Ordinal);
+
+    public string Protect(string plainText)
+    {
+        var bytes = Encoding.UTF8.GetBytes(plainText);
+
+        // The OS check has to be on this line: it is what lets the platform analyser see that
+        // the Windows-only call below is guarded.
+        if (OperatingSystem.IsWindows())
+            return Prefix + DpapiScheme + "."
+                 + Convert.ToBase64String(ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser));
+
+        // nonce ‖ tag ‖ ciphertext, so the whole envelope is one base64 blob.
+        var payload = new byte[NonceLength + TagLength + bytes.Length];
+        var nonce = payload.AsSpan(0, NonceLength);
+        RandomNumberGenerator.Fill(nonce);
+
+        using var aes = new AesGcm(GetOrCreateKey(), TagLength);
+        aes.Encrypt(
+            nonce,
+            bytes,
+            payload.AsSpan(NonceLength + TagLength),
+            payload.AsSpan(NonceLength, TagLength));
+
+        return Prefix + AesGcmScheme + "." + Convert.ToBase64String(payload);
+    }
+
+    /// <summary>
+    /// Reverses <see cref="Protect"/>. Throws — on a foreign scheme, a wrong key, a truncated
+    /// or tampered payload — rather than returning something plausible; callers treat that the
+    /// same way they already treat unreadable settings, by starting fresh.
+    /// </summary>
+    public string Unprotect(string envelope)
+    {
+        if (!IsProtected(envelope))
+            throw new CryptographicException("Not a protected payload.");
+
+        var body = envelope.AsSpan(Prefix.Length);
+        var separator = body.IndexOf('.');
+        if (separator < 0) throw new CryptographicException("Protected payload has no scheme.");
+
+        var scheme = body[..separator].ToString();
+        var payload = Convert.FromBase64String(body[(separator + 1)..].ToString());
+
+        switch (scheme)
+        {
+            case DpapiScheme when OperatingSystem.IsWindows():
+                return Encoding.UTF8.GetString(
+                    ProtectedData.Unprotect(payload, null, DataProtectionScope.CurrentUser));
+
+            case AesGcmScheme:
+                if (payload.Length < NonceLength + TagLength)
+                    throw new CryptographicException("Protected payload is truncated.");
+
+                var plain = new byte[payload.Length - NonceLength - TagLength];
+                using (var aes = new AesGcm(ReadKey() ?? throw new CryptographicException(
+                           $"No key at {_keyFilePath} to read this payload with."), TagLength))
+                {
+                    aes.Decrypt(
+                        payload.AsSpan(0, NonceLength),
+                        payload.AsSpan(NonceLength + TagLength),
+                        payload.AsSpan(NonceLength, TagLength),
+                        plain);
+                }
+                return Encoding.UTF8.GetString(plain);
+
+            default:
+                throw new CryptographicException(
+                    $"Payload was protected with '{scheme}', unreadable on this system.");
+        }
+    }
+
+    byte[] GetOrCreateKey()
+    {
+        lock (_keyLock)
+        {
+            return _key ??= ReadKeyLocked() ?? CreateKeyLocked();
+        }
+    }
+
+    byte[]? ReadKey()
+    {
+        lock (_keyLock)
+        {
+            return _key ??= ReadKeyLocked();
+        }
+    }
+
+    byte[]? ReadKeyLocked()
+    {
+        if (!File.Exists(_keyFilePath)) return null;
+
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(File.ReadAllText(_keyFilePath).Trim());
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"Secret key {_keyFilePath} is unreadable ({e.Message}); replacing it. Paired televisions must be paired again.");
+            return null;
+        }
+
+        if (key.Length != KeyLength)
+        {
+            Console.Error.WriteLine($"Secret key {_keyFilePath} has the wrong length; replacing it. Paired televisions must be paired again.");
+            return null;
+        }
+
+        // A key restored from a backup, or written before this ran, may be group- or
+        // world-readable. Narrow it back down.
+        if (!OperatingSystem.IsWindows())
+        {
+            try { File.SetUnixFileMode(_keyFilePath, UnixFileMode.UserRead | UnixFileMode.UserWrite); }
+            catch (Exception e) { Console.Error.WriteLine($"Could not restrict {_keyFilePath}: {e.Message}"); }
+        }
+
+        return key;
+    }
+
+    byte[] CreateKeyLocked()
+    {
+        var key = RandomNumberGenerator.GetBytes(KeyLength);
+
+        var directory = Path.GetDirectoryName(_keyFilePath);
+        if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+
+        // CreateNew + UnixCreateMode: the key is never briefly world-readable, and a second
+        // instance racing us here loses the create and reuses the key that won.
+        var options = new FileStreamOptions { Mode = FileMode.CreateNew, Access = FileAccess.Write };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+        try
+        {
+            using var stream = new FileStream(_keyFilePath, options);
+            using var writer = new StreamWriter(stream);
+            writer.Write(Convert.ToBase64String(key));
+        }
+        catch (IOException) when (File.Exists(_keyFilePath))
+        {
+            var winner = ReadKeyLocked();
+            if (winner is null) throw;
+            return winner;
+        }
+
+        return key;
+    }
+}

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -20,23 +20,28 @@ The installer additionally downloads the .NET 10 Runtime from Microsoft's `aka.m
 
 - `HKCU\SOFTWARE\Mgth\LittleBigMouse` — layout options, monitor positions and border settings.
 - `%LOCALAPPDATA%\Mgth\LittleBigMouse` — `Current.xml` (the active layout), `Excluded.txt`, and the UI log.
-- `%APPDATA%\LittleBigMouse\hisense-vidaa.json` and the Samsung equivalent in the configuration directory — smart-TV addresses and pairing tokens.
+- `%LOCALAPPDATA%\Mgth\LittleBigMouse\samsung-tizen.json` and `hisense-vidaa.json` — smart-TV addresses and pairing tokens, encrypted (see below). Up to 5.6.0 the Hisense file was written to `%APPDATA%\LittleBigMouse\` instead; it is moved on first read and the old copy deleted.
 - A Windows Task Scheduler entry named `LittleBigMouse_<your account>`, if you enable start-on-logon. It is removed with the setting.
 
 **Linux**
 
-- `~/.config/LittleBigMouse/` — `options.json`, `models.json`, `layouts/`, `window.json`, `samsung-tizen.json`, `wallpaper.json`.
+- `~/.config/LittleBigMouse/` — `options.json`, `models.json`, `layouts/`, `window.json`, `samsung-tizen.json`, `hisense-vidaa.json`, `wallpaper.json`, `secrets.key`.
 - `~/.local/share/LittleBigMouse/` — `Current.xml`, `Excluded.txt`, `ui.log`, `wallpapers/`.
 
 `Excluded.txt` holds the list of applications excluded from mouse handling, as fragments of executable paths (`\steamapps\`, `/Games/`, and whatever you add). It is seeded with defaults and only ever grows by your choice. No history of what you ran is kept: nothing records which applications were seen, only which ones you excluded.
 
-## Smart-TV credentials are not encrypted
+## Smart-TV credentials are encrypted
 
-Pairing tokens for Samsung Tizen and Hisense VIDAA televisions are stored **in plain text**, as JSON, in the locations above.
+Pairing tokens for Samsung Tizen and Hisense VIDAA televisions are encrypted before they are written, so the files listed above hold ciphertext rather than readable JSON.
 
-On Linux and other Unix systems the Samsung store is created with owner-only permissions (`0600`). On Windows the file carries no protection beyond the ACL of your user profile, and the Hisense store is not permission-restricted on any platform.
+- **Windows** — DPAPI (`CurrentUser` scope). The key comes from your logon credentials; nothing extra is stored on disk, and another Windows account cannot read the tokens even if it can reach your profile directory.
+- **Linux and other Unix systems** — AES-GCM, with a 32-byte random key in `~/.config/LittleBigMouse/secrets.key`. That file is created with owner-only permissions (`0600`), as are the token files themselves.
 
-These tokens authorise control of a television on your own network — changing input, volume, power. They are not accounts, and they carry no payment or identity data. Still, anything running as you can read them, and they are not protected against another user with access to your profile directory. If that matters in your situation, do not pair a television.
+If a token file cannot be decrypted — a restored profile without its key, a file copied from another account — it is discarded and you are asked to pair again. Files written in clear by 5.6.0 and earlier are read once and rewritten encrypted the next time the application starts.
+
+**What this does not protect against.** Anything running under your own account can read the key file, or ask DPAPI, exactly as this application does. Encryption at rest keeps the tokens out of backups, synced profiles, support archives and other users' hands; it is not a defence against malware already running as you.
+
+These tokens authorise control of a television on your own network — changing input, volume, power. They are not accounts, and they carry no payment or identity data.
 
 ## What is never done
 


### PR DESCRIPTION
Samsung Tizen and Hisense VIDAA pairing tokens were persisted as plain-text JSON. On Unix the Samsung file was at least `0600`; on Windows neither file had protection beyond the profile ACL, and the Hisense file had none on any platform.

Surfaced while preparing the SignPath Foundation application (#535, #536) — an earlier draft of PRIVACY.md wrongly claimed this encryption already existed. It does now.

## How

New `SecretProtector`:

- **Windows** — DPAPI, `CurrentUser` scope. Key comes from logon credentials, so nothing extra is stored and no other account can read the file.
- **Unix** — AES-GCM with a 32-byte key created **atomically** at `0600` via `FileMode.CreateNew` + `UnixCreateMode`, so it is never briefly world-readable. A process losing the creation race reuses the winner's key.

Envelopes are self-describing (`LBM1.<scheme>.<base64>`), so a payload that cannot be read on this machine fails loudly instead of decoding to rubbish — and files still in clear stay recognisable for migration.

The temp file in the write path now holds ciphertext, which incidentally closes the window where the old code had plain-text tokens at default permissions between `WriteAllText` and the `chmod`.

## Migration

Files written by 5.6.0 and earlier are read once and rewritten encrypted. A file that cannot be decrypted costs a re-pairing rather than leaving the feature stuck: the store logs, starts empty and carries on. That is the right trade for a token authorising volume and input on a television, and would not be for anything harder to re-obtain.

## Two divergences found alongside

- `HisenseVidaaSettingsStore` built its own `%APPDATA%` path instead of using `LbmPaths`, so on Windows its file landed outside the configured config directory. It now uses `LbmPaths` and moves the old file in on first read — deleting the clear-text original only once the encrypted copy is confirmed written, and never if the old file failed to parse.
- Both stores had drifted into near-identical load/save code. They now share `EncryptedJsonStore<T>`, which owns the lock, lazy load, both migrations, the atomic temp+move and the `0600`. Subclasses keep only a label, a `Clone` and an optional legacy path.

Public constructor shapes are unchanged on purpose: both stores are `AddSingleton<T>()` and the container picks the greediest constructor it can satisfy, so a new public string-taking overload would break resolution silently at startup. The Hisense legacy-path constructor is `internal` for that reason.

## Verification

16 new tests (76 in the plugin suite, 321 across the solution).

**The first CI run failed, on one test, and that turned out to be the useful part of it.** `PayloadFromAnotherKeyIsRejected` asserted that a protector rooted in another directory cannot read the payload. That is the Unix property — the key lives beside the file — and it is not the Windows one: DPAPI keys on the logon credentials, where the location plays no part, so the same user reads it back wherever it sits. The code was right; the test had encoded one platform's answer as the contract.

Fixed in 32d41d8 by asserting **both** answers rather than guarding the test out on Windows the way the neighbouring key-file tests do. The divergence is a designed property of the two schemes and worth pinning; a bare early return would have left the Windows behaviour unstated, which is how this got through in the first place.

### What that run settled

The caveat this PR originally carried — *"the DPAPI branch is guarded and compiles but is unexercised"* — no longer holds. That run was the first execution of the DPAPI path anywhere, and 75 of the 76 tests passed on Windows, including:

- protect/unprotect round-trip, non-determinism, and tamper rejection under DPAPI;
- both clear-text → encrypted migrations;
- `HisenseFileOutsideTheConfigDirectoryIsMovedIntoItAndRemoved`, i.e. the `%APPDATA%` → `%LOCALAPPDATA%` move, which only has an effect on Windows and was the other thing flagged for a manual check.

Beyond the unit tests, the real default constructors were run against a sandboxed `XDG_CONFIG_HOME`: both stores migrated their clear-text files, a fresh save round-tripped, all three files came out `0600`, and no token was greppable anywhere under the config directory.

### What is still not covered

- **Isolation between user accounts on Windows.** That is what DPAPI actually buys, and a suite running as a single account cannot exercise it. Stated in the test rather than implied by its name.
- **A real television.** Nothing here re-pairs against actual hardware; the migration paths are covered by tests, not by a Samsung set in the room.

## Rebase

Rebased onto `master` after #543, #544 and #545 landed. The original branch predated all three, and its recorded submodule gitlink was the pre-#543 one — so CI had never run this code against the HLab.Core that #543 bumps, the one removing the dead TripleDES `CryptService` this work pointedly did not build on. It now does, which is the combination that actually ships.

Local re-verification after the rebase: 76/76 in the plugin suite, 245/245 on `LittleBigMouse-Linux.slnf`.

## Notes

- PRIVACY.md documented the plain-text storage honestly; it is updated to match, including what encryption at rest does **not** buy — anything running as you can read the key file or ask DPAPI, exactly as this application does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
