### PR TITLE
hook: ask who is in front before hooking over them

### DIFF
--- a/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
@@ -264,9 +264,21 @@ fn run(shared: &Shared) {
     }
 
     load_excluded(shared);
-    if !shared.paused.load(Ordering::SeqCst) {
-        hook::request_hook(shared);
+
+    // Ask who is in front rather than wait to be told. The list was just
+    // (re)read, and `Run` is the one moment the daemon decides to hook — reading
+    // a pause flag that only a focus *change* ever sets is what let the engine
+    // hook straight over an excluded game that was already running (#541).
+    if hook::adopt_foreground(shared) {
+        // An excluded app holds the foreground: do not hook over it, and let go
+        // if an earlier Run already did.
+        if shared.hooked.load(Ordering::SeqCst) {
+            hook::request_unhook(shared);
+        }
+        return;
     }
+
+    hook::request_hook(shared);
 }
 
 /// C++ `LoadExcluded`: read `Excluded.txt`, skipping blank lines and `:` comments.

--- a/LittleBigMouse-Hook-Rust/src/hook/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/mod.rs
@@ -134,8 +134,94 @@ pub(crate) fn on_focus_changed(shared: &Shared, path: String) {
     shared.broadcast(&protocol::focus_changed(&path));
 }
 
+/// Re-decide the pause against whoever is in the foreground *right now*, and
+/// report whether an excluded app is in front.
+///
+/// [`on_focus_changed`] only ever fires on a *change*, so an excluded app already
+/// in front was never announced and the pause never engaged: the engine hooked
+/// straight over a game and stayed there until the user alt-tabbed out and back
+/// (#541). Starting LBM after the game was always enough to reproduce it; live
+/// update (#525) made it ordinary rather than rare, by re-Running on every edit.
+///
+/// This is the question asked at `Run` time, which is the one moment the daemon
+/// decides to hook, and therefore the one place the answer changes anything.
+pub(crate) fn adopt_foreground(shared: &Shared) -> bool {
+    let path = crate::platform::process::foreground_path_now();
+    adopt_foreground_path(shared, path.as_deref())
+}
+
+/// See [`adopt_foreground`]; split from the OS query so the decision can be
+/// tested without a desktop.
+pub(crate) fn adopt_foreground_path(shared: &Shared, path: Option<&str>) -> bool {
+    // Unknown foreground (no window, unresolvable owner, a platform that does not
+    // answer) leaves the flag exactly as it was: the last thing we actually knew
+    // beats a guess, and guessing "not excluded" would unpause over a game.
+    let Some(path) = path.filter(|p| !p.is_empty()) else {
+        return shared.paused.load(Ordering::SeqCst);
+    };
+
+    let excluded = shared.is_excluded(path);
+    shared.paused.store(excluded, Ordering::SeqCst);
+    // Same announcement a real focus change makes: the UI keeps its own idea of
+    // what is in front, and it must not diverge just because nothing moved.
+    shared.broadcast(&protocol::focus_changed(path));
+    excluded
+}
+
 /// Run a callback body catching any panic, so it can never unwind across an
 /// `extern "system"` FFI boundary (which would be UB).
 pub(crate) fn guard<F: FnOnce()>(body: F) {
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shared_excluding(entries: &[&str]) -> Shared {
+        let shared = Shared::new();
+        *shared.excluded.lock().unwrap() = entries.iter().map(|e| e.to_string()).collect();
+        shared
+    }
+
+    /// The #541 case: the game is already in front when `Run` arrives, so no
+    /// focus change ever announced it.
+    #[test]
+    fn a_foreground_already_excluded_engages_the_pause() {
+        let shared = shared_excluding(&[r"\Genshin Impact\"]);
+        let excluded = adopt_foreground_path(
+            &shared,
+            Some(r"C:\Games\Genshin Impact\Genshin Impact game\GenshinImpact.exe"),
+        );
+
+        assert!(excluded, "an excluded foreground must stop Run hooking");
+        assert!(shared.paused.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn a_foreground_that_is_not_excluded_lifts_a_stale_pause() {
+        let shared = shared_excluding(&[r"\Genshin Impact\"]);
+        shared.paused.store(true, Ordering::SeqCst);
+
+        let explorer = Some(r"C:\Windows\explorer.exe");
+        assert!(!adopt_foreground_path(&shared, explorer));
+        assert!(!shared.paused.load(Ordering::SeqCst));
+    }
+
+    /// "Unknown" is not "nobody": a locked session, an unresolvable owner, or a
+    /// platform that does not answer must not unpause over a game.
+    #[test]
+    fn an_unknown_foreground_leaves_the_pause_untouched() {
+        for path in [None, Some("")] {
+            let shared = shared_excluding(&[r"\Genshin Impact\"]);
+
+            shared.paused.store(true, Ordering::SeqCst);
+            assert!(adopt_foreground_path(&shared, path), "{path:?} unpaused");
+            assert!(shared.paused.load(Ordering::SeqCst));
+
+            shared.paused.store(false, Ordering::SeqCst);
+            assert!(!adopt_foreground_path(&shared, path), "{path:?} paused");
+            assert!(!shared.paused.load(Ordering::SeqCst));
+        }
+    }
 }

--- a/LittleBigMouse-Hook-Rust/src/platform/linux/process.rs
+++ b/LittleBigMouse-Hook-Rust/src/platform/linux/process.rs
@@ -14,6 +14,19 @@ pub fn parent_process_path() -> Option<String> {
         .map(|p| p.to_string_lossy().into_owned())
 }
 
+/// Windows counterpart of "who is in front right now?" — deliberately unanswered
+/// here, and `None` means "unknown", not "nobody": the caller leaves the pause
+/// flag as it stands rather than guess.
+///
+/// Answering would mean opening an X connection from whichever thread asked. The
+/// focus watcher already owns one, and already reports the active window once
+/// when it connects (`hook/linux/focus.rs`, the `report` before the event loop),
+/// so the case this exists for on Windows — a game already in front when the
+/// engine starts — is covered here by that initial report instead.
+pub fn foreground_path_now() -> Option<String> {
+    None
+}
+
 /// Identity string of a foreground process, for exclusion matching and the UI's
 /// seen-processes list (Windows reports the exe full path there).
 ///

--- a/LittleBigMouse-Hook-Rust/src/platform/windows/process.rs
+++ b/LittleBigMouse-Hook-Rust/src/platform/windows/process.rs
@@ -10,7 +10,22 @@ use windows::Win32::System::Threading::{
     GetCurrentProcessId, OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
     PROCESS_QUERY_LIMITED_INFORMATION,
 };
-use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
+
+/// Full Win32 executable path of whatever holds the foreground *right now*, or
+/// `None` when there is nothing to ask about (a locked session, a switch in
+/// progress) or the owner cannot be resolved.
+///
+/// The focus hook only ever reports a *change*. This is how the daemon asks the
+/// same question at a moment of its own choosing — when it is about to hook, and
+/// needs to know whether it would be hooking over an excluded app (#541).
+pub fn foreground_path_now() -> Option<String> {
+    let hwnd = unsafe { GetForegroundWindow() };
+    if hwnd == HWND::default() {
+        return None;
+    }
+    exe_path_from_window(hwnd)
+}
 
 /// Full Win32 executable path of the process owning `hwnd`, or `None`.
 pub fn exe_path_from_window(hwnd: HWND) -> Option<String> {


### PR DESCRIPTION
Addresses the exclusion half of #541.

The exclusion list is only ever consulted when the foreground **changes**. [`on_focus_changed`](../blob/master/LittleBigMouse-Hook-Rust/src/hook/mod.rs) is its sole reader, and it fires on a WinEvent — so a game already in front when the engine starts, or when a layout is re-applied over it, was never announced, the pause never engaged, and LBM hooked straight over an excluded process. It stayed that way until the user alt-tabbed out and back, which is the only thing that produces the event the decision was waiting for.

That is why the reporter of #541 saw no effect from adding the game: the entry was right, it was simply never consulted at a moment when it could still matter.

```rust
// before — daemon/mod.rs, run()
load_excluded(shared);
if !shared.paused.load(Ordering::SeqCst) {
    hook::request_hook(shared);   // paused is only ever set by a focus *change*
}
```

Starting LBM after the game was always enough to reproduce it. Live update (#525) made it ordinary rather than rare, by re-Running on every edit of the layout.

## The change

`Run` is the one moment the daemon decides to hook, so it is the one place the answer changes anything. It now reads the foreground itself, right after re-reading the list, and lets go of the hook if an earlier `Run` had already taken it over an excluded app.

Three deliberate choices:

- **An unknown foreground leaves the flag as it stands.** No window, an owner that will not resolve, a platform that does not answer — all mean "unknown", not "nobody". Guessing *not excluded* would unpause over a game, which is the failure this PR exists to remove.
- **Linux answers `None` by design.** The query would mean opening an X connection from whichever thread asked; the focus watcher already owns one and already reports the active window once when it connects, so the case is covered there by that initial report instead.
- **The decision is split from the OS query**, so it can be tested without a desktop.

## Tested

- `cargo test` 84/84 on Linux — three new tests covering the excluded, not-excluded and unknown paths
- `cargo check --all-targets` clean for `x86_64-pc-windows-gnu`, which actually compiles the Windows paths this touches rather than only the Linux ones
- `cargo clippy` quiet on the touched files (the pre-existing warnings elsewhere are unchanged), `cargo fmt` clean on them

## Not tested — needs Windows

The behaviour itself. The checklist:

- [ ] a game from the exclusion list already in the foreground when the engine starts: the engine must **not** hook
- [ ] alt-tab away from it: the engine hooks, and border crossing works again
- [ ] alt-tab back into it: the engine lets go again
- [ ] hitting Apply while the game is in front: still no hook (this is the live-update path that made it frequent)

## Scope

This is the part of #541 that is a bug on our side. The reporter also has *Pause in games* switched off and border sections set to `Move: 0`, which explain the escapes independently of this — asked about both in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
