### PR TITLE
Fix nullable primary layout contract

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PrimaryMonitorContractTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PrimaryMonitorContractTests.cs
@@ -1,0 +1,106 @@
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+public class PrimaryMonitorContractTests
+{
+    static (PhysicalMonitor Monitor, DisplaySource Source, PhysicalSource PhysicalSource) CreateMonitor(
+        IMonitorsLayout layout, string id, bool primary)
+    {
+        var model = new PhysicalMonitorModel($"PNP_{id}");
+        model.PhysicalSize.Width = 600;
+        model.PhysicalSize.Height = 340;
+
+        var monitor = new PhysicalMonitor(id, layout, model);
+        var source = new DisplaySource($"{id}-source")
+        {
+            AttachedToDesktop = true,
+            Primary = primary,
+        };
+        source.InPixel.Set(new Rect(new Point(0, 0), new Size(1920, 1080)));
+
+        var physicalSource = new PhysicalSource($"{id}-device", monitor, source);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+
+        return (monitor, source, physicalSource);
+    }
+
+    static (PhysicalMonitor Monitor, DisplaySource Source) AddMonitor(
+        MonitorsLayout layout, string id, bool primary)
+    {
+        var (monitor, source, physicalSource) = CreateMonitor(layout, id, primary);
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        layout.AddOrUpdatePhysicalSource(physicalSource);
+
+        return (monitor, source);
+    }
+
+    [Fact]
+    public void EmptyLayoutHasNoPrimary()
+    {
+        IMonitorsLayout layout = new MonitorsLayout(new ILayoutOptions.Design());
+
+        Assert.Empty(layout.PhysicalMonitors);
+        Assert.Null(layout.PrimaryMonitor);
+        Assert.Null(layout.PrimarySource);
+        Assert.Empty(layout.ComputePixelLocationsFromPhysical());
+    }
+
+    [Fact]
+    public void PartiallyBuiltLayoutHasNoPrimaryAndPlacementIsIgnored()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        var (monitor, _, _) = CreateMonitor(layout, "PENDING", primary: true);
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        var before = monitor.DepthProjection.Bounds;
+
+        Assert.Single(layout.PhysicalMonitors);
+        Assert.Empty(layout.PhysicalSources);
+        Assert.Null(layout.PrimaryMonitor);
+        Assert.Null(layout.PrimarySource);
+
+        layout.AnchorOnPrimary();
+        layout.SetLocationsFromSystemConfiguration();
+        layout.ForceCompact();
+
+        Assert.Equal(before, monitor.DepthProjection.Bounds);
+    }
+
+    [Fact]
+    public void DesignatingPrimaryUpdatesBothProperties()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        var (monitor, source) = AddMonitor(layout, "MONITOR", primary: false);
+
+        source.Primary = true;
+
+        Assert.Same(monitor, layout.PrimaryMonitor);
+        Assert.Same(source, layout.PrimarySource);
+    }
+
+    [Fact]
+    public void ReplacingPrimaryAllowsTheTransientStateAndSelectsTheReplacement()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        var (oldMonitor, oldSource) = AddMonitor(layout, "OLD", primary: true);
+        var (newMonitor, newSource) = AddMonitor(layout, "NEW", primary: false);
+
+        Assert.Same(oldMonitor, layout.PrimaryMonitor);
+        Assert.Same(oldSource, layout.PrimarySource);
+
+        oldSource.Primary = false;
+
+        Assert.Null(layout.PrimaryMonitor);
+        Assert.Null(layout.PrimarySource);
+
+        newSource.Primary = true;
+
+        Assert.Same(newMonitor, layout.PrimaryMonitor);
+        Assert.Same(newSource, layout.PrimarySource);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleDip.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleDip.cs
@@ -23,6 +23,7 @@
 
 using LittleBigMouse.DisplayLayout.Monitors;
 using ReactiveUI;
+using System.Reactive.Linq;
 using System.Reactive.Concurrency;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
@@ -55,10 +56,18 @@ public class DisplayScaleDip : DisplaySize
             (h, r) => h * r
             ).ToProperty(this, e => e.Y, scheduler: Scheduler.Immediate);
 
-        _mainRatio = this.WhenAnyValue(
-            e => e.Layout.PrimarySource.EffectiveDpi.X,
-            e => e.Layout.PrimarySource.EffectiveDpi.Y,
-            (x, y) => new DisplayRatioValue(96 / x, 96 / y))
+        _mainRatio = this.WhenAnyValue(e => e.Layout.PrimarySource)
+            .Select(primarySource =>
+            {
+                if (primarySource == null)
+                    return Observable.Empty<IDisplayRatio>();
+
+                return primarySource.WhenAnyValue(
+                    e => e.EffectiveDpi.X,
+                    e => e.EffectiveDpi.Y,
+                    (x, y) => (IDisplayRatio)new DisplayRatioValue(96 / x, 96 / y));
+            })
+            .Switch()
             .ToProperty(this,e=>e.MainRatio, scheduler: Scheduler.Immediate);
 
         _width = this.WhenAnyValue(

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
@@ -56,7 +56,9 @@ public static class MonitorsLocationsFromSystemExtensions
     /// <param name="placeAll">reset already placed windows</param>
     public static void SetLocationsFromSystemConfiguration(this IMonitorsLayout layout, bool placeAll = true)
     {
-        if (layout.PrimarySource == null) return;
+        var primarySource = layout.PrimarySource;
+        var primaryMonitor = layout.PrimaryMonitor;
+        if (primarySource == null || primaryMonitor == null) return;
 
         lock (CompactLock)
         {
@@ -69,7 +71,7 @@ public static class MonitorsLocationsFromSystemExtensions
 
             // start with primary display
             Queue<PhysicalMonitor> todo = new();
-            todo.Enqueue(layout.PrimaryMonitor);
+            todo.Enqueue(primaryMonitor);
 
             while (todo.Count > 0)
             {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/IMonitorsLayout.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/IMonitorsLayout.cs
@@ -49,15 +49,20 @@ public interface IMonitorsLayout : IDisposable
     double Y0 { get; }
 
     /// <summary>
-    /// 
+    /// Primary display source, or <see langword="null"/> while the layout is empty,
+    /// partially built, or between primary sources during reconfiguration.
     /// </summary>
-    DisplaySource PrimarySource { get; }
+    DisplaySource? PrimarySource { get; }
 
 
     string Id { get; set; }
 
     DpiAwarenessKind DpiAwareness { get; }
-    PhysicalMonitor PrimaryMonitor { get; }
+    /// <summary>
+    /// Physical monitor displaying <see cref="PrimarySource"/>, or
+    /// <see langword="null"/> whenever no primary source is currently designated.
+    /// </summary>
+    PhysicalMonitor? PrimaryMonitor { get; }
 
     void Compact();
     void ForceCompact();

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorsLayout.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorsLayout.cs
@@ -46,6 +46,7 @@ public class MonitorsLayout : SavableReactiveModel, IMonitorsLayout
       _physicalSourcesCache.Connect()
           .AutoRefresh(e => e.Source.EffectiveDpi.X)
           .AutoRefresh(e => e.Source.EffectiveDpi.Y)
+          .AutoRefresh(e => e.Source.Primary)
           .AutoRefresh(e => e.PixelToDipRatio)
           .ToCollection()
           .Do(ParseDisplaySources)
@@ -266,16 +267,17 @@ public class MonitorsLayout : SavableReactiveModel, IMonitorsLayout
    public void ForceCompact()
    {
       // we cannot compact until primary monitor is placed
-      if (PrimaryMonitor == null) return;
+      var primaryMonitor = PrimaryMonitor;
+      if (primaryMonitor == null) return;
 
       var monitors = PhysicalMonitors.ToList();
       if (monitors.Count < 2) return;
 
-      if (!Options.AllowOverlaps) ResolveOverlaps(monitors);
+      if (!Options.AllowOverlaps) ResolveOverlaps(monitors, primaryMonitor);
 
       // Primary monitor is always at 0,0: its cluster anchors everything.
       var clusters = BuildClusters(monitors);
-      var anchored = clusters.First(c => c.Contains(PrimaryMonitor));
+      var anchored = clusters.First(c => c.Contains(primaryMonitor));
       var todo = clusters.Where(c => !ReferenceEquals(c, anchored)).ToList();
 
       while (todo.Count > 0)
@@ -334,14 +336,14 @@ public class MonitorsLayout : SavableReactiveModel, IMonitorsLayout
    /// neighbours forever); fall back to the shortest push when every direction is
    /// occupied, and iterate until stable.
    /// </summary>
-   void ResolveOverlaps(List<PhysicalMonitor> monitors)
+   void ResolveOverlaps(List<PhysicalMonitor> monitors, PhysicalMonitor primaryMonitor)
    {
       for (var pass = 0; pass < monitors.Count + 4; pass++)
       {
          var moved = false;
          foreach (var monitor in monitors)
          {
-            if (ReferenceEquals(monitor, PrimaryMonitor)) continue;
+            if (ReferenceEquals(monitor, primaryMonitor)) continue;
 
             var others = monitors.Where(m => !ReferenceEquals(m, monitor)).ToList();
             var overlapped = others.FirstOrDefault(o => Overlap(monitor.DepthProjection.OutsideBounds, o.DepthProjection.OutsideBounds));

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalSource.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 using HLab.Base.ReactiveUI;
@@ -93,18 +94,39 @@ public class PhysicalSource : SavableReactiveModel
             GetRealDpiAvg
         ).ToProperty(this, e => e.RealDpiAvg).DisposeWith(this);
 
-        _dipToPixelRatio = this.WhenAnyValue(
+        var primaryDpi = this.WhenAnyValue(e => e.Monitor.Layout.PrimarySource)
+            .Select(primarySource =>
+            {
+                if (primarySource == null)
+                    return Observable.Empty<(double X, double Y)>();
+
+                return primarySource.WhenAnyValue(
+                    e => e.EffectiveDpi.X,
+                    e => e.EffectiveDpi.Y,
+                    (x, y) => (X: x, Y: y));
+            })
+            .Switch();
+
+        var dipToPixelInputs = this.WhenAnyValue(
             e => e.Monitor.Layout.DpiAwareness,
             e => e.RealDpi.X,
             e => e.RealDpi.Y,
             e => e.Source.DpiAwareAngularDpi.X,
             e => e.Source.DpiAwareAngularDpi.Y,
-            e => e.Monitor.Layout.PrimarySource.EffectiveDpi.X,
-            e => e.Monitor.Layout.PrimarySource.EffectiveDpi.Y,
             e => e.Source.EffectiveDpi.X,
             e => e.Source.EffectiveDpi.Y,
-            UpdateDipToPixelRatio
-        ).ToProperty(this, e => e.DipToPixelRatio).DisposeWith(this);
+            (aware, realX, realY, angularX, angularY, sourceX, sourceY) =>
+                (aware, realX, realY, angularX, angularY, sourceX, sourceY));
+
+        _dipToPixelRatio = dipToPixelInputs
+            .CombineLatest(primaryDpi, (input, primary) => UpdateDipToPixelRatio(
+                input.aware,
+                input.realX, input.realY,
+                input.angularX, input.angularY,
+                primary.X, primary.Y,
+                input.sourceX, input.sourceY))
+            .ToProperty(this, e => e.DipToPixelRatio)
+            .DisposeWith(this);
 
         _mmToDipRatio = this.WhenAnyValue(
             e => e.Monitor.DepthRatio,


### PR DESCRIPTION
## Summary

- align `IMonitorsLayout` and `MonitorsLayout` on nullable primary monitor/source contracts
- guard transient empty and partially reconstructed layouts without null-forgiving operators
- keep DPI-derived observables suspended until a primary exists, and react to primary replacement
- add lifecycle coverage for empty, partial, designation, and replacement states

## Root cause

`MonitorsLayout` legitimately clears both primary properties while a layout is empty, partially built, or being reconfigured, but `IMonitorsLayout` advertised them as always non-null. Consumers therefore dereferenced a state that the implementation explicitly produced.

## Impact

Transient layout states are represented honestly and handled explicitly. Screen placement behavior is unchanged.

## Validation

- `LittleBigMouse.DisplayLayout.Tests`: 115 passed
- `LittleBigMouse.Ui.Avalonia.Tests`: 129 passed
- Debug smoke launch on Linux with UI and `lbm-hook` both active