### PR TITLE
Split mutable display dimension contracts

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionContractTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionContractTests.cs
@@ -1,0 +1,183 @@
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using ReactiveUI;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+public class DimensionContractTests
+{
+    static DisplaySizeInMm PhysicalSize() => new()
+    {
+        X = 1,
+        Y = 2,
+        Width = 300,
+        Height = 200,
+        LeftBorder = 3,
+        TopBorder = 4,
+        RightBorder = 5,
+        BottomBorder = 6,
+    };
+
+    [Fact]
+    public void PhysicalDimensionImplementationsExposeWorkingFullMutationContracts()
+    {
+        var ratio = new DisplayRatioValue(2, 4);
+        var borderSource = new DisplayBorders { Left = 3, Top = 4, Right = 5, Bottom = 6 };
+        var dimensions = new (string Name, IMutableDisplaySize Value)[]
+        {
+            (nameof(DisplaySizeInMm), PhysicalSize()),
+            (nameof(DisplayBorderOverride), new DisplayBorderOverride(PhysicalSize(), borderSource)),
+            (nameof(DisplayLocate), new DisplayLocate(PhysicalSize())),
+            (nameof(DisplayRotate), new DisplayRotate(PhysicalSize(), 1)),
+            (nameof(DisplayScale), new DisplayScale(PhysicalSize(), ratio)),
+            (nameof(DisplayScaleWithLocation), new DisplayScaleWithLocation(PhysicalSize(), ratio)),
+            (nameof(DisplayTranslate), new DisplayTranslate(PhysicalSize(), new Vector(7, 11))),
+        };
+
+        foreach (var (name, value) in dimensions)
+        {
+            var observedWidths = new List<double>();
+            IDisplaySize readOnlyView = value;
+            using var subscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(observedWidths.Add);
+
+            value.X = 17;
+            value.Y = 19;
+            value.Width = 230;
+            value.Height = 170;
+            value.LeftBorder = 7;
+            value.TopBorder = 8;
+            value.RightBorder = 9;
+            value.BottomBorder = 10;
+
+            Assert.Equal(17, value.X, 10);
+            Assert.Equal(19, value.Y, 10);
+            Assert.Equal(230, value.Width, 10);
+            Assert.Equal(170, value.Height, 10);
+            Assert.Equal(7, value.LeftBorder, 10);
+            Assert.Equal(8, value.TopBorder, 10);
+            Assert.Equal(9, value.RightBorder, 10);
+            Assert.Equal(10, value.BottomBorder, 10);
+            Assert.Equal(230, observedWidths[^1], 10);
+            Assert.True(observedWidths.Count >= 2, $"{name} did not notify its read-only Width contract");
+            Assert.True(value.OutsideWidth > value.Width, name);
+            Assert.True(value.OutsideHeight > value.Height, name);
+        }
+    }
+
+    [Fact]
+    public void PixelDimensionsExposeMutableBoundsAndReadOnlyZeroBorders()
+    {
+        IMutableDisplayBounds pixels = new DisplaySizeInPixels(
+            new Rect(new Point(10, 20), new Size(1920, 1080)));
+
+        Assert.False(pixels is IMutableDisplaySize);
+
+        var observedWidths = new List<double>();
+        IDisplaySize readOnlyView = pixels;
+        using var subscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(observedWidths.Add);
+
+        pixels.Set(new Rect(new Point(30, 40), new Size(2560, 1440)));
+
+        Assert.Equal(new Rect(new Point(30, 40), new Size(2560, 1440)), pixels.Bounds);
+        Assert.Equal(0, pixels.LeftBorder);
+        Assert.Equal(0, pixels.TopBorder);
+        Assert.Equal(0, pixels.RightBorder);
+        Assert.Equal(0, pixels.BottomBorder);
+        Assert.Equal(pixels.Bounds, pixels.OutsideBounds);
+        Assert.Equal(new[] { 1920d, 2560d }, observedWidths);
+    }
+
+    [Fact]
+    public void PixelScaleImplementationsKeepOnlyTheSupportedMutationContract()
+    {
+        var pixels = new DisplaySizeInPixels(
+            new Rect(new Point(10, 20), new Size(1920, 1080)));
+        var ratio = new DisplayRatioValue(0.5, 0.25);
+
+        IMutableDisplayBounds wpf = new DisplaySizeWpf(pixels, ratio);
+        Assert.False(wpf is IMutableDisplaySize);
+
+        var observedWidths = new List<double>();
+        IDisplaySize readOnlyView = wpf;
+        using var subscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(observedWidths.Add);
+
+        wpf.X = 15;
+        wpf.Y = 10;
+        wpf.Width = 1280;
+        wpf.Height = 360;
+
+        Assert.Equal(15, wpf.X, 10);
+        Assert.Equal(10, wpf.Y, 10);
+        Assert.Equal(1280, wpf.Width, 10);
+        Assert.Equal(360, wpf.Height, 10);
+        Assert.Equal(new[] { 960d, 1280d }, observedWidths);
+        Assert.Equal(0, wpf.OutsideWidth - wpf.Width);
+        Assert.Equal(0, wpf.OutsideHeight - wpf.Height);
+    }
+
+    [Fact]
+    public void DipScaleExposesMutableBoundsButNotFixedPixelBorders()
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design());
+        var model = new PhysicalMonitorModel("MODEL");
+        model.PhysicalSize.Width = 600;
+        model.PhysicalSize.Height = 340;
+        var monitor = new PhysicalMonitor("MONITOR", layout, model);
+        var source = new DisplaySource("SOURCE") { Primary = true, AttachedToDesktop = true };
+        source.InPixel.Set(new Rect(new Point(0, 0), new Size(1920, 1080)));
+        var physicalSource = new PhysicalSource("DEVICE", monitor, source);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        layout.AddOrUpdatePhysicalSource(physicalSource);
+
+        IMutableDisplayBounds dip = new DisplayScaleDip(source.InPixel, new DisplayRatioValue(96), layout);
+        Assert.False(dip is IMutableDisplaySize);
+
+        var observedWidths = new List<double>();
+        IDisplaySize readOnlyView = dip;
+        using var subscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(observedWidths.Add);
+
+        dip.X = 12;
+        dip.Y = 14;
+        dip.Width = 960;
+        dip.Height = 540;
+
+        Assert.Equal(12, dip.X, 10);
+        Assert.Equal(14, dip.Y, 10);
+        Assert.Equal(960, dip.Width, 10);
+        Assert.Equal(540, dip.Height, 10);
+        Assert.Equal(new[] { 1920d, 960d }, observedWidths);
+        Assert.Equal(0, dip.LeftBorder);
+        Assert.Equal(0, dip.TopBorder);
+        Assert.Equal(0, dip.RightBorder);
+        Assert.Equal(0, dip.BottomBorder);
+    }
+
+    [Fact]
+    public void RatioImplementationsAdvertiseOnlySupportedMutability()
+    {
+        IMutableDisplayRatio value = new DisplayRatioValue(2, 3);
+        IMutableDisplayRatio registry = new DisplayRatioRegistry(null!);
+        IDisplayRatio inverse = new DisplayInverseRatio(value);
+        IDisplayRatio product = new DisplayRatioRatio(value, new DisplayRatioValue(5, 7));
+
+        value.X = 11;
+        value.Y = 13;
+        registry.X = 17;
+        registry.Y = 19;
+
+        Assert.Equal(11, value.X);
+        Assert.Equal(13, value.Y);
+        Assert.Equal(17, registry.X);
+        Assert.Equal(19, registry.Y);
+        Assert.False(inverse is IMutableDisplayRatio);
+        Assert.False(product is IMutableDisplayRatio);
+        Assert.Equal(1.0 / 11, inverse.X, 10);
+        Assert.Equal(1.0 / 13, inverse.Y, 10);
+        Assert.Equal(55, product.X);
+        Assert.Equal(91, product.Y);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionReactiveContractTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionReactiveContractTests.cs
@@ -1,0 +1,212 @@
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using ReactiveUI;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// Guards the ReactiveUI behaviour behind the dimension contracts. In particular, these
+/// tests exercise getter-only views and the properties hidden by the mutable interfaces:
+/// observing a property must not depend on that property's compile-time setter.
+/// </summary>
+public class DimensionReactiveContractTests
+{
+    sealed class ReactiveLayoutOptions : ILayoutOptions.Design
+    {
+        public void SetBorderValues(string value)
+        {
+            BorderValues = value;
+            OnPropertyChanged(nameof(BorderValues));
+        }
+    }
+
+    static DisplaySizeInMm PhysicalSize() => new()
+    {
+        X = 1,
+        Y = 2,
+        Width = 300,
+        Height = 200,
+        LeftBorder = 3,
+        TopBorder = 4,
+        RightBorder = 5,
+        BottomBorder = 6,
+    };
+
+    [Fact]
+    public void MutablePropertyIsObservedThroughConcreteBaseMutableAndReadOnlyViews()
+    {
+        var concrete = PhysicalSize();
+        DisplaySize baseView = concrete;
+        IMutableDisplaySize mutableView = concrete;
+        IDisplaySize readOnlyView = concrete;
+
+        var concreteValues = new List<double>();
+        var baseValues = new List<double>();
+        var mutableValues = new List<double>();
+        var readOnlyValues = new List<double>();
+
+        using var concreteSubscription = concrete.WhenAnyValue(e => e.Width).Subscribe(concreteValues.Add);
+        using var baseSubscription = baseView.WhenAnyValue(e => e.Width).Subscribe(baseValues.Add);
+        using var mutableSubscription = mutableView.WhenAnyValue(e => e.Width).Subscribe(mutableValues.Add);
+        using var readOnlySubscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(readOnlyValues.Add);
+
+        mutableView.Width = 640;
+
+        var expected = new[] { 300d, 640d };
+        Assert.Equal(expected, concreteValues);
+        Assert.Equal(expected, baseValues);
+        Assert.Equal(expected, mutableValues);
+        Assert.Equal(expected, readOnlyValues);
+    }
+
+    [Fact]
+    public void GetterOnlyPixelBordersDoNotPreventCalculatedPropertiesFromUpdating()
+    {
+        var pixels = new DisplaySizeInPixels(new Rect(10, 20, 1920, 1080));
+        IDisplaySize readOnlyView = pixels;
+
+        var borders = new List<double>();
+        var outsideWidths = new List<double>();
+        var outsideBounds = new List<Rect>();
+
+        using var borderSubscription = readOnlyView.WhenAnyValue(e => e.LeftBorder).Subscribe(borders.Add);
+        using var widthSubscription = readOnlyView.WhenAnyValue(e => e.OutsideWidth).Subscribe(outsideWidths.Add);
+        using var boundsSubscription = readOnlyView.WhenAnyValue(e => e.OutsideBounds).Subscribe(outsideBounds.Add);
+
+        pixels.Width = 2560;
+        pixels.X = 30;
+
+        Assert.Equal(new[] { 0d }, borders);
+        Assert.Equal(new[] { 1920d, 2560d }, outsideWidths);
+        Assert.Equal(new Rect(30, 20, 2560, 1080), outsideBounds[^1]);
+        Assert.True(outsideBounds.Count >= 3);
+    }
+
+    [Fact]
+    public void SourceAndRatioChangesPropagateAcrossTheFullDecoratorChain()
+    {
+        var source = PhysicalSize();
+        var ratio = new DisplayRatioValue(2, 3);
+        var rotated = new DisplayRotate(source, 1);
+        var scaled = new DisplayScale(rotated, ratio);
+        var located = new DisplayLocate(scaled, new Point(50, 60));
+        IDisplaySize readOnlyView = located;
+
+        var widths = new List<double>();
+        var heights = new List<double>();
+        var bounds = new List<Rect>();
+        var outsideBounds = new List<Rect>();
+        var changedProperties = new HashSet<string?>();
+
+        using var widthSubscription = readOnlyView.WhenAnyValue(e => e.Width).Subscribe(widths.Add);
+        using var heightSubscription = readOnlyView.WhenAnyValue(e => e.Height).Subscribe(heights.Add);
+        using var boundsSubscription = readOnlyView.WhenAnyValue(e => e.Bounds).Subscribe(bounds.Add);
+        using var outsideSubscription = readOnlyView.WhenAnyValue(e => e.OutsideBounds).Subscribe(outsideBounds.Add);
+        located.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+        source.Height = 250;
+        source.Width = 350;
+        ratio.X = 4;
+        ratio.Y = 5;
+        located.X = 75;
+        located.Y = 85;
+
+        Assert.Equal(1000, readOnlyView.Width, 10);
+        Assert.Equal(1750, readOnlyView.Height, 10);
+        Assert.Equal(new Rect(75, 85, 1000, 1750), readOnlyView.Bounds);
+        Assert.Equal(new Rect(59, 60, 1040, 1790), readOnlyView.OutsideBounds);
+        Assert.Equal(readOnlyView.Width, widths[^1]);
+        Assert.Equal(readOnlyView.Height, heights[^1]);
+        Assert.Equal(readOnlyView.Bounds, bounds[^1]);
+        Assert.Equal(readOnlyView.OutsideBounds, outsideBounds[^1]);
+        Assert.Contains(nameof(IDisplaySize.Width), changedProperties);
+        Assert.Contains(nameof(IDisplaySize.Height), changedProperties);
+        Assert.Contains(nameof(IDisplaySize.Bounds), changedProperties);
+        Assert.Contains(nameof(IDisplaySize.OutsideBounds), changedProperties);
+    }
+
+    [Fact]
+    public void ReadOnlyCalculatedRatiosRemainReactiveThroughTheirContracts()
+    {
+        var first = new DisplayRatioValue(2, 3);
+        var second = new DisplayRatioValue(5, 7);
+        var product = new DisplayRatioRatio(first, second);
+        var inverse = new DisplayInverseRatio(first);
+        DisplayRatio baseProduct = product;
+        IDisplayRatio productContract = product;
+        IDisplayRatio inverseContract = inverse;
+
+        var concreteValues = new List<double>();
+        var baseValues = new List<double>();
+        var contractValues = new List<double>();
+        var inverseValues = new List<double>();
+
+        using var concreteSubscription = product.WhenAnyValue(e => e.X).Subscribe(concreteValues.Add);
+        using var baseSubscription = baseProduct.WhenAnyValue(e => e.X).Subscribe(baseValues.Add);
+        using var contractSubscription = productContract.WhenAnyValue(e => e.X).Subscribe(contractValues.Add);
+        using var inverseSubscription = inverseContract.WhenAnyValue(e => e.X).Subscribe(inverseValues.Add);
+
+        first.X = 3;
+        second.X = 11;
+        first.Set(4, 6);
+
+        Assert.Equal(new[] { 10d, 15d, 33d, 44d }, concreteValues);
+        Assert.Equal(concreteValues, baseValues);
+        Assert.Equal(concreteValues, contractValues);
+        Assert.Equal(new[] { 0.5, 1.0 / 3.0, 0.25 }, inverseValues);
+    }
+
+    [Fact]
+    public void MonitorGeometryRewiresWhenTheEffectiveDimensionInstanceChanges()
+    {
+        var options = new ReactiveLayoutOptions();
+        var layout = new MonitorsLayout(options);
+        var model = new PhysicalMonitorModel("MODEL");
+        model.PhysicalSize.Width = 600;
+        model.PhysicalSize.Height = 340;
+        model.PhysicalSize.LeftBorder = 10;
+        model.PhysicalSize.TopBorder = 11;
+        model.PhysicalSize.RightBorder = 12;
+        model.PhysicalSize.BottomBorder = 13;
+
+        var monitor = new PhysicalMonitor("MONITOR", layout, model);
+        var source = new DisplaySource("SOURCE") { AttachedToDesktop = true };
+        source.InPixel.Set(new Rect(0, 0, 1920, 1080));
+        var physicalSource = new PhysicalSource("DEVICE", monitor, source);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+
+        var effectiveSizes = new List<IMutableDisplaySize>();
+        var outsideWidths = new List<double>();
+        using var sizeSubscription = monitor.WhenAnyValue(e => e.EffectivePhysicalSize).Subscribe(effectiveSizes.Add);
+        using var geometrySubscription = monitor.WhenAnyValue(e => e.DepthProjection.OutsideWidth).Subscribe(outsideWidths.Add);
+
+        Assert.Same(model.PhysicalSize, monitor.EffectivePhysicalSize);
+        Assert.Equal(622, outsideWidths[^1]);
+
+        options.SetBorderValues("PerMonitor");
+        var perMonitorSize = monitor.EffectivePhysicalSize;
+        Assert.NotSame(model.PhysicalSize, perMonitorSize);
+        monitor.Borders.Left = 40;
+        Assert.Equal(652, outsideWidths[^1]);
+
+        var activeBranchEmissionCount = outsideWidths.Count;
+        model.PhysicalSize.LeftBorder = 15;
+        Assert.Equal(activeBranchEmissionCount, outsideWidths.Count);
+
+        options.SetBorderValues("PerModel");
+        Assert.Same(model.PhysicalSize, monitor.EffectivePhysicalSize);
+        Assert.Equal(627, outsideWidths[^1]);
+
+        activeBranchEmissionCount = outsideWidths.Count;
+        monitor.Borders.Right = 50;
+        Assert.Equal(activeBranchEmissionCount, outsideWidths.Count);
+
+        options.SetBorderValues("PerMonitor");
+        Assert.Same(perMonitorSize, monitor.EffectivePhysicalSize);
+        Assert.Equal(690, outsideWidths[^1]);
+        Assert.Equal(4, effectiveSizes.Count);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorderOverride.cs
@@ -12,9 +12,9 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 /// Sits at the raw-size root of the chain (below rotation/scale), so those transforms apply to the
 /// overridden borders exactly as they do to the model's.
 /// </summary>
-public class DisplayBorderOverride : DisplaySize
+public class DisplayBorderOverride : MutableDisplaySize
 {
-    public DisplayBorderOverride(IDisplaySize source, DisplayBorders borderSource) : base(source)
+    public DisplayBorderOverride(IMutableDisplaySize source, DisplayBorders borderSource) : base(source)
     {
         BorderSource = borderSource;
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayInverseRatio.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayInverseRatio.cs
@@ -46,17 +46,9 @@ public class DisplayInverseRatio : DisplayRatio
 
     public IDisplayRatio Source { get; }
 
-    public override double X
-    {
-        get => _x.Value;
-        set => Source.X = 1 / value;
-    }
+    protected override double XValue => _x.Value;
     readonly ObservableAsPropertyHelper<double> _x;
 
-    public override double Y
-    {
-        get => _y.Value;
-        set => Source.Y = 1 / value;
-    }
+    protected override double YValue => _y.Value;
     readonly ObservableAsPropertyHelper<double> _y;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayLocate.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayLocate.cs
@@ -28,7 +28,7 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 
 public class DisplayLocate : DisplayMove
 {
-    public DisplayLocate(IDisplaySize source, Point? point = null) : base(source)
+    public DisplayLocate(IMutableDisplaySize source, Point? point = null) : base(source)
     {
         Location = point ?? new Point();
     }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayMove.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayMove.cs
@@ -3,9 +3,9 @@ using System.Reactive.Concurrency;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public abstract class DisplayMove : DisplaySize
+public abstract class DisplayMove : MutableDisplaySize
 {
-    protected DisplayMove(IDisplaySize source) : base(source)
+    protected DisplayMove(IMutableDisplaySize source) : base(source)
     {
         _width = this.WhenAnyValue(e => e.Source.Width)
             .ToProperty(this, e => e.Width, scheduler: Scheduler.Immediate);

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatio.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatio.cs
@@ -31,9 +31,11 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 public abstract class DisplayRatio : SavableReactiveModel, IDisplayRatio, IEquatable<IDisplayRatio>
 {
     [DataMember]
-    public abstract double X { get; set; }
+    public double X => XValue;
+    protected abstract double XValue { get; }
     [DataMember]
-    public abstract double Y { get; set; }
+    public double Y => YValue;
+    protected abstract double YValue { get; }
 
     public bool IsUnary => Math.Abs(X - 1) < double.Epsilon && Math.Abs(Y - 1) < double.Epsilon;
 
@@ -45,4 +47,16 @@ public abstract class DisplayRatio : SavableReactiveModel, IDisplayRatio, IEquat
 
     public override string ToString() => $"({X},{Y})";
 
+}
+
+/// <summary>
+/// Base class for ratios whose components are explicitly editable.
+/// </summary>
+public abstract class MutableDisplayRatio : DisplayRatio, IMutableDisplayRatio
+{
+    public new abstract double X { get; set; }
+    public new abstract double Y { get; set; }
+
+    protected sealed override double XValue => X;
+    protected sealed override double YValue => Y;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioExt.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioExt.cs
@@ -5,11 +5,11 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 
 public static class DisplayExtensions
 {
-    public static IDisplaySize Scale(this IDisplaySize source, IDisplayRatio ratio) => new DisplayScale(source, ratio);
-    public static IDisplaySize ScaleWithLocation(this IDisplaySize source, IDisplayRatio ratio) => new DisplayScaleWithLocation(source, ratio);
-    public static IDisplaySize Locate(this IDisplaySize source, Point? point = null) => new DisplayLocate(source, point);
-    public static IDisplaySize Rotate(this IDisplaySize source, int rotation) => new DisplayRotate(source, rotation);
-    public static IDisplaySize ScaleDip(this IDisplaySize source, IDisplayRatio effectiveDpi, IMonitorsLayout config) 
+    public static IMutableDisplaySize Scale(this IMutableDisplaySize source, IDisplayRatio ratio) => new DisplayScale(source, ratio);
+    public static IMutableDisplaySize ScaleWithLocation(this IMutableDisplaySize source, IDisplayRatio ratio) => new DisplayScaleWithLocation(source, ratio);
+    public static IMutableDisplaySize Locate(this IMutableDisplaySize source, Point? point = null) => new DisplayLocate(source, point);
+    public static IMutableDisplaySize Rotate(this IMutableDisplaySize source, int rotation) => new DisplayRotate(source, rotation);
+    public static IMutableDisplayBounds ScaleDip(this IMutableDisplayBounds source, IDisplayRatio effectiveDpi, IMonitorsLayout config)
         => new DisplayScaleDip(source, effectiveDpi, config);
 
     public static IDisplayRatio Multiply(this IDisplayRatio sourceA, IDisplayRatio sourceB) => new DisplayRatioRatio(sourceA, sourceB);

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioRatio.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioRatio.cs
@@ -21,7 +21,6 @@
 	  http://www.mgth.fr
 */
 
-using System;
 using System.Reactive.Concurrency;
 using ReactiveUI;
 
@@ -55,17 +54,9 @@ public class DisplayRatioRatio : DisplayRatio
 
 
 
-    public override double X
-    {
-        get => _x.Value;
-        set => throw new NotImplementedException();
-    }
+    protected override double XValue => _x.Value;
     readonly ObservableAsPropertyHelper<double> _x;
 
-    public override double Y
-    {
-        get => _y.Value;
-        set => throw new NotImplementedException();
-    }
+    protected override double YValue => _y.Value;
     readonly ObservableAsPropertyHelper<double> _y;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioRegistry.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioRegistry.cs
@@ -29,7 +29,7 @@ using ReactiveUI;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayRatioRegistry : DisplayRatio
+public class DisplayRatioRegistry : MutableDisplayRatio
 {
     readonly string _prefix;
     public PhysicalMonitor Monitor { get; }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioValue.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRatioValue.cs
@@ -1,25 +1,24 @@
 ﻿using HLab.Geo;
+using ReactiveUI;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayRatioValue(double x, double y) : DisplayRatio
+public class DisplayRatioValue(double x, double y) : MutableDisplayRatio
 {
    public DisplayRatioValue(double r):this(r,r) {}
     public DisplayRatioValue(Vector v):this(v.X, v.Y) {}
 
     public DisplayRatioValue Set(double x, double y)
     {
-        _x = x;
-        _y = y;
+        using (DelayChangeNotifications())
+        {
+            X = x;
+            Y = y;
+        }
         return this;
     }
 
-    public DisplayRatioValue Set(Vector v)
-    {
-        _x = v.X;
-        _y = v.Y;
-        return this;
-    }
+    public DisplayRatioValue Set(Vector v) => Set(v.X, v.Y);
 
     public override double X
     {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRotate.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayRotate.cs
@@ -27,11 +27,11 @@ using HLab.Geo;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayRotate : DisplaySize
+public class DisplayRotate : MutableDisplaySize
 {
     public int Rotation { get; }
 
-    public DisplayRotate(IDisplaySize source, int rotation = 0) : base(source)
+    public DisplayRotate(IMutableDisplaySize source, int rotation = 0) : base(source)
     {
         Rotation = rotation;
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScale.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScale.cs
@@ -28,9 +28,9 @@ using System.Reactive.Concurrency;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayScale : DisplaySize
+public class DisplayScale : MutableDisplaySize
 {
-    public DisplayScale(IDisplaySize source, IDisplayRatio ratio) : base(source)
+    public DisplayScale(IMutableDisplaySize source, IDisplayRatio ratio) : base(source)
     {
         Ratio = ratio;
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleDip.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleDip.cs
@@ -28,13 +28,15 @@ using System.Reactive.Concurrency;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayScaleDip : DisplaySize
+public class DisplayScaleDip : MutableDisplayBounds
 {
     public IDisplayRatio EffectiveDpi { get; }
     public IMonitorsLayout Layout { get; }
+    IMutableDisplayBounds MutableSource { get; }
 
-    public DisplayScaleDip(IDisplaySize source, IDisplayRatio effectiveDpi, IMonitorsLayout layout) : base(source)
+    public DisplayScaleDip(IMutableDisplayBounds source, IDisplayRatio effectiveDpi, IMonitorsLayout layout) : base(source)
     {
+        MutableSource = source;
         EffectiveDpi = effectiveDpi;
         Layout = layout;
 
@@ -118,57 +120,41 @@ public class DisplayScaleDip : DisplaySize
     public override double Width
     {
         get => _width.Value;
-        set => Source.Width = value / Ratio.X;
+        set => MutableSource.Width = value / Ratio.X;
     }
     readonly ObservableAsPropertyHelper<double> _width;
 
     public override double Height
     {
         get => _height.Value;
-        set => Source.Height = value / Ratio.Y;
+        set => MutableSource.Height = value / Ratio.Y;
     }
     readonly ObservableAsPropertyHelper<double> _height;
 
     public override double X
     {
         get => _x.Value;
-        set => Source.X = value / MainRatio.X;
+        set => MutableSource.X = value / MainRatio.X;
     }
     readonly ObservableAsPropertyHelper<double> _x;
 
     public override double Y
     {
         get => _y.Value;
-        set => Source.Y = value / MainRatio.Y;
+        set => MutableSource.Y = value / MainRatio.Y;
     }
     readonly ObservableAsPropertyHelper<double> _y;
 
-    public override double TopBorder
-    {
-        get => _topBorder.Value;
-        set => Source.TopBorder = value / Ratio.Y;
-    }
+    protected override double TopBorderValue => _topBorder.Value;
     readonly ObservableAsPropertyHelper<double> _topBorder;
 
-    public override double BottomBorder
-    {
-        get => _bottomBorder.Value;
-        set => Source.BottomBorder = value / Ratio.Y;
-    }
+    protected override double BottomBorderValue => _bottomBorder.Value;
     readonly ObservableAsPropertyHelper<double> _bottomBorder;
 
-    public override double LeftBorder
-    {
-        get => _leftBorder.Value;
-        set => Source.LeftBorder = value / Ratio.X;
-    }
+    protected override double LeftBorderValue => _leftBorder.Value;
     readonly ObservableAsPropertyHelper<double> _leftBorder;
 
-    public override double RightBorder
-    {
-        get => _rightBorder.Value;
-        set => Source.RightBorder = value / Ratio.X;
-    }
+    protected override double RightBorderValue => _rightBorder.Value;
     readonly ObservableAsPropertyHelper<double> _rightBorder;
 
     public override string TransformToString => $"DPI:{EffectiveDpi}";

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleWithLocation.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayScaleWithLocation.cs
@@ -27,9 +27,9 @@ using System.Reactive.Concurrency;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplayScaleWithLocation : DisplaySize
+public class DisplayScaleWithLocation : MutableDisplaySize
 {
-    public DisplayScaleWithLocation(IDisplaySize source, IDisplayRatio ratio) : base(source)
+    public DisplayScaleWithLocation(IMutableDisplaySize source, IDisplayRatio ratio) : base(source)
     {
         Ratio = ratio;
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySize.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySize.cs
@@ -108,22 +108,30 @@ public abstract class DisplaySize(IDisplaySize source) : SavableReactiveModel, I
     public IDisplaySize Source { get; } = source;
 
     //[DataMember]
-    public abstract double Width { get; set; }
+    public double Width => WidthValue;
+    protected abstract double WidthValue { get; }
     //[DataMember]
-    public abstract double Height { get; set; }
+    public double Height => HeightValue;
+    protected abstract double HeightValue { get; }
     //[DataMember]
-    public abstract double X { get; set; }
+    public double X => XValue;
+    protected abstract double XValue { get; }
     //[DataMember]
-    public abstract double Y { get; set; }
+    public double Y => YValue;
+    protected abstract double YValue { get; }
     //[DataMember]
-    public abstract double TopBorder { get; set; }
+    public double TopBorder => TopBorderValue;
+    protected abstract double TopBorderValue { get; }
     //[DataMember]
-    public abstract double BottomBorder { get; set; }
+    public double BottomBorder => BottomBorderValue;
+    protected abstract double BottomBorderValue { get; }
     //[DataMember]
-    public abstract double LeftBorder { get; set; }
+    public double LeftBorder => LeftBorderValue;
+    protected abstract double LeftBorderValue { get; }
 
     //[DataMember]
-    public abstract double RightBorder { get; set; }
+    public double RightBorder => RightBorderValue;
+    protected abstract double RightBorderValue { get; }
 
 
     [DataMember]
@@ -131,26 +139,10 @@ public abstract class DisplaySize(IDisplaySize source) : SavableReactiveModel, I
     ObservableAsPropertyHelper<Thickness> _borders;
 
     //[DataMember]
-    public Point Location
-    {
-        get => _location.Value;
-        set
-        {
-            X = value.X;
-            Y = value.Y;
-        }
-    }
+    public Point Location => _location.Value;
     ObservableAsPropertyHelper<Point> _location;
 
-    public Size Size
-    {
-        get => _size.Value;
-        set
-        {
-            Height = value.Height;
-            Width = value.Width;
-        }
-    }
+    public Size Size => _size.Value;
     ObservableAsPropertyHelper<Size> _size;
 
     public Point Center => _center.Value;
@@ -160,33 +152,17 @@ public abstract class DisplaySize(IDisplaySize source) : SavableReactiveModel, I
     ObservableAsPropertyHelper<Rect> _bounds;
 
     //[DataMember]
-    public double OutsideX
-    {
-        get => _outsideX.Value;
-        set => X = value + LeftBorder;
-    }
+    public double OutsideX => _outsideX.Value;
     ObservableAsPropertyHelper<double> _outsideX;
 
     //[DataMember]
-    public double OutsideY
-    {
-        get => _outsideY.Value;
-        set => Y = value + TopBorder;
-    }
+    public double OutsideY => _outsideY.Value;
     ObservableAsPropertyHelper<double> _outsideY;
 
-    public double OutsideWidth
-    {
-        get => _outsideWidth.Value;
-        set => throw new NotImplementedException();
-    }
+    public double OutsideWidth => _outsideWidth.Value;
     ObservableAsPropertyHelper<double> _outsideWidth;
 
-    public double OutsideHeight
-    {
-        get => _outsideHeight.Value;
-        set => throw new NotImplementedException();
-    }
+    public double OutsideHeight => _outsideHeight.Value;
     ObservableAsPropertyHelper<double> _outsideHeight;
 
     [DataMember]
@@ -215,4 +191,78 @@ public abstract class DisplaySize(IDisplaySize source) : SavableReactiveModel, I
 
         return b.ToString();
     }
+}
+
+/// <summary>
+/// Base class for dimensions that can propagate every edit, including borders, to
+/// their source. Read-only computed dimensions derive directly from <see cref="DisplaySize"/>.
+/// </summary>
+public abstract class MutableDisplayBounds(IMutableDisplayBounds source)
+    : DisplaySize(source), IMutableDisplayBounds
+{
+    [JsonIgnore]
+    public new IMutableDisplayBounds Source => source;
+
+    public new abstract double Width { get; set; }
+    public new abstract double Height { get; set; }
+    public new abstract double X { get; set; }
+    public new abstract double Y { get; set; }
+
+    public new Point Location
+    {
+        get => base.Location;
+        set
+        {
+            X = value.X;
+            Y = value.Y;
+        }
+    }
+
+    public new Size Size
+    {
+        get => base.Size;
+        set
+        {
+            Width = value.Width;
+            Height = value.Height;
+        }
+    }
+
+    public new double OutsideX
+    {
+        get => base.OutsideX;
+        set => X = value + LeftBorder;
+    }
+
+    public new double OutsideY
+    {
+        get => base.OutsideY;
+        set => Y = value + TopBorder;
+    }
+
+    protected sealed override double WidthValue => Width;
+    protected sealed override double HeightValue => Height;
+    protected sealed override double XValue => X;
+    protected sealed override double YValue => Y;
+}
+
+/// <summary>
+/// Base class for dimensions that can propagate every edit, including borders, to
+/// their source.
+/// </summary>
+public abstract class MutableDisplaySize(IMutableDisplaySize source)
+    : MutableDisplayBounds(source), IMutableDisplaySize
+{
+    [JsonIgnore]
+    public new IMutableDisplaySize Source => source;
+
+    public new abstract double TopBorder { get; set; }
+    public new abstract double BottomBorder { get; set; }
+    public new abstract double LeftBorder { get; set; }
+    public new abstract double RightBorder { get; set; }
+
+    protected sealed override double TopBorderValue => TopBorder;
+    protected sealed override double BottomBorderValue => BottomBorder;
+    protected sealed override double LeftBorderValue => LeftBorder;
+    protected sealed override double RightBorderValue => RightBorder;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeExtensions.cs
@@ -23,7 +23,7 @@ public static class DisplaySizeExtensions
         return new(x, y);
     }
 
-    public static T Set<T>(this T @this, Size size) where T : IDisplaySize
+    public static T Set<T>(this T @this, Size size) where T : IMutableDisplayBounds
     {
         using (@this.DelayChangeNotifications())
         {
@@ -33,7 +33,7 @@ public static class DisplaySizeExtensions
         }
     }
 
-    public static T Set<T>(this T @this, Rect rect) where T : IDisplaySize
+    public static T Set<T>(this T @this, Rect rect) where T : IMutableDisplayBounds
     {
         using (@this.DelayChangeNotifications())
         {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInMm.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInMm.cs
@@ -29,7 +29,7 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 /// <summary>
 /// Actual real monitor size 
 /// </summary>
-public class DisplaySizeInMm : DisplaySize
+public class DisplaySizeInMm : MutableDisplaySize
 {
     public DisplaySizeInMm() : base(null) => Init();
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInPixel.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeInPixel.cs
@@ -21,12 +21,11 @@
 	  http://www.mgth.fr
 */
 
-using System;
 using HLab.Geo;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
-public class DisplaySizeInPixels : DisplaySize
+public class DisplaySizeInPixels : MutableDisplayBounds
 {
     public DisplaySizeInPixels(Rect rect) : base(null)
     {
@@ -39,8 +38,8 @@ public class DisplaySizeInPixels : DisplaySize
     public override double X { get; set => SetUnsavedValue(ref field, value); }
     public override double Y { get; set => SetUnsavedValue(ref field, value); }
 
-    public override double TopBorder { get => 0; set => throw new NotImplementedException(); }
-    public override double BottomBorder { get => 0; set => throw new NotImplementedException(); }
-    public override double LeftBorder { get => 0; set => throw new NotImplementedException(); }
-    public override double RightBorder { get => 0; set => throw new NotImplementedException(); }
+    protected override double TopBorderValue => 0;
+    protected override double BottomBorderValue => 0;
+    protected override double LeftBorderValue => 0;
+    protected override double RightBorderValue => 0;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeWpf.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplaySizeWpf.cs
@@ -21,70 +21,87 @@
 	  http://www.mgth.fr
 */
 
+using System.Reactive.Concurrency;
+using ReactiveUI;
+
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
 public static class ScreenSizeWpfExt
 {
-    public static IDisplaySize Wpf(this DisplaySizeInPixels source, IDisplayRatio ratio) => new DisplayScale(source, ratio);
+    public static IMutableDisplayBounds Wpf(this DisplaySizeInPixels source, IDisplayRatio ratio) => new DisplaySizeWpf(source, ratio);
 }
-public class DisplaySizeWpf : DisplaySize
+public class DisplaySizeWpf : MutableDisplayBounds
 {
-    public DisplaySizeWpf(IDisplaySize source) : base(source)
+    public DisplaySizeWpf(IMutableDisplayBounds source, IDisplayRatio ratio) : base(source)
     {
+        MutableSource = source;
+        Ratio = ratio;
+
+        _width = this.WhenAnyValue(e => e.Source.Width, e => e.Ratio.X, (value, scale) => value * scale)
+            .ToProperty(this, e => e.Width, scheduler: Scheduler.Immediate);
+        _height = this.WhenAnyValue(e => e.Source.Height, e => e.Ratio.Y, (value, scale) => value * scale)
+            .ToProperty(this, e => e.Height, scheduler: Scheduler.Immediate);
+        _x = this.WhenAnyValue(e => e.Source.X)
+            .ToProperty(this, e => e.X, scheduler: Scheduler.Immediate);
+        _y = this.WhenAnyValue(e => e.Source.Y)
+            .ToProperty(this, e => e.Y, scheduler: Scheduler.Immediate);
+        _topBorder = this.WhenAnyValue(e => e.Source.TopBorder, e => e.Ratio.Y, (value, scale) => value * scale)
+            .ToProperty(this, e => e.TopBorder, scheduler: Scheduler.Immediate);
+        _bottomBorder = this.WhenAnyValue(e => e.Source.BottomBorder, e => e.Ratio.Y, (value, scale) => value * scale)
+            .ToProperty(this, e => e.BottomBorder, scheduler: Scheduler.Immediate);
+        _leftBorder = this.WhenAnyValue(e => e.Source.LeftBorder, e => e.Ratio.X, (value, scale) => value * scale)
+            .ToProperty(this, e => e.LeftBorder, scheduler: Scheduler.Immediate);
+        _rightBorder = this.WhenAnyValue(e => e.Source.RightBorder, e => e.Ratio.X, (value, scale) => value * scale)
+            .ToProperty(this, e => e.RightBorder, scheduler: Scheduler.Immediate);
+
         Init();
     }
+
+    IMutableDisplayBounds MutableSource { get; }
 
     public IDisplayRatio Ratio
     {
        get;
-       set => field = value;
+       private set => field = value;
     }
 
     public override double Width
     {
-        get => Source.Width * Ratio.X;
-        set => Source.Width = value / Ratio.X;
+        get => _width.Value;
+        set => MutableSource.Width = value / Ratio.X;
     }
+    readonly ObservableAsPropertyHelper<double> _width;
 
     public override double Height
     {
-        get => Source.Height * Ratio.Y;
-        set => Source.Height = value / Ratio.Y;
+        get => _height.Value;
+        set => MutableSource.Height = value / Ratio.Y;
     }
+    readonly ObservableAsPropertyHelper<double> _height;
 
     public override double X
     {
-        get => Source.X * Ratio.X;
-        set => Source.X = value / Ratio.X;
+        get => _x.Value;
+        set => MutableSource.X = value;
     }
+    readonly ObservableAsPropertyHelper<double> _x;
 
     public override double Y
     {
-        get => Source.Y * Ratio.Y;
-        set => Source.Y = value / Ratio.Y;
+        get => _y.Value;
+        set => MutableSource.Y = value;
     }
+    readonly ObservableAsPropertyHelper<double> _y;
 
-    public override double TopBorder
-    {
-        get => Source.TopBorder * Ratio.Y;
-        set => Source.TopBorder = value / Ratio.Y;
-    }
+    protected override double TopBorderValue => _topBorder.Value;
+    readonly ObservableAsPropertyHelper<double> _topBorder;
 
-    public override double BottomBorder
-    {
-        get => Source.BottomBorder * Ratio.Y;
-        set => Source.BottomBorder = value / Ratio.Y;
-    }
+    protected override double BottomBorderValue => _bottomBorder.Value;
+    readonly ObservableAsPropertyHelper<double> _bottomBorder;
 
-    public override double LeftBorder
-    {
-        get => Source.LeftBorder * Ratio.X;
-        set => Source.LeftBorder = value / Ratio.X;
-    }
+    protected override double LeftBorderValue => _leftBorder.Value;
+    readonly ObservableAsPropertyHelper<double> _leftBorder;
 
-    public override double RightBorder
-    {
-        get => Source.RightBorder * Ratio.X;
-        set => Source.RightBorder = value / Ratio.X;
-    }
+    protected override double RightBorderValue => _rightBorder.Value;
+    readonly ObservableAsPropertyHelper<double> _rightBorder;
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayTranslate.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayTranslate.cs
@@ -29,12 +29,12 @@ namespace LittleBigMouse.DisplayLayout.Dimensions;
 
 public static class DisplayTranslateExt
 {
-    public static IDisplaySize Translate(this IDisplaySize source, Vector translation) => new DisplayTranslate(source, translation);
+    public static IMutableDisplaySize Translate(this IMutableDisplaySize source, Vector translation) => new DisplayTranslate(source, translation);
 }
 
 public class DisplayTranslate : DisplayMove
 {
-    public DisplayTranslate(IDisplaySize source, Vector? translation = null) : base(source)
+    public DisplayTranslate(IMutableDisplaySize source, Vector? translation = null) : base(source)
     {
         Translation = translation ?? new Vector();
         

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/IDisplayRatio.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/IDisplayRatio.cs
@@ -2,9 +2,21 @@
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
+/// <summary>
+/// Read-only ratio view. Ratios produced by calculations expose this contract.
+/// </summary>
 public interface IDisplayRatio : ISavable
 {
-   double X { get; set; }
-   double Y { get; set; }
+   double X { get; }
+   double Y { get; }
    bool IsUnary { get; }
+}
+
+/// <summary>
+/// Ratio whose two components are independently editable.
+/// </summary>
+public interface IMutableDisplayRatio : IDisplayRatio
+{
+   new double X { get; set; }
+   new double Y { get; set; }
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/IDisplaySize.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/IDisplaySize.cs
@@ -5,18 +5,22 @@ using HLab.Geo;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
+/// <summary>
+/// Read-only view of display dimensions. Computed dimensions expose this contract so
+/// consumers cannot request a mutation that the implementation cannot perform.
+/// </summary>
 public interface IDisplaySize : IEquatable<IDisplaySize>, ISavable
 {
     IDisposable DelayChangeNotifications();
 
-    double Width { get; set; }
-    double Height { get; set; }
-    double X { get; set; }
-    double Y { get; set; }
-    double TopBorder { get; set; }
-    double BottomBorder { get; set; }
-    double LeftBorder { get; set; }
-    double RightBorder { get; set; }
+    double Width { get; }
+    double Height { get; }
+    double X { get; }
+    double Y { get; }
+    double TopBorder { get; }
+    double BottomBorder { get; }
+    double LeftBorder { get; }
+    double RightBorder { get; }
 
     Rect Bounds { get; }
     Point Center { get; }
@@ -28,4 +32,27 @@ public interface IDisplaySize : IEquatable<IDisplaySize>, ISavable
     double OutsideY { get; }
 
     Point Location { get; }
+}
+
+/// <summary>
+/// Display dimensions whose content bounds can be explicitly edited. Fixed borders,
+/// such as the zero pixel border, remain read-only through this contract.
+/// </summary>
+public interface IMutableDisplayBounds : IDisplaySize
+{
+    new double Width { get; set; }
+    new double Height { get; set; }
+    new double X { get; set; }
+    new double Y { get; set; }
+}
+
+/// <summary>
+/// Fully mutable display dimensions, including physical borders.
+/// </summary>
+public interface IMutableDisplaySize : IMutableDisplayBounds
+{
+    new double TopBorder { get; set; }
+    new double BottomBorder { get; set; }
+    new double LeftBorder { get; set; }
+    new double RightBorder { get; set; }
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
@@ -118,8 +118,11 @@ public class PhysicalMonitor : SavableReactiveModel
         // WhenAnyValue(e => e.EffectivePhysicalSize) OAPH-PropertyChanged round-trip that breaks
         // in Avalonia's synchronous reentrancy model (mode-change event → OAPH fires → inner
         // PropertyChanged → WhenAnyValue chain stops).
+        IMutableDisplaySize EffectiveSizeFor(string mode) =>
+            mode == "PerMonitor" ? _borderOverride : Model.PhysicalSize;
+
         var effectiveSizeObs = borderValuesObs
-            .Select(mode => mode == "PerMonitor" ? (IDisplaySize)_borderOverride : Model.PhysicalSize)
+            .Select(EffectiveSizeFor)
             .Replay(1)
             .RefCount();
 
@@ -147,7 +150,7 @@ public class PhysicalMonitor : SavableReactiveModel
             .CombineLatest(
                 this.WhenAnyValue(e => e.ActiveSource.Source.Orientation),
                 this.WhenAnyValue(e => e.DepthRatio),
-                (physicalSize, orientation, ratio) => (IDisplaySize)physicalSize.Rotate(orientation).Scale(ratio).Locate()
+                (physicalSize, orientation, ratio) => physicalSize.Rotate(orientation).Scale(ratio).Locate()
             )
             .Log(this, "_inMm")
             .Subscribe(dp => DepthProjection = dp)
@@ -303,8 +306,8 @@ public class PhysicalMonitor : SavableReactiveModel
     /// It exists as the single seam where a future "Border values: per monitor" option can substitute
     /// a per-monitor border source, without touching any geometry consumer. See the border-values plan.
     /// </summary>
-    public IDisplaySize EffectivePhysicalSize => _effectivePhysicalSize.Value;
-    readonly ObservableAsPropertyHelper<IDisplaySize> _effectivePhysicalSize;
+    public IMutableDisplaySize EffectivePhysicalSize => _effectivePhysicalSize.Value;
+    readonly ObservableAsPropertyHelper<IMutableDisplaySize> _effectivePhysicalSize;
 
     /// <summary>
     /// This monitor's own bezel borders, used to build the geometry only when "Border values" is
@@ -328,7 +331,7 @@ public class PhysicalMonitor : SavableReactiveModel
     /// <summary>
     /// Dimensions with rotation applied
     /// </summary>
-    [DataMember] public IDisplaySize PhysicalRotated
+    [DataMember] public IMutableDisplaySize PhysicalRotated
     {
         get;
         private set
@@ -347,7 +350,7 @@ public class PhysicalMonitor : SavableReactiveModel
     /// Dimensions with depth ratio applied to deal with monitor distance
     /// </summary>
     [DataMember]
-    public IDisplaySize DepthProjection
+    public IMutableDisplaySize DepthProjection
     {
         get;
         private set
@@ -370,14 +373,14 @@ public class PhysicalMonitor : SavableReactiveModel
     /// Dimensions with depth ratio applied but without rotation
     /// </summary>
     [DataMember]
-    public IDisplaySize DepthProjectionUnrotated => _depthProjectionUnrotated.Value;
-    readonly ObservableAsPropertyHelper<IDisplaySize> _depthProjectionUnrotated;
+    public IMutableDisplaySize DepthProjectionUnrotated => _depthProjectionUnrotated.Value;
+    readonly ObservableAsPropertyHelper<IMutableDisplaySize> _depthProjectionUnrotated;
 
     /// <summary>
     /// Final ratio to deal with monitor distance
     /// </summary>
     [DataMember]
-    public IDisplayRatio DepthRatio { get; }
+    public IMutableDisplayRatio DepthRatio { get; }
 
     [DataMember]
     public BorderResistance BorderResistance { get; } = new BorderResistance();
@@ -487,4 +490,3 @@ public class PhysicalMonitor : SavableReactiveModel
 
     public override string ToString() => $"{this.Id}";
 }
-

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMonitorsLayoutPresenterViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/IMonitorsLayoutPresenterViewModel.cs
@@ -10,7 +10,7 @@ public interface IMonitorsLayoutPresenterViewModel : INotifyPropertyChanged
 {
     IMainPluginsViewModel MainViewModel { get; }
 
-    IDisplayRatio VisualRatio { get; }
+    IMutableDisplayRatio VisualRatio { get; }
 
     IMonitorsLayout Model { get; }
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModelDesign.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorFrame/MonitorFrameViewModelDesign.cs
@@ -78,7 +78,7 @@ public class MonitorFrameViewModelDesign2 : MonitorFrameViewModel, IDesignViewMo
 {
     class MonitorsPresenterDesign : IMonitorsLayoutPresenterViewModel, IDesignViewModel
     {
-        public IDisplayRatio VisualRatio => new DisplayRatioValue(1.0);
+        public IMutableDisplayRatio VisualRatio => new DisplayRatioValue(1.0);
         public IMonitorsLayout Model { get; }
 
         public IMainPluginsViewModel MainViewModel => new MainViewModelDesign();

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorsLayoutPresenterViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/MonitorsLayoutPresenterViewModel.cs
@@ -152,7 +152,7 @@ public class MonitorsLayoutPresenterViewModel
     public double Height => _height.Value;
     readonly ObservableAsPropertyHelper<double> _height;
 
-    public IDisplayRatio VisualRatio { get; } = new DisplayRatioValue(1.0);
+    public IMutableDisplayRatio VisualRatio { get; } = new DisplayRatioValue(1.0);
 
     public PhysicalMonitor? SelectedMonitor { get; set => this.RaiseAndSetIfChanged(ref field, value);}
 


### PR DESCRIPTION
## Summary

- split display dimensions and ratios into read-only views and explicit mutable contracts
- remove public setters from calculated or fixed values while preserving units, calculations, bindings and persisted formats
- keep mutable monitor and presenter consumers strongly typed without casts or reflection
- make `DisplayRatioValue.Set` emit ReactiveUI notifications
- add contract and ReactiveUI propagation coverage for every dimension implementation

## Root cause

The public `IDisplaySize` and `IDisplayRatio` contracts advertised setters even for calculated implementations whose setters could only throw. This made callers believe all dimensions were writable and obscured the actual ReactiveUI requirement: observable getters need correct `PropertyChanged` notifications, not fake setters.

## Impact

Computed dimensions now expose read-only contracts. Writable bounds, physical borders and ratios use `IMutableDisplayBounds`, `IMutableDisplaySize` and `IMutableDisplayRatio`. Internal consumers that perform writes were retagged to the corresponding mutable contract. Persistence DTOs and formats are unchanged.

## Validation

- `LittleBigMouse.DisplayLayout.Tests`: 125 passed
- full solution build: 0 errors
- `git diff --check`: clean
- Linux Release smoke launch: UI and evdev hook started with a 3-zone layout