### PR TITLE
Keep dimension editors valid and wheel-stable

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionContractTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/DimensionContractTests.cs
@@ -180,4 +180,21 @@ public class DimensionContractTests
         Assert.Equal(55, product.X);
         Assert.Equal(91, product.Y);
     }
+
+    [Fact]
+    public void PerMonitorBordersRejectNegativeValues()
+    {
+        var borders = new DisplayBorders
+        {
+            Left = -1,
+            Top = -2,
+            Right = -3,
+            Bottom = -4,
+        };
+
+        Assert.Equal(0, borders.Left);
+        Assert.Equal(0, borders.Top);
+        Assert.Equal(0, borders.Right);
+        Assert.Equal(0, borders.Bottom);
+    }
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorders.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Dimensions/DisplayBorders.cs
@@ -1,14 +1,17 @@
-﻿using ReactiveUI;
+﻿using System;
+using ReactiveUI;
 
 namespace LittleBigMouse.DisplayLayout.Dimensions;
 
 public class DisplayBorders : ReactiveObject
 {
-   public double Left { get; set => this.RaiseAndSetIfChanged(ref field, value); }
+   static double NonNegative(double value) => Math.Max(0.0, value);
 
-   public double Top { get; set => this.RaiseAndSetIfChanged(ref field, value); }
+   public double Left { get; set => this.RaiseAndSetIfChanged(ref field, NonNegative(value)); }
 
-   public double Right { get; set => this.RaiseAndSetIfChanged(ref field, value); }
+   public double Top { get; set => this.RaiseAndSetIfChanged(ref field, NonNegative(value)); }
 
-   public double Bottom { get; set => this.RaiseAndSetIfChanged(ref field, value); }
+   public double Right { get; set => this.RaiseAndSetIfChanged(ref field, NonNegative(value)); }
+
+   public double Bottom { get; set => this.RaiseAndSetIfChanged(ref field, NonNegative(value)); }
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderResistanceView.axaml.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderResistanceView.axaml.cs
@@ -25,11 +25,8 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Threading;
 using HLab.Base.Avalonia.Controls;
 using HLab.Mvvm.Annotations;
-using HLab.Sys.Windows.API;
-using LittleBigMouse.Plugin.Layout.Avalonia.SizePlugin;
 using LittleBigMouse.Plugins;
 using LittleBigMouse.Plugins.Avalonia;
 
@@ -41,6 +38,8 @@ namespace LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
 // but it meant BorderResistanceViewModel was never actually instantiated.
 public partial class BorderResistanceView : UserControl, IView<BorderResistanceViewMode, BorderResistanceViewModel>, IMonitorFrameContentViewClass
 {
+    readonly WheelPointerCapture _wheelPointerCapture = new();
+
     public BorderResistanceView()
     {
         InitializeComponent();
@@ -92,24 +91,10 @@ public partial class BorderResistanceView : UserControl, IView<BorderResistanceV
     {
         if (sender is not DoubleBox db) return;
 
-        var p = e.GetPosition(db);
-        var rx = p.X / db.Bounds.Width;
-        var ry = p.Y / db.Bounds.Height;
-
         // Floored here as well as in the model: the wheel would otherwise walk the
         // box down into negatives that the model silently drops.
         db.Value = Math.Max(0, db.Value + WheelDelta(e));
         this.GetLayout()?.Compact();
-
-        // Keeping the pointer over the box it is scrolling is a Win32-only nicety;
-        // the P/Invoke would throw DllNotFoundException on Linux.
-        if (!OperatingSystem.IsWindows()) return;
-
-        Dispatcher.UIThread.InvokeAsync(() =>
-        {
-            var p2 = new Point(rx * db.Bounds.Width, ry * db.Bounds.Height);
-            var l = db.PointToScreen(p2);
-            WinUser.SetCursorPos((int)l.X, (int)l.Y);
-        }, DispatcherPriority.Loaded);
+        _wheelPointerCapture.KeepOn(db, e.Pointer);
     }
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LittleBigMouse.Plugin.Layout.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LittleBigMouse.Plugin.Layout.Avalonia.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="LittleBigMouse.Ui.Avalonia.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Assets\**" />
   </ItemGroup>
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LocationPlugin/MonitorLocationView.axaml.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LocationPlugin/MonitorLocationView.axaml.cs
@@ -63,6 +63,8 @@ public static class MonitorAnchorsExtensions
 
 internal partial class MonitorLocationView : UserControl, IView<MonitorLocationViewMode, MonitorLocationViewModel>, IMonitorFrameContentViewClass
 {
+    readonly WheelPointerCapture _wheelPointerCapture = new();
+
     public MonitorLocationView()
     {
         InitializeComponent();
@@ -201,20 +203,10 @@ internal partial class MonitorLocationView : UserControl, IView<MonitorLocationV
     {
         if (sender is not DoubleBox db) return;
 
-        var p = e.GetPosition(db);
-        var rx = p.X / db.Bounds.Width;
-        var ry = p.Y / db.Bounds.Height;
-
         db.Value += WheelDelta(e);
 
         this.GetLayout()?.Compact();
-
-        Dispatcher.UIThread.InvokeAsync(() => 
-        {
-            var p2 = new Point(rx * db.Bounds.Width, ry * db.Bounds.Height);
-            var l = db.PointToScreen(p2);
-            SetCursorPos((int)l.X, (int)l.Y);
-        }, DispatcherPriority.Loaded);
+        _wheelPointerCapture.KeepOn(db, e.Pointer);
     }
 
     void OnMouseDoubleClick(object sender, PointerPressedEventArgs e)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/MonitorSizeView.axaml
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/MonitorSizeView.axaml
@@ -235,7 +235,7 @@
 		<!-- Borders -->
 		<Grid ColumnDefinitions="*,*,*,*">
 			<!-- Top Border -->
-			<controls:DoubleBox Grid.Column="1"
+			<sizePlugin:NonNegativeDoubleBox Grid.Column="1"
 								HorizontalAlignment="Center"
 								VerticalAlignment="Top"
 								PointerWheelChanged="OnMouseWheel"
@@ -244,7 +244,7 @@
                             />
 
 			<!-- Left Border -->
-			<controls:DoubleBox Grid.Column="0"
+			<sizePlugin:NonNegativeDoubleBox Grid.Column="0"
 								HorizontalAlignment="Left"
 								VerticalAlignment="Center"
 								PointerWheelChanged="OnMouseWheel"
@@ -253,7 +253,7 @@
                             />
 
 			<!-- Bottom Border -->
-			<controls:DoubleBox Grid.Column="1"
+			<sizePlugin:NonNegativeDoubleBox Grid.Column="1"
 								HorizontalAlignment="Center"
 								VerticalAlignment="Bottom"
 								PointerWheelChanged="OnMouseWheel"
@@ -262,7 +262,7 @@
                             />
 
 			<!-- Right Border -->
-			<controls:DoubleBox Grid.Column="3"
+			<sizePlugin:NonNegativeDoubleBox Grid.Column="3"
 								HorizontalAlignment="Right"
 								VerticalAlignment="Center"
 								PointerWheelChanged="OnMouseWheel"

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/MonitorSizeView.axaml.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/MonitorSizeView.axaml.cs
@@ -24,10 +24,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Threading;
 using HLab.Base.Avalonia.Controls;
 using HLab.Mvvm.Annotations;
-using HLab.Sys.Windows.API;
 using LittleBigMouse.Plugins;
 using LittleBigMouse.Plugins.Avalonia;
 
@@ -35,6 +33,8 @@ namespace LittleBigMouse.Plugin.Layout.Avalonia.SizePlugin;
 
 public partial class MonitorSizeView : UserControl, IView<ScreenSizeViewMode, ScreenSizeViewModel>, IMonitorFrameContentViewClass
 {
+    readonly WheelPointerCapture _wheelPointerCapture = new();
+
     public MonitorSizeView()
     {
         InitializeComponent();
@@ -65,18 +65,8 @@ public partial class MonitorSizeView : UserControl, IView<ScreenSizeViewMode, Sc
     {
         if (sender is not DoubleBox db) return;
 
-        var p = e.GetPosition(db);
-        var rx = p.X / db.Bounds.Width;
-        var ry = p.Y / db.Bounds.Height;
-
         db.Value += WheelDelta(e);
         this.GetLayout()?.Compact();
-
-        Dispatcher.UIThread.InvokeAsync(() =>
-        {
-            var p2 = new Point(rx * db.Bounds.Width, ry * db.Bounds.Height);
-            var l = db.PointToScreen(p2);
-            WinUser.SetCursorPos((int)l.X, (int)l.Y);
-        }, DispatcherPriority.Loaded);
+        _wheelPointerCapture.KeepOn(db, e.Pointer);
     }
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/NonNegativeDoubleBox.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/SizePlugin/NonNegativeDoubleBox.cs
@@ -1,0 +1,24 @@
+using Avalonia;
+using HLab.Base.Avalonia.Controls;
+
+namespace LittleBigMouse.Plugin.Layout.Avalonia.SizePlugin;
+
+/// <summary>
+/// Numeric editor for dimensions that cannot be negative. Coercing the control value
+/// keeps rejected input from remaining visible when the model is already at zero and
+/// therefore has no property change to emit back to the binding.
+/// </summary>
+internal class NonNegativeDoubleBox : DoubleBox
+{
+    // DoubleBox's theme uses an exact type selector. Reuse its style key so this
+    // specialized editor keeps the standard template instead of rendering empty.
+    protected override Type StyleKeyOverride => typeof(DoubleBox);
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == ValueProperty && Value < 0)
+            SetCurrentValue(ValueProperty, 0.0);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/WheelPointerCapture.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/WheelPointerCapture.cs
@@ -1,0 +1,75 @@
+using Avalonia.Input;
+
+namespace LittleBigMouse.Plugin.Layout.Avalonia;
+
+/// <summary>
+/// Keeps a wheel interaction routed to the same editor when changing the model
+/// moves that editor away from the stationary pointer. The capture ends as soon
+/// as the user moves or presses the pointer.
+/// </summary>
+internal sealed class WheelPointerCapture
+{
+    IPointer? _pointer;
+    InputElement? _target;
+
+    public void KeepOn(InputElement target, IPointer pointer)
+    {
+        if (ReferenceEquals(_target, target) && ReferenceEquals(_pointer, pointer))
+        {
+            if (!ReferenceEquals(pointer.Captured, target)) pointer.Capture(target);
+            return;
+        }
+
+        Release();
+
+        _pointer = pointer;
+        _target = target;
+
+        target.PointerMoved += OnPointerMoved;
+        target.PointerPressed += OnPointerPressed;
+        target.PointerCaptureLost += OnPointerCaptureLost;
+
+        pointer.Capture(target);
+    }
+
+    public void Release()
+    {
+        var pointer = _pointer;
+        var target = _target;
+
+        _pointer = null;
+        _target = null;
+
+        if (target != null)
+        {
+            target.PointerMoved -= OnPointerMoved;
+            target.PointerPressed -= OnPointerPressed;
+            target.PointerCaptureLost -= OnPointerCaptureLost;
+        }
+
+        if (pointer != null && ReferenceEquals(pointer.Captured, target))
+            pointer.Capture(null);
+    }
+
+    void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (ReferenceEquals(e.Pointer, _pointer)) Release();
+    }
+
+    void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (ReferenceEquals(e.Pointer, _pointer)) Release();
+    }
+
+    void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        var target = _target;
+        _pointer = null;
+        _target = null;
+
+        if (target == null) return;
+        target.PointerMoved -= OnPointerMoved;
+        target.PointerPressed -= OnPointerPressed;
+        target.PointerCaptureLost -= OnPointerCaptureLost;
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DimensionTextBoxTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DimensionTextBoxTests.cs
@@ -1,0 +1,39 @@
+using HLab.Base.Avalonia.Controls;
+using LittleBigMouse.Plugin.Layout.Avalonia.SizePlugin;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+public sealed class DimensionTextBoxTests
+{
+    sealed class InspectableBorderEditor : NonNegativeDoubleBox
+    {
+        public Type EffectiveStyleKey => StyleKeyOverride;
+    }
+
+    [Fact]
+    public void BorderEditorCoercesNegativeValuesToZero()
+    {
+        var editor = new NonNegativeDoubleBox { Value = 12.5 };
+
+        editor.Value = -1;
+
+        Assert.Equal(0, editor.Value);
+    }
+
+    [Fact]
+    public void BorderEditorPreservesPositiveValues()
+    {
+        var editor = new NonNegativeDoubleBox { Value = 12.5 };
+
+        Assert.Equal(12.5, editor.Value);
+    }
+
+    [Fact]
+    public void BorderEditorUsesTheStandardDoubleBoxStyle()
+    {
+        var editor = new InspectableBorderEditor();
+
+        Assert.Equal(typeof(DoubleBox), editor.EffectiveStyleKey);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/WheelPointerCaptureTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/WheelPointerCaptureTests.cs
@@ -1,0 +1,48 @@
+using Avalonia.Input;
+using HLab.Base.Avalonia.Controls;
+using LittleBigMouse.Plugin.Layout.Avalonia;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+public sealed class WheelPointerCaptureTests
+{
+    [Fact]
+    public void KeepsWheelPointerCapturedByTheEditor()
+    {
+        using var pointer = new Pointer(1, PointerType.Mouse, true);
+        var editor = new DoubleBox();
+        var capture = new WheelPointerCapture();
+
+        capture.KeepOn(editor, pointer);
+
+        Assert.Same(editor, pointer.Captured);
+    }
+
+    [Fact]
+    public void ReleaseReturnsPointerToNormalHitTesting()
+    {
+        using var pointer = new Pointer(1, PointerType.Mouse, true);
+        var editor = new DoubleBox();
+        var capture = new WheelPointerCapture();
+        capture.KeepOn(editor, pointer);
+
+        capture.Release();
+
+        Assert.Null(pointer.Captured);
+    }
+
+    [Fact]
+    public void ANewWheelTargetReplacesThePreviousCapture()
+    {
+        using var pointer = new Pointer(1, PointerType.Mouse, true);
+        var first = new DoubleBox();
+        var second = new DoubleBox();
+        var capture = new WheelPointerCapture();
+        capture.KeepOn(first, pointer);
+
+        capture.KeepOn(second, pointer);
+
+        Assert.Same(second, pointer.Captured);
+    }
+}


### PR DESCRIPTION
## What changed

- clamp persisted monitor borders to non-negative values
- use a dedicated non-negative border editor while retaining the standard `DoubleBox` theme
- keep wheel input captured by dimension editors when layout changes move them away from the stationary pointer
- apply the portable wheel behavior to size, location, and border-resistance editors

## Why

Negative bezels are invalid, but rejected values could remain visible when the model was already at zero. The first specialized editor also lost its template because the existing Avalonia style targets the exact `DoubleBox` style key. Separately, wheel continuity relied on Win32 cursor warping and therefore did not work on Linux/Wayland.

The editor now coerces invalid input locally, explicitly reuses the standard style key, and uses Avalonia pointer capture instead of platform cursor APIs.

## Validation

- DisplayLayout tests: 126 passed
- Avalonia UI tests: 135 passed
- Release build succeeded
- manually verified on Linux that border fields remain visible, reject negative values, and retain wheel interaction while moving
