### PR TITLE
hook: preserve application pointer confinement

### DIFF
--- a/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/daemon/mod.rs
@@ -110,7 +110,7 @@ pub fn receive_message(
 /// the UI drop live preview on the stop and then find nothing left to act on.
 pub fn rescue_fired(shared: &'static Shared) {
     eprintln!("[LittleBigMouse.Hook] rescue: freeing the cursor and stopping");
-    crate::platform::cursor::release_clip();
+    crate::platform::cursor::force_release_clip();
     shared.broadcast(protocol::RESCUED);
     hook::request_unhook(shared);
     shared.paused.store(false, Ordering::SeqCst);
@@ -209,16 +209,15 @@ fn load_layout(shared: &Shared, xml: &str, keep_hooked: bool) -> Option<LoadInfo
         // this is what lets a Stop/Start (Load) heal crossing instead of staying broken.
         // Before the move: the layout is about to be handed to the engine.
         adopt_rescue_shortcut(shared, &layout.rescue_shortcut);
-        shared
-            .engine
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .load(layout);
-        // The one thing the teardown used to guarantee: a cursor confined by the
-        // outgoing geometry is never left confined by it. The engine re-clips on the
-        // next move if the new layout still calls for it.
-        if keep_hooked {
-            crate::platform::cursor::release_clip();
+        {
+            let mut engine = shared.engine.lock().unwrap_or_else(|p| p.into_inner());
+            // A Load+Run keeps the hook alive. Restore the outgoing engine's clip
+            // BEFORE replacing its tracking state, but only when that exact LBM
+            // clip is still active. A game-owned replacement must survive reload.
+            if keep_hooked {
+                crate::platform::cursor::restore_managed_clip(&mut engine);
+            }
+            engine.load(layout);
         }
         // Kept for the edge prober, which re-parses rather than touching the
         // live engine.

--- a/LittleBigMouse-Hook-Rust/src/engine/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/engine/mod.rs
@@ -23,6 +23,12 @@ enum Mode {
     Cross,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FreelookReason {
+    CursorHidden,
+    ExternalClip,
+}
+
 /// Identity of a zone-border link, replacing the C++ `const ZoneLink*` pointer
 /// used to detect "same border as last event" for resistance tracking.
 ///
@@ -42,7 +48,12 @@ pub struct MouseEngine {
 
     old_point: Point<i32>,
     old_zone: Option<ZoneId>,
+    /// Clip that was active before LBM first confined the cursor. Kept until
+    /// LBM restores it or another application replaces our confinement.
     old_clip_rect: Rect<i32>,
+    /// Last clip LBM applied. This is the ownership check that prevents a
+    /// teardown/reload from restoring over a newer game-owned ClipCursor rect.
+    managed_clip_rect: Rect<i32>,
     mode: Mode,
 
     current_resistance: Option<ResistanceKey>,
@@ -60,6 +71,7 @@ impl MouseEngine {
             old_point: Point::default(),
             old_zone: None,
             old_clip_rect: Rect::empty(),
+            managed_clip_rect: Rect::empty(),
             mode: Mode::ExtFirst,
             current_resistance: None,
             border_resistance: 0.0,
@@ -86,14 +98,34 @@ impl MouseEngine {
     // --- clip save/restore ---------------------------------------------------
 
     fn save_clip(&mut self, env: &impl CursorEnv) {
-        self.old_clip_rect = env.get_clip();
+        // A resisted border can apply the same confinement for many consecutive
+        // events. Preserve the clip from before LBM's FIRST write; overwriting it
+        // with our own zone rect would later restore a stale LBM confinement.
+        if self.old_clip_rect.is_empty() {
+            self.old_clip_rect = env.get_clip();
+        }
     }
 
-    fn reset_clip(&mut self, env: &mut impl CursorEnv) {
-        if !self.old_clip_rect.is_empty() {
+    fn set_managed_clip(&mut self, env: &mut impl CursorEnv, rect: Rect<i32>) {
+        env.set_clip(rect);
+        self.managed_clip_rect = rect;
+    }
+
+    fn owns_current_clip(&self, env: &impl CursorEnv) -> bool {
+        !self.managed_clip_rect.is_empty() && env.get_clip() == self.managed_clip_rect
+    }
+
+    /// Restore only a confinement LBM still owns.
+    ///
+    /// `ClipCursor` is process-global. A game may replace our temporary zone
+    /// clip before the next mouse event; in that case its new rect is ownership
+    /// changing hands, not something LBM is allowed to overwrite or clear.
+    pub(crate) fn restore_managed_clip(&mut self, env: &mut impl CursorEnv) {
+        if !self.old_clip_rect.is_empty() && self.owns_current_clip(env) {
             env.set_clip(self.old_clip_rect);
-            self.old_clip_rect = Rect::empty();
         }
+        self.old_clip_rect = Rect::empty();
+        self.managed_clip_rect = Rect::empty();
     }
 
     // --- entry: freelook gate + dispatch (C++ MouseEngine::OnMouseMove) -------
@@ -106,24 +138,33 @@ impl MouseEngine {
         } else if self.was_freelook {
             env.tick_count().wrapping_sub(self.last_freelook_check)
                 >= self.layout.freelook_check_interval_ms as u64
-        } else if self.mode == Mode::ExtFirst || self.old_zone.is_none() {
+        } else if self.mode == Mode::ExtFirst {
             true
-        } else {
-            let bounds = self.layout.arena[self.old_zone.unwrap()].pixels_bounds();
+        } else if let Some(old_zone) = self.old_zone {
+            let bounds = self.layout.arena[old_zone].pixels_bounds();
             e.point.x() <= bounds.left()
                 || e.point.x() >= bounds.right() - 1
                 || e.point.y() <= bounds.top()
                 || e.point.y() >= bounds.bottom() - 1
+        } else {
+            true
         };
 
         if check_freelook {
             self.last_freelook_check = env.tick_count();
-            let freelook = self.is_freelook_active(env);
+            let reason = self.freelook_reason(env);
+            let freelook = reason.is_some();
             if freelook != self.was_freelook {
                 if freelook {
                     // Entering freelook: hand the game a clean cursor environment.
-                    self.reset_clip(env);
+                    self.restore_managed_clip(env);
                     self.reset();
+                    eprintln!(
+                        "[LittleBigMouse.Hook] pointer-capture bypass entered: {:?}",
+                        reason.unwrap()
+                    );
+                } else {
+                    eprintln!("[LittleBigMouse.Hook] pointer-capture bypass left");
                 }
                 self.was_freelook = freelook;
             }
@@ -140,20 +181,21 @@ impl MouseEngine {
         }
     }
 
-    fn is_freelook_active(&self, env: &impl CursorEnv) -> bool {
+    fn freelook_reason(&self, env: &impl CursorEnv) -> Option<FreelookReason> {
         if env.cursor_hidden() {
-            return true;
+            return Some(FreelookReason::CursorHidden);
         }
-        // Skip the clip check when LBM itself set the clip.
-        if self.old_clip_rect.is_empty() && env.clip_is_subrect_of_virtual_screen() {
-            return true;
+        // Skip the clip check only while LBM's own rect is still active. If a
+        // game replaced it, ownership changed and its confinement is freelook.
+        if !self.owns_current_clip(env) && env.clip_is_subrect_of_virtual_screen() {
+            return Some(FreelookReason::ExternalClip);
         }
-        false
+        None
     }
 
     /// C++ `CheckForStopped`.
     fn check_for_stopped(&mut self, env: &mut impl CursorEnv, e: &MouseEventArg) -> bool {
-        self.reset_clip(env);
+        self.restore_managed_clip(env);
         if e.running {
             return false;
         }
@@ -558,14 +600,14 @@ impl MouseEngine {
             if rect.contains(pos) {
                 continue;
             }
-            env.set_clip(*rect);
+            self.set_managed_clip(env, *rect);
             pos = env.get_mouse_location();
             if rect.contains(p_out) {
                 break;
             }
         }
 
-        env.set_clip(r);
+        self.set_managed_clip(env, r);
         env.set_mouse_location(p_out);
         e.handled = true;
     }
@@ -574,7 +616,7 @@ impl MouseEngine {
     fn no_zone_matches(&mut self, env: &mut impl CursorEnv, e: &mut MouseEventArg) {
         self.save_clip(env);
         let bounds = self.layout.arena[self.old_zone.unwrap()].pixels_bounds();
-        env.set_clip(bounds);
+        self.set_managed_clip(env, bounds);
         e.handled = false;
     }
 
@@ -927,6 +969,59 @@ mod tests {
         let ev = feed(&mut eng, &mut env, 0, 1000);
         assert!(!ev.handled, "freelook must pass the event through");
         assert_eq!(env.pos, Point::new(0, 0), "cursor untouched in freelook");
+    }
+
+    #[test]
+    fn repeated_lbm_confinement_restores_the_original_clip() {
+        let mut eng = engine();
+        let mut env = FakeCursor::new();
+        let original = env.clip;
+        let first_lbm_clip = Rect::new(-3840, 0, 3840, 2160);
+        let second_lbm_clip = Rect::new(0, 0, 3840, 2160);
+
+        eng.save_clip(&env);
+        eng.set_managed_clip(&mut env, first_lbm_clip);
+        // A second resisted/crossing frame must not replace `original` with
+        // the first LBM rect.
+        eng.save_clip(&env);
+        eng.set_managed_clip(&mut env, second_lbm_clip);
+        eng.restore_managed_clip(&mut env);
+
+        assert_eq!(env.clip, original);
+        assert!(eng.old_clip_rect.is_empty());
+        assert!(eng.managed_clip_rect.is_empty());
+    }
+
+    #[test]
+    fn game_clip_that_replaces_lbm_clip_survives_restore() {
+        let mut eng = engine();
+        let mut env = FakeCursor::new();
+        let lbm_clip = Rect::new(-3840, 0, 3840, 2160);
+        let game_clip = Rect::new(700, 300, 1920, 1080);
+
+        eng.save_clip(&env);
+        eng.set_managed_clip(&mut env, lbm_clip);
+        // Another process calls ClipCursor after LBM. Its differing rect proves
+        // that LBM no longer owns the global confinement.
+        env.clip = game_clip;
+        eng.restore_managed_clip(&mut env);
+
+        assert_eq!(env.clip, game_clip, "LBM must not overwrite a newer game clip");
+        assert!(eng.old_clip_rect.is_empty());
+        assert!(eng.managed_clip_rect.is_empty());
+    }
+
+    #[test]
+    fn game_clip_replacing_lbm_clip_is_detected_as_freelook() {
+        let mut eng = engine();
+        let mut env = FakeCursor::new();
+
+        eng.save_clip(&env);
+        eng.set_managed_clip(&mut env, Rect::new(-3840, 0, 3840, 2160));
+        env.clip = Rect::new(700, 300, 1920, 1080);
+        env.clipped_sub = true;
+
+        assert_eq!(eng.freelook_reason(&env), Some(FreelookReason::ExternalClip));
     }
 
     #[test]

--- a/LittleBigMouse-Hook-Rust/src/hook/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/mod.rs
@@ -110,10 +110,9 @@ pub(crate) fn on_resume(shared: &Shared) {
     if !shared.suspended.swap(false, Ordering::SeqCst) {
         return; // was not suspended
     }
-    // Never come back from sleep with the cursor still confined: if a clip lingered across the
-    // suspend (or the OS set one during the display transition), a leftover sub-virtual-screen clip
-    // makes the engine read "freelook" and stop crossing. Release it before the UI re-Starts us.
-    crate::platform::cursor::release_clip();
+    // The suspend-side unhook already restores a clip LBM still owns. Do not call
+    // ClipCursor(NULL) here: a game or remote-control app may legitimately have
+    // installed a new confinement while the display/session was transitioning.
     shared.broadcast(protocol::RESUMED);
 }
 

--- a/LittleBigMouse-Hook-Rust/src/hook/windows/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/windows/mod.rs
@@ -188,9 +188,6 @@ impl Hooker {
             e.running = false;
             engine.on_mouse_move(&mut env, &mut e);
         }
-        // Safety net: never leave the cursor confined once we stop managing it.
-        crate::platform::cursor::release_clip();
-
         shared.hooked.store(false, Ordering::SeqCst);
         shared.broadcast(protocol::STOPPED);
     }

--- a/LittleBigMouse-Hook-Rust/src/platform/linux/cursor.rs
+++ b/LittleBigMouse-Hook-Rust/src/platform/linux/cursor.rs
@@ -5,7 +5,11 @@
 //! Linux the way to read/warp/confine the cursor is inseparable from the way
 //! events are captured.
 
-/// Release any cursor confinement. On Linux confinement is owned by the active
-/// backend session (X11 grab / portal barriers) and is torn down with it —
-/// there is no process-global clip to clear, unlike Win32's `ClipCursor(NULL)`.
-pub fn release_clip() {}
+/// Force-release cursor confinement for the explicit rescue shortcut. On Linux
+/// confinement is owned by the active backend session (X11 grab / portal barriers)
+/// and is torn down with it, so there is no process-global clip to clear.
+pub fn force_release_clip() {}
+
+/// Linux confinement belongs to the active input backend rather than a global
+/// cursor API, so a hot layout reload has no Win32-style clip to restore here.
+pub fn restore_managed_clip(_engine: &mut crate::engine::MouseEngine) {}

--- a/LittleBigMouse-Hook-Rust/src/platform/windows/cursor.rs
+++ b/LittleBigMouse-Hook-Rust/src/platform/windows/cursor.rs
@@ -15,12 +15,20 @@ use windows::Win32::System::SystemInformation::GetTickCount64;
 use crate::engine::cursor::CursorEnv;
 use crate::geometry::{Point, Rect};
 
-/// Release any cursor confinement (`ClipCursor(NULL)`). Called on unhook so a
-/// stopped daemon never leaves the cursor clipped to a sub-region.
-pub fn release_clip() {
+/// Force-release every cursor confinement (`ClipCursor(NULL)`). This deliberately
+/// ignores ownership and is therefore reserved for the explicit rescue shortcut.
+pub fn force_release_clip() {
     unsafe {
         let _ = ClipCursor(None);
     }
+}
+
+/// Restore the confinement saved by the engine when it is still the active LBM
+/// rect. Kept platform-side so shared daemon code does not construct a Win32
+/// cursor environment on other targets.
+pub fn restore_managed_clip(engine: &mut crate::engine::MouseEngine) {
+    let mut env = Win32Cursor;
+    engine.restore_managed_clip(&mut env);
 }
 
 pub struct Win32Cursor;


### PR DESCRIPTION
Addresses the pointer-confinement half of #541. This intentionally does not close the issue before the Windows test build is validated.

## Root cause

The Rust hook introduced unconditional `ClipCursor(NULL)` calls on ordinary unhook, resume, and hot-layout-reload paths. `ClipCursor` is global state: those calls could clear confinement installed by a foreground game, even when LBM did not own it.

The engine also remembered only the pre-crossing clip, without tracking the last rect LBM applied. That made it impossible to tell whether a game had replaced LBM's temporary confinement before cleanup.

## Change

- Track both the original clip and the last clip applied by LBM.
- Restore the original only if the exact LBM rect is still active.
- Preserve a newer rect installed by a game or remote-control application.
- Restore LBM-owned state before a hot layout reload.
- Remove unconditional clip clearing from normal unhook and resume.
- Reserve ownership-blind `ClipCursor(NULL)` for the explicit rescue shortcut.
- Report whether automatic pointer-capture bypass entered because the cursor was hidden or externally confined.

## Validation

- `cargo test --manifest-path LittleBigMouse-Hook-Rust/Cargo.toml -- --test-threads=1`: 87 passed.
- `cargo clippy --all-targets --target x86_64-pc-windows-gnu --manifest-path LittleBigMouse-Hook-Rust/Cargo.toml -- -D warnings`: clean.
- Windows cross-target release build: clean.
- GitHub Actions Windows/MSVC build, dependency checks and installer smoke test: passed.
- Added regression coverage for repeated LBM clips, application takeover, and freelook detection after takeover.

## Test build

[Download the Windows portable artifact](https://github.com/mgth/LittleBigMouse/actions/runs/32142313367/artifacts/9326537408) produced from commit `f930498`. GitHub retains it until 2026-11-16.

## Windows test checklist

- Genshin Impact in borderless mode with “Pause in games” enabled.
- The game listed under Excluded Processes.
- Apply a layout or power a secondary display off/on while the game owns the pointer.
- Switch launcher → game → desktop and check for a jump to the last monitor border.