### PR TITLE
Honor start minimized for every automatic startup window

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -286,7 +286,11 @@ public class MainService : ReactiveModel, IMainService
         // window instead of doing nothing. Raised on a background thread.
         if (Program.SingleInstance is { } singleInstance)
         {
-            singleInstance.ShowRequested += () => Dispatcher.UIThread.Post(() => _ = ShowControlAsync());
+            singleInstance.ShowRequested += () =>
+            {
+                Console.Error.WriteLine("Single-instance activation requested: showing the control window.");
+                Dispatcher.UIThread.Post(() => _ = ShowControlAsync());
+            };
         }
 
         // Apply / react to the "hide tray icon" option. The notify service hides the tray icon

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Core/MainBootloader.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Core/MainBootloader.cs
@@ -18,13 +18,20 @@ public class MainBootloader(
 
         await mainService.StartNotifierAsync();
 
-        // Check for update
-        if (mainService.MonitorsLayout.Options.AutoUpdate)
+        var options = mainService.MonitorsLayout.Options;
+        Console.Error.WriteLine(
+            $"Startup options: StartMinimized={options.StartMinimized}, AutoUpdate={options.AutoUpdate}");
+
+        // A blind update check is not actually silent when a newer release exists: the
+        // updater opens its window.  "Start minimized to tray" must suppress every
+        // automatic startup window, not only the main configuration window (#549).
+        if (options.AutoUpdate && !options.StartMinimized)
             await updater.CheckUpdateAsync(false);
 
-        // Show control
-        if (!mainService.MonitorsLayout.Options.StartMinimized)
+        if (!options.StartMinimized)
             await mainService.ShowControlAsync();
+        else
+            Console.Error.WriteLine("Startup UI suppressed: running in the notification area.");
 
         return BootState.Completed;
     }


### PR DESCRIPTION
Fixes #549.

## What changed

- Treat **Start minimized to tray** as a strict no-automatic-window startup policy.
- Skip the automatic update check in that mode, because the supposedly blind check opens the updater window when a release is found.
- Keep manual update checks available from the notification-area menu.
- Log the loaded startup options and any single-instance activation request, so one `ui.log` identifies a second-launch edge case without another diagnostic build.

## Root cause

The main configuration window already honored `StartMinimized`, but the automatic update check ran first. When it found an update it created its own window, bypassing the startup preference.

## Validation

`dotnet test LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LittleBigMouse.Ui.Avalonia.Tests.csproj --no-restore -c Release -m:1 --disable-build-servers`

135 tests passed.