### PR TITLE
Extract VCP calibration service

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/CalibrationServiceTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/CalibrationServiceTests.cs
@@ -1,0 +1,154 @@
+using LittleBigMouse.Plugin.Vcp.Calibration;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class CalibrationServiceTests
+{
+    readonly CalibrationService _service = new();
+
+    [Fact]
+    public async Task BrightnessCalibrationReturnsMeasuredBusinessPoints()
+    {
+        var hardware = new FakeCalibrationHardware((state, _) => Task.FromResult(
+            new CalibrationMeasurement(
+                Luminance: state.Brightness * 10,
+                ChromaticityX: 0.31,
+                ChromaticityY: 0.33,
+                DeltaE: 1)));
+        var progress = new List<CalibrationProgress>();
+
+        var result = await _service.CalibrateBrightnessAsync(
+            hardware,
+            new BrightnessCalibrationInput(
+                1,
+                2,
+                new HashSet<uint>(),
+                WhitePoint(stablePasses: 1, maximumPasses: 1)),
+            new RecordingProgress(progress));
+
+        Assert.Equal(CalibrationCompletion.Converged, result.Completion);
+        Assert.Collection(result.Points,
+            point => Assert.Equal((1u, 10d), (point.Display.Brightness, point.Measurement.Luminance)),
+            point => Assert.Equal((2u, 20d), (point.Display.Brightness, point.Measurement.Luminance)));
+        Assert.Equal(2, progress.Count(p => p.Stage == CalibrationStage.MeasurementCompleted));
+    }
+
+    [Fact]
+    public async Task ProbeErrorIsPropagatedWithoutInventingAMeasurement()
+    {
+        var expected = new InvalidOperationException("probe disconnected");
+        var hardware = new FakeCalibrationHardware((_, _) => Task.FromException<CalibrationMeasurement>(expected));
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.TuneWhitePointAsync(hardware, WhitePoint(1, 1)));
+
+        Assert.Same(expected, actual);
+        Assert.Equal(1, hardware.MeasurementCount);
+    }
+
+    [Fact]
+    public async Task CancellationStopsAnInFlightHardwareRead()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hardware = new FakeCalibrationHardware(async (_, token) =>
+        {
+            entered.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return default;
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = _service.TuneWhitePointAsync(
+            hardware,
+            WhitePoint(1, 10),
+            cancellationToken: cancellation.Token);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+    }
+
+    [Fact]
+    public async Task WhitePointReportsConvergenceAfterAStablePass()
+    {
+        var hardware = new FakeCalibrationHardware((_, _) => Task.FromResult(
+            new CalibrationMeasurement(100, 0.31, 0.33, 1)));
+
+        var result = await _service.TuneWhitePointAsync(
+            hardware,
+            WhitePoint(stablePasses: 1, maximumPasses: 1));
+
+        Assert.Equal(CalibrationCompletion.Converged, result.Completion);
+        Assert.Equal(1, result.PassCount);
+    }
+
+    [Fact]
+    public async Task WhitePointReportsNonConvergenceAtThePassLimit()
+    {
+        var hardware = new FakeCalibrationHardware((state, _) => Task.FromResult(
+            new CalibrationMeasurement(100, 0.31, 0.33, state.Gains.Red)));
+
+        var result = await _service.TuneWhitePointAsync(
+            hardware,
+            WhitePoint(stablePasses: 2, maximumPasses: 1));
+
+        Assert.Equal(CalibrationCompletion.NotConverged, result.Completion);
+        Assert.Equal(1, result.PassCount);
+        Assert.NotEqual(new CalibrationRgb(2, 2, 2), result.Gains);
+    }
+
+    static WhitePointCalibrationInput WhitePoint(int stablePasses, int maximumPasses) =>
+        new(
+            MaximumGain: 0,
+            TestChannelPairs: false,
+            SettleDelay: TimeSpan.Zero,
+            StablePassesRequired: stablePasses,
+            MaximumPasses: maximumPasses);
+
+    sealed class RecordingProgress(List<CalibrationProgress> entries) : IProgress<CalibrationProgress>
+    {
+        public void Report(CalibrationProgress value) => entries.Add(value);
+    }
+
+    sealed class FakeCalibrationHardware(
+        Func<CalibrationDisplayState, CancellationToken, Task<CalibrationMeasurement>> measure)
+        : ICalibrationHardware
+    {
+        CalibrationDisplayState _state = new(0, 0, new(2, 2, 2));
+
+        public CalibrationRange BrightnessRange { get; } = new(0, 10);
+        public CalibrationRange ContrastRange { get; } = new(0, 10);
+        public CalibrationRgbRanges GainRanges { get; } = new(
+            new(0, 2), new(0, 2), new(0, 2));
+        public CalibrationDisplayState CurrentState => _state;
+        public int MeasurementCount { get; private set; }
+
+        public Task SetBrightnessAsync(uint value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = _state with { Brightness = value };
+            return Task.CompletedTask;
+        }
+
+        public Task SetContrastAsync(uint value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = _state with { Contrast = value };
+            return Task.CompletedTask;
+        }
+
+        public Task SetGainsAsync(CalibrationRgb gains, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = _state with { Gains = gains };
+            return Task.CompletedTask;
+        }
+
+        public Task<CalibrationMeasurement> MeasureAsync(CancellationToken cancellationToken)
+        {
+            MeasurementCount++;
+            return measure(_state, cancellationToken);
+        }
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/LittleBigMouse.Plugin.Vcp.Avalonia.Tests.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/LittleBigMouse.Plugin.Vcp.Avalonia.Tests.csproj
@@ -17,6 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LittleBigMouse.Plugin.Vcp.Avalonia\LittleBigMouse.Plugin.Vcp.Avalonia.csproj" />
+    <ProjectReference Include="..\LittleBigMouse.Plugin.Vcp\LittleBigMouse.Plugin.Vcp.csproj" />
   </ItemGroup>
 </Project>
-

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/Calibration/VcpCalibrationHardware.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/Calibration/VcpCalibrationHardware.cs
@@ -1,0 +1,80 @@
+using HLab.Sys.Argyll;
+using HLab.Sys.Windows.MonitorVcp;
+using LittleBigMouse.Plugin.Vcp.Calibration;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Calibration;
+
+/// <summary>
+/// Adapts the existing DDC/CI controls and blocking Argyll probe to the
+/// UI-neutral calibration hardware port.
+/// </summary>
+internal sealed class VcpCalibrationHardware(VcpControl control, ArgyllProbe probe)
+    : ICalibrationHardware
+{
+    public CalibrationRange BrightnessRange => control.Brightness is { } level
+        ? new(level.Min, level.Max)
+        : new(0, 0);
+
+    public CalibrationRange ContrastRange => control.Contrast is { } level
+        ? new(level.Min, level.Max)
+        : new(0, 0);
+
+    public CalibrationRgbRanges GainRanges => control.Gain is { } gain
+        ? new(
+            new(gain.Red.Min, gain.Red.Max),
+            new(gain.Green.Min, gain.Green.Max),
+            new(gain.Blue.Min, gain.Blue.Max))
+        : new(new(0, 0), new(0, 0), new(0, 0));
+
+    public CalibrationDisplayState CurrentState
+    {
+        get
+        {
+            var gains = control.Gain?.GetValues() ?? [0, 0, 0];
+            return new(
+                control.Brightness?.Value ?? 0,
+                control.Contrast?.Value ?? 0,
+                new(gains[0], gains[1], gains[2]));
+        }
+    }
+
+    public Task SetBrightnessAsync(uint value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (control.Brightness is { } level) level.Value = ClampLevel(level, value);
+        return Task.CompletedTask;
+    }
+
+    public Task SetContrastAsync(uint value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (control.Contrast is { } level) level.Value = ClampLevel(level, value);
+        return Task.CompletedTask;
+    }
+
+    public Task SetGainsAsync(CalibrationRgb gains, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        control.Gain?.SetTo([gains.Red, gains.Green, gains.Blue]);
+        return Task.CompletedTask;
+    }
+
+    public async Task<CalibrationMeasurement> MeasureAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var registration = cancellationToken.Register(probe.Abort);
+        var succeeded = await Task.Run(probe.SpotRead).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!succeeded)
+            throw new CalibrationMeasurementException("ArgyllCMS could not obtain a measurement.");
+
+        var color = probe.ProbedColor;
+        return new(
+            color.xyY.Y,
+            color.xyY.x,
+            color.xyY.y,
+            color.DeltaE00());
+    }
+
+    static uint ClampLevel(MonitorLevel level, uint value) => Math.Clamp(value, level.Min, level.Max);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\..\HLab.Sys\HLab.Sys.Windows.MonitorVcp\HLab.Sys.Windows.MonitorVcp.csproj" />
     <ProjectReference Include="..\..\LittleBigMouse.Core\LittleBigMouse.DisplayLayout\LittleBigMouse.DisplayLayout.csproj" />
     <ProjectReference Include="..\LittleBigMouse.Plugins.Avalonia\LittleBigMouse.Plugins.Avalonia.csproj" />
+    <ProjectReference Include="..\LittleBigMouse.Plugin.Vcp\LittleBigMouse.Plugin.Vcp.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
@@ -37,9 +37,11 @@ using HLab.Sys.Argyll;
 using HLab.Sys.Windows.MonitorVcp;
 using HLab.Sys.Windows.MonitorVcp.Avalonia;
 using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugin.Vcp.Avalonia.Calibration;
 using LittleBigMouse.Plugin.Vcp.Avalonia.Patterns;
 using LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using LittleBigMouse.Plugin.Vcp.Calibration;
 using LiveChartsCore;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView;
@@ -51,7 +53,7 @@ using SkiaSharp;
 namespace LittleBigMouse.Plugin.Vcp.Avalonia;
 
 public class VcpScreenViewModelDesign()
-    : VcpScreenViewModel(vm => new TestPatternButtonViewModel(vm), null, null, null, null), IDesignViewModel;
+    : VcpScreenViewModel(vm => new TestPatternButtonViewModel(vm), null, null, null, null, null), IDesignViewModel;
 
 public record ObserverChoice(ArgyllProbe.ObserverEnum Value, string Label);
 
@@ -73,6 +75,7 @@ public class ProbeLogEntry
 public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
 {
    readonly IVcpService? _vcpService;
+   readonly ICalibrationService _calibrationService;
    readonly CalibrationTaskCoordinator _calibrations;
    static readonly SemaphoreSlim SpotreadCommandGate = new(1, 1);
    int _disposed;
@@ -83,9 +86,11 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
        IVcpService? vcpService,
        ISamsungTizenService? samsungTizenService,
        IHisenseVidaaService? hisenseVidaaService,
-       ILayoutOptions? layoutOptions)
+       ILayoutOptions? layoutOptions,
+       ICalibrationService? calibrationService)
    {
       _vcpService = vcpService;
+      _calibrationService = calibrationService ?? new CalibrationService();
       _calibrations = new CalibrationTaskCoordinator(ReportCalibrationError);
 
       // experimental gate: Argyll calibration and the smart-TV test tooling
@@ -540,16 +545,20 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
    public ObservableCollection<ProbeLogEntry> ProbeLog { get; } = new();
 
    /// <summary>One entry per spot read: channels touched, direction, ΔE00 before → after, verdict.</summary>
-   void ReportProbe(uint[] channels, int n, string arrow, double previous, double current, bool revert = false)
+   void ReportProbe(WhitePointAdjustment adjustment)
    {
-      var r = false; var g = false; var b = false;
-      for (var i = 0; i < n; i++)
-         switch (channels[i])
-         {
-            case 0: r = true; break;
-            case 1: g = true; break;
-            case 2: b = true; break;
-         }
+      var r = adjustment.Channels.HasFlag(CalibrationChannels.Red);
+      var g = adjustment.Channels.HasFlag(CalibrationChannels.Green);
+      var b = adjustment.Channels.HasFlag(CalibrationChannels.Blue);
+      var arrow = adjustment.Direction switch
+      {
+         CalibrationDirection.Down => "↓",
+         CalibrationDirection.Up => "↑",
+         CalibrationDirection.Revert => "↓",
+         _ => "",
+      };
+      var previous = adjustment.PreviousDeltaE;
+      var current = adjustment.CurrentDeltaE;
 
       string delta, verdict;
       IBrush brush;
@@ -563,7 +572,7 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
       else
       {
          delta = $"ΔE00 {previous:0.00} → {current:0.00}";
-         (verdict, brush) = revert
+         (verdict, brush) = adjustment.Direction == CalibrationDirection.Revert
             ? ("revert", NeutralBrush)
             : current.CompareTo(previous) switch
             {
@@ -811,65 +820,31 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
          return Task.CompletedTask;
       }
 
-      var level = Vcp?.Brightness;
-      var gain = Vcp?.Gain;
+      var control = Vcp;
       var lut = ProbeLut;
-      if (level is null || gain is null || lut is null)
+      if (control?.Brightness is null || control.Gain is null || lut is null)
          return Task.CompletedTask;
 
+      var input = new LowLuminanceCalibrationInput(WhitePointInput());
       return RunCalibrationAsync(
           "low-luminance probe",
           ArgyllProbe,
-          token => ProbeLowLuminanceCoreAsync(level, gain, lut, token),
+          control,
+          async (hardware, progress, token) =>
+          {
+             var result = await _calibrationService.CalibrateLowLuminanceAsync(
+                 hardware, input, progress, token).ConfigureAwait(false);
+             SetCompletionMessage(result.Completion);
+          },
+          progress => ProjectLowLuminanceProgress(lut, progress),
           cancellationToken);
-   }
-
-   async Task ProbeLowLuminanceCoreAsync(
-       MonitorLevel level,
-       MonitorRgbLevel gain,
-       ProbeLut lut,
-       CancellationToken cancellationToken)
-   {
-      var max = gain.Red.Max;
-      var min = gain.Red.Min;
-      var old = lut.Luminance;
-      level.Value = 0;
-
-      try
-      {
-         for (var i = max; i >= min; i--)
-         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await TuneWhitePointCoreAsync(gain, i, cancellationToken).ConfigureAwait(false);
-
-            var t = lut.Current;
-            if (ArgyllProbe.SpotRead())
-            {
-               t.Y = ArgyllProbe.ProbedColor.xyY.Y;
-               t.x = ArgyllProbe.ProbedColor.xyY.x;
-               t.y = ArgyllProbe.ProbedColor.xyY.y;
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            lut.RemoveLowBrightness(i);
-            lut.Add(t);
-            lut.Save();
-
-            if (t.MinGain <= min) break;
-         }
-      }
-      finally
-      {
-         lut.Luminance = old;
-      }
    }
 
    async Task ProbeBrightnessAsync(CancellationToken cancellationToken = default)
    {
-      var level = Vcp?.Brightness;
-      var gain = Vcp?.Gain;
+      var control = Vcp;
       var lut = ProbeLut;
-      if (level is null || gain is null || lut is null) return;
+      if (control?.Brightness is null || control.Gain is null || lut is null) return;
 
       // the panel's probe instance: its Message property is bound in the
       // calibration section, so progress and errors are actually visible
@@ -880,95 +855,34 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
          return;
       }
 
-      await _calibrations.RunAsync(
+      var measured = lut.SortedLut
+          .Select(t => (uint)t.Brightness)
+          .ToHashSet();
+      var input = new BrightnessCalibrationInput(
+          control.Brightness.Min,
+          control.Brightness.Max,
+          measured,
+          WhitePointInput());
+
+      await RunCalibrationAsync(
           "brightness probe",
-          async token =>
+          probe,
+          control,
+          async (hardware, progress, token) =>
           {
-             probe.ResetAbort();
-             using var abortRegistration = token.Register(probe.Abort);
-             token.ThrowIfCancellationRequested();
-
-             TuneRunning = true;
-             // the instrument needs several seconds to come up, then may ask for its
-             // calibration position: say so before spotread produces its first output
-             probe.Message = "Initializing instrument — calibration may be requested…";
-
-             try
-             {
-                await Task.Run(
-                    () => ProbeBrightnessCoreAsync(level, gain, lut, probe, token),
-                    token).ConfigureAwait(false);
-             }
-             finally
-             {
-                if (token.IsCancellationRequested) probe.Message = "Tuning stopped";
-                ScheduleOnUi(() => TuneRunning = false);
-             }
+             var result = await _calibrationService.CalibrateBrightnessAsync(
+                 hardware, input, progress, token).ConfigureAwait(false);
+             SetCompletionMessage(result.Completion);
           },
-          cancellationToken).ConfigureAwait(false);
-   }
-
-   async Task ProbeBrightnessCoreAsync(
-       MonitorLevel level,
-       MonitorRgbLevel gain,
-       ProbeLut lut,
-       ArgyllProbe probe,
-       CancellationToken cancellationToken)
-   {
-      for (var i = level.Min; i <= level.Max && !probe.Aborted; i++)
-      {
-         cancellationToken.ThrowIfCancellationRequested();
-         if (lut.SortedLut.Any(t => t.Brightness == i)) continue;
-
-         probe.Message = $"Measuring brightness {i} / {level.Max}…";
-         level.Value = i;
-
-         await TuneWhitePointCoreAsync(gain, 0, cancellationToken).ConfigureAwait(false);
-
-         // aborted mid-tuning: don't record a half-tuned point
-         if (probe.Aborted) break;
-
-         var t = lut.Current;
-         if (probe.SpotRead())
-         {
-            t.Y = probe.ProbedColor.xyY.Y;
-            t.x = probe.ProbedColor.xyY.x;
-            t.y = probe.ProbedColor.xyY.y;
-            t.DeltaE = probe.ProbedColor.DeltaE00();
-         }
-         else if (probe.Aborted) break;
-
-         cancellationToken.ThrowIfCancellationRequested();
-         lut.RemoveBrightness(t.Brightness);
-         lut.Add(t);
-         lut.Save();
-
-         LastMeasure = $"B {t.Brightness:0} → {t.Y:0.0} cd/m² · R {t.Red:0} G {t.Green:0} B {t.Blue:0} · ΔE00 {t.DeltaE:0.00}";
-      }
-
-      probe.Message = probe.Aborted ? "Tuning stopped" : "White point tuning done";
-   }
-
-   static void ProbeLevel(
-       ArgyllProbe probe,
-       Color color,
-       MonitorLevel level,
-       CancellationToken cancellationToken)
-   {
-      _ = color;
-      for (var i = level.Min; i <= level.Max; i++)
-      {
-         cancellationToken.ThrowIfCancellationRequested();
-         level.Value = i;
-         probe.SpotRead();
-      }
+          progress => ProjectBrightnessProgress(lut, progress),
+          cancellationToken,
+          showRunning: true).ConfigureAwait(false);
    }
 
    public Task Probe(CancellationToken cancellationToken = default)
    {
-      var gain = Vcp?.Gain;
-      var contrast = Vcp?.Contrast;
-      if (gain is null || contrast is null) return Task.CompletedTask;
+      var control = Vcp;
+      if (control?.Gain is null || control.Contrast is null) return Task.CompletedTask;
 
       var probe = new ArgyllProbe();
       if (!probe.Installed)
@@ -977,269 +891,123 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
          return Task.CompletedTask;
       }
 
+      var input = new ContrastCalibrationInput(control.Contrast.Min, control.Contrast.Max);
       return RunCalibrationAsync(
           "contrast probe",
           probe,
-          token => ProbeCoreAsync(gain, contrast, probe, token),
+          control,
+          async (hardware, progress, token) =>
+          {
+             await _calibrationService.ProbeContrastAsync(
+                 hardware, input, progress, token).ConfigureAwait(false);
+          },
+          ProjectCalibrationProgress,
           cancellationToken);
    }
 
-   static Task ProbeCoreAsync(
-       MonitorRgbLevel gain,
-       MonitorLevel contrast,
-       ArgyllProbe probe,
-       CancellationToken cancellationToken)
-   {
-      var red = gain.Red.Value;
-      var green = gain.Green.Value;
-      var blue = gain.Blue.Value;
-
-      try
-      {
-         gain.Red.SetToMax();
-         gain.Green.SetToMin();
-         gain.Blue.SetToMin();
-         ProbeLevel(probe, Colors.Red, contrast, cancellationToken);
-
-         gain.Red.SetToMin();
-         gain.Green.SetToMax();
-         gain.Blue.SetToMin();
-         ProbeLevel(probe, Colors.Green, contrast, cancellationToken);
-
-         gain.Red.SetToMin();
-         gain.Green.SetToMin();
-         gain.Blue.SetToMax();
-         ProbeLevel(probe, Colors.Blue, contrast, cancellationToken);
-      }
-      finally
-      {
-         gain.Red.Value = red;
-         gain.Green.Value = green;
-         gain.Blue.Value = blue;
-      }
-
-      return Task.CompletedTask;
-   }
-
-   double[,,] _tune = new double[0, 0, 0];
-
    public Task Tune(CancellationToken cancellationToken = default)
    {
-      var gain = Vcp?.Gain;
-      if (gain is null) return Task.CompletedTask;
+      var control = Vcp;
+      if (control?.Gain is null) return Task.CompletedTask;
 
       return RunCalibrationAsync(
           "white-point tuning",
           ArgyllProbe,
-          token => TuneWhitePointCoreAsync(gain, 0, token),
+          control,
+          async (hardware, progress, token) =>
+          {
+             var result = await _calibrationService.TuneWhitePointAsync(
+                 hardware, WhitePointInput(), progress, token).ConfigureAwait(false);
+             SetCompletionMessage(result.Completion);
+          },
+          ProjectCalibrationProgress,
           cancellationToken);
    }
 
-   async Task TuneWhitePointCoreAsync(
-       MonitorRgbLevel gain,
-       uint max,
-       CancellationToken cancellationToken)
+   WhitePointCalibrationInput WhitePointInput(uint maximumGain = 0)
+      => new(
+          maximumGain,
+          TestPairs,
+          TimeSpan.FromMilliseconds(SelectedSpeed?.SettleMs ?? 500));
+
+   void ProjectCalibrationProgress(CalibrationProgress progress)
    {
-
-      var count = 6;
-      uint channel = 0;
-
-      _tune = new double[gain.Red.Max + 1, gain.Green.Max + 1, gain.Blue.Max + 1];
-
-      var rgb = gain.GetValues();
-
-      try
+      if (progress.Adjustment is { } adjustment)
       {
-         while (count > 0 && !ArgyllProbe.Aborted)
-         {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (await TuneWhitePointChannelAsync(
-                    gain,
-                    channel,
-                    rgb,
-                    max,
-                    cancellationToken).ConfigureAwait(false)) count = 5;
-            else count--;
+         ReportProbe(adjustment);
+         return;
+      }
 
-            channel++;
-            // phases 3-5 move channel pairs, for monitors whose gains interact —
-            // skippable, they double the cycle
-            channel %= TestPairs ? 6u : 3u;
-         }
-      }
-      finally
+      var message = progress.Stage switch
       {
-         gain.SetTo(rgb);
-      }
+         CalibrationStage.Initializing => "Initializing instrument — calibration may be requested…",
+         CalibrationStage.SettingBrightness => $"Measuring brightness {progress.Current} / {progress.Total}…",
+         CalibrationStage.SettingContrast => $"Measuring contrast {progress.Current} / {progress.Total}…",
+         CalibrationStage.Measuring => "Measuring…",
+         _ => null,
+      };
+      if (message is not null) ScheduleOnUi(() => ArgyllProbe.Message = message);
    }
 
-   async Task<bool> TuneWhitePointChannelAsync(
-       MonitorRgbLevel gain,
-       uint channel,
-       uint[] rgb,
-       uint maxLevel,
-       CancellationToken cancellationToken)
+   void ProjectBrightnessProgress(ProbeLut lut, CalibrationProgress progress)
    {
-      uint[] c;
-      var min = new uint[3];
-      var max = new uint[3];
-      uint n = 0;
+      ProjectCalibrationProgress(progress);
+      if (progress.Point is not { } point) return;
 
-      switch (channel)
+      ScheduleOnUi(() =>
       {
-         case 0:
-            c = [0, 1, 2];
-            n = 1;
-            break;
-         case 1:
-            c = [1, 2, 0];
-            n = 1;
-            break;
-         case 2:
-            c = [2, 0, 1];
-            n = 1;
-            break;
-         case 3: //0
-            c = [0, 1, 2];
-            n = 2;
-            break;
-         case 4: //1
-            c = [1, 2, 0];
-            n = 2;
-            break;
-         case 5: //2
-            c = [2, 0, 1];
-            n = 2;
-            break;
-         default:
-            c = [0, 1, 2];
-            n = 3;
-            break;
-      }
-
-
-      for (var i = 0; i < 3; i++)
-      {
-         min[i] = gain.Channel(c[i]).Min;
-         max[i] = maxLevel == 0 ? gain.Channel(c[i]).Max : maxLevel;
-      }
-
-
-      // keep one channel to its max
-      switch (n)
-      {
-         case 1:
-            if (rgb[c[0]] == max[0] && rgb[c[1]] < max[1] && rgb[c[2]] < max[2]) return false;
-            break;
-         case 2:
-            if ((rgb[c[0]] == max[0] || rgb[c[1]] == max[1]) && rgb[c[2]] < max[2]) return false;
-            break;
-         case 3:
-            return false;
-      }
-
-      uint[] oldGain = [rgb[c[0]], rgb[c[1]], rgb[c[2]]];
-
-      var deltaE = await ProbeGainAsync(gain, rgb, cancellationToken).ConfigureAwait(false);
-      ReportProbe(c, (int)n, "", deltaE, deltaE);
-
-      while (!ArgyllProbe.Aborted && rgb[c[0]] > min[0] && (n < 2 || rgb[c[1]] > min[1]) && (n < 3 || rgb[c[2]] > min[2]))
-      {
-         cancellationToken.ThrowIfCancellationRequested();
-         var old = deltaE;
-
-         for (var i = 0; i < n; i++) rgb[c[i]]--;
-
-         deltaE = await ProbeGainAsync(gain, rgb, cancellationToken).ConfigureAwait(false);
-         ReportProbe(c, (int)n, "↓", old, deltaE);
-
-         if (deltaE > old) break;
-      }
-
-      while (!ArgyllProbe.Aborted && rgb[c[0]] < max[0] && (n < 2 || rgb[c[1]] < max[1]) && (n < 3 || rgb[c[2]] < max[2]))
-      {
-         cancellationToken.ThrowIfCancellationRequested();
-         var old = deltaE;
-
-         for (var i = 0; i < n; i++) rgb[c[i]]++;
-
-         deltaE = await ProbeGainAsync(gain, rgb, cancellationToken).ConfigureAwait(false);
-         ReportProbe(c, (int)n, "↑", old, deltaE);
-
-         if (deltaE <= old) continue;
-
-         for (var i = 0; i < n; i++) rgb[c[i]]--;
-         var reverted = deltaE;
-         deltaE = await ProbeGainAsync(gain, rgb, cancellationToken).ConfigureAwait(false);
-         ReportProbe(c, (int)n, "↓", reverted, deltaE, revert: true);
-         break;
-      }
-
-      return (
-          oldGain[0] != rgb[c[0]]
-          || oldGain[1] != rgb[c[1]]
-          || oldGain[2] != rgb[c[2]]
-          );
+         var tune = ToTune(point);
+         lut.RemoveBrightness(tune.Brightness);
+         lut.Add(tune);
+         lut.Save();
+         LastMeasure = $"B {tune.Brightness:0} → {tune.Y:0.0} cd/m² · R {tune.Red:0} G {tune.Green:0} B {tune.Blue:0} · ΔE00 {tune.DeltaE:0.00}";
+      });
    }
 
-   static readonly bool PerfTrace =
-      Environment.GetEnvironmentVariable("LBM_PERF") is "1" or "true" or "yes";
-
-   async Task<double> ProbeGainAsync(
-       MonitorRgbLevel gain,
-       uint[] rgb,
-       CancellationToken cancellationToken)
+   void ProjectLowLuminanceProgress(ProbeLut lut, CalibrationProgress progress)
    {
-      var tune = _tune[rgb[0], rgb[1], rgb[2]];
-      if (tune != 0) return tune;
+      ProjectCalibrationProgress(progress);
+      if (progress.Point is not { } point) return;
 
-      cancellationToken.ThrowIfCancellationRequested();
-      var sw = PerfTrace ? Stopwatch.StartNew() : null;
-      if (sw is not null)
-         Console.Error.WriteLine(
-            $"PERF {DateTime.Now:HH:mm:ss.fff} tune-probe SetTo({rgb[0]},{rgb[1]},{rgb[2]}) queued");
-
-      gain.SetTo(rgb);
-
-      // let the panel settle on the new gains before reading
-      await Task.Delay(SelectedSpeed?.SettleMs ?? 500, cancellationToken).ConfigureAwait(false);
-
-      var settleDone = sw?.ElapsedMilliseconds ?? 0;
-
-      // shared panel instance: spotread's prompts stay visible in the bound Message
-      var probe = ArgyllProbe;
-      if (!probe.Installed)
+      ScheduleOnUi(() =>
       {
-         PleaseInstall();
-         return 0;
-      }
-
-      if (probe.SpotRead())
-      {
-         tune = probe.ProbedColor.DeltaE00();
-         _tune[rgb[0], rgb[1], rgb[2]] = tune;
-      }
-      else if (!probe.Aborted)
-      {
-         // a failed reading must not feed ΔE=0 ("perfect") into the optimizer:
-         // it would walk the gains into the walls one dead cycle at a time
-         probe.Message = "Measurement failed — tuning stopped";
-         probe.Abort();
-      }
-
-      if (sw is not null)
-         Console.Error.WriteLine(
-            $"PERF {DateTime.Now:HH:mm:ss.fff} tune-probe done: settle={settleDone} ms, spotread={sw.ElapsedMilliseconds - settleDone} ms, total={sw.ElapsedMilliseconds} ms");
-
-      return tune;
+         var tune = ToTune(point);
+         lut.RemoveLowBrightness(tune.MaxGain);
+         lut.Add(tune);
+         lut.Save();
+      });
    }
+
+   static Tune ToTune(CalibrationPoint point) => new()
+   {
+      Date = DateTime.Now,
+      Brightness = point.Display.Brightness,
+      Contrast = point.Display.Contrast,
+      Red = point.Display.Gains.Red,
+      Green = point.Display.Gains.Green,
+      Blue = point.Display.Gains.Blue,
+      Y = point.Measurement.Luminance,
+      x = point.Measurement.ChromaticityX,
+      y = point.Measurement.ChromaticityY,
+      DeltaE = point.Measurement.DeltaE,
+   };
+
+   void SetCompletionMessage(CalibrationCompletion completion)
+      => ScheduleOnUi(() => ArgyllProbe.Message = completion == CalibrationCompletion.Converged
+          ? "White point tuning done"
+          : "White point tuning did not converge");
 
    async Task RunCalibrationAsync(
        string operationName,
        ArgyllProbe probe,
-       Func<CancellationToken, Task> operation,
-       CancellationToken cancellationToken)
+       VcpControl control,
+       Func<ICalibrationHardware, IProgress<CalibrationProgress>, CancellationToken, Task> operation,
+       Action<CalibrationProgress> projectProgress,
+       CancellationToken cancellationToken,
+       bool showRunning = false)
    {
+      var hardware = new VcpCalibrationHardware(control, probe);
+      var progress = new CallbackProgress<CalibrationProgress>(projectProgress);
       await _calibrations.RunAsync(
           operationName,
           async token =>
@@ -1247,9 +1015,32 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
              probe.ResetAbort();
              using var abortRegistration = token.Register(probe.Abort);
              token.ThrowIfCancellationRequested();
-             await Task.Run(() => operation(token), token).ConfigureAwait(false);
+             if (showRunning)
+             {
+                ScheduleOnUi(() =>
+                {
+                   TuneRunning = true;
+                   probe.Message = "Initializing instrument — calibration may be requested…";
+                });
+             }
+
+             try
+             {
+                await operation(hardware, progress, token).ConfigureAwait(false);
+             }
+             finally
+             {
+                if (token.IsCancellationRequested)
+                   ScheduleOnUi(() => probe.Message = "Tuning stopped");
+                if (showRunning) ScheduleOnUi(() => TuneRunning = false);
+             }
           },
           cancellationToken).ConfigureAwait(false);
+   }
+
+   sealed class CallbackProgress<T>(Action<T> callback) : IProgress<T>
+   {
+      public void Report(T value) => callback(value);
    }
 
    void ReportCalibrationError(string operationName, Exception error)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationAbstractions.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationAbstractions.cs
@@ -1,0 +1,45 @@
+namespace LittleBigMouse.Plugin.Vcp.Calibration;
+
+/// <summary>
+/// Narrow hardware boundary used by calibration. Implementations may use DDC/CI
+/// and ArgyllCMS; tests can provide an in-memory display and probe.
+/// </summary>
+public interface ICalibrationHardware
+{
+    CalibrationRange BrightnessRange { get; }
+    CalibrationRange ContrastRange { get; }
+    CalibrationRgbRanges GainRanges { get; }
+    CalibrationDisplayState CurrentState { get; }
+
+    Task SetBrightnessAsync(uint value, CancellationToken cancellationToken);
+    Task SetContrastAsync(uint value, CancellationToken cancellationToken);
+    Task SetGainsAsync(CalibrationRgb gains, CancellationToken cancellationToken);
+    Task<CalibrationMeasurement> MeasureAsync(CancellationToken cancellationToken);
+}
+
+public interface ICalibrationService
+{
+    Task<WhitePointCalibrationResult> TuneWhitePointAsync(
+        ICalibrationHardware hardware,
+        WhitePointCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    Task<BrightnessCalibrationResult> CalibrateBrightnessAsync(
+        ICalibrationHardware hardware,
+        BrightnessCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    Task<LowLuminanceCalibrationResult> CalibrateLowLuminanceAsync(
+        ICalibrationHardware hardware,
+        LowLuminanceCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    Task<ContrastCalibrationResult> ProbeContrastAsync(
+        ICalibrationHardware hardware,
+        ContrastCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationModels.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationModels.cs
@@ -1,0 +1,148 @@
+namespace LittleBigMouse.Plugin.Vcp.Calibration;
+
+public readonly record struct CalibrationRange(uint Min, uint Max)
+{
+    public uint Clamp(uint value) => Math.Clamp(value, Min, Max);
+}
+
+public readonly record struct CalibrationRgb(uint Red, uint Green, uint Blue)
+{
+    public uint Channel(int channel) => channel switch
+    {
+        0 => Red,
+        1 => Green,
+        2 => Blue,
+        _ => throw new ArgumentOutOfRangeException(nameof(channel)),
+    };
+
+    public CalibrationRgb WithChannel(int channel, uint value) => channel switch
+    {
+        0 => this with { Red = value },
+        1 => this with { Green = value },
+        2 => this with { Blue = value },
+        _ => throw new ArgumentOutOfRangeException(nameof(channel)),
+    };
+
+    public uint Min => Math.Min(Red, Math.Min(Green, Blue));
+}
+
+public readonly record struct CalibrationRgbRanges(
+    CalibrationRange Red,
+    CalibrationRange Green,
+    CalibrationRange Blue)
+{
+    public CalibrationRange Channel(int channel) => channel switch
+    {
+        0 => Red,
+        1 => Green,
+        2 => Blue,
+        _ => throw new ArgumentOutOfRangeException(nameof(channel)),
+    };
+}
+
+public readonly record struct CalibrationDisplayState(
+    uint Brightness,
+    uint Contrast,
+    CalibrationRgb Gains);
+
+public readonly record struct CalibrationMeasurement(
+    double Luminance,
+    double ChromaticityX,
+    double ChromaticityY,
+    double DeltaE);
+
+public sealed record CalibrationPoint(
+    CalibrationDisplayState Display,
+    CalibrationMeasurement Measurement);
+
+public enum CalibrationCompletion
+{
+    Converged,
+    NotConverged,
+}
+
+[Flags]
+public enum CalibrationChannels
+{
+    None = 0,
+    Red = 1,
+    Green = 2,
+    Blue = 4,
+}
+
+public enum CalibrationDirection
+{
+    Baseline,
+    Down,
+    Up,
+    Revert,
+}
+
+public enum CalibrationStage
+{
+    Initializing,
+    SettingBrightness,
+    SettingContrast,
+    AdjustingWhitePoint,
+    Measuring,
+    MeasurementCompleted,
+    Completed,
+}
+
+public sealed record WhitePointAdjustment(
+    CalibrationChannels Channels,
+    CalibrationDirection Direction,
+    double PreviousDeltaE,
+    double CurrentDeltaE);
+
+public sealed record CalibrationProgress(
+    CalibrationStage Stage,
+    int Current = 0,
+    int Total = 0,
+    CalibrationPoint? Point = null,
+    WhitePointAdjustment? Adjustment = null);
+
+public sealed record WhitePointCalibrationInput(
+    uint MaximumGain,
+    bool TestChannelPairs,
+    TimeSpan SettleDelay,
+    int StablePassesRequired = 6,
+    int MaximumPasses = 120);
+
+public sealed record BrightnessCalibrationInput(
+    uint MinimumBrightness,
+    uint MaximumBrightness,
+    IReadOnlySet<uint> AlreadyMeasured,
+    WhitePointCalibrationInput WhitePoint);
+
+public sealed record LowLuminanceCalibrationInput(
+    WhitePointCalibrationInput WhitePoint);
+
+public sealed record ContrastCalibrationInput(
+    uint MinimumContrast,
+    uint MaximumContrast);
+
+public sealed record WhitePointCalibrationResult(
+    CalibrationCompletion Completion,
+    CalibrationRgb Gains,
+    double DeltaE,
+    int MeasurementCount,
+    int PassCount);
+
+public sealed record BrightnessCalibrationResult(
+    CalibrationCompletion Completion,
+    IReadOnlyList<CalibrationPoint> Points);
+
+public sealed record LowLuminanceCalibrationResult(
+    CalibrationCompletion Completion,
+    IReadOnlyList<CalibrationPoint> Points);
+
+public sealed record ContrastCalibrationPoint(
+    CalibrationChannels Channel,
+    uint Contrast,
+    CalibrationMeasurement Measurement);
+
+public sealed record ContrastCalibrationResult(
+    IReadOnlyList<ContrastCalibrationPoint> Points);
+
+public sealed class CalibrationMeasurementException(string message) : Exception(message);

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/CalibrationService.cs
@@ -1,0 +1,175 @@
+namespace LittleBigMouse.Plugin.Vcp.Calibration;
+
+/// <summary>
+/// Runs calibration workflows against a small hardware port. It has no UI,
+/// charting, persistence, or vendor-protocol responsibilities.
+/// </summary>
+public sealed class CalibrationService : ICalibrationService
+{
+    readonly WhitePointOptimizer _whitePoint = new();
+
+    public Task<WhitePointCalibrationResult> TuneWhitePointAsync(
+        ICalibrationHardware hardware,
+        WhitePointCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+        => _whitePoint.TuneAsync(hardware, input, progress, cancellationToken);
+
+    public async Task<BrightnessCalibrationResult> CalibrateBrightnessAsync(
+        ICalibrationHardware hardware,
+        BrightnessCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        WhitePointOptimizer.Validate(input.WhitePoint);
+
+        var minimum = Math.Max(input.MinimumBrightness, hardware.BrightnessRange.Min);
+        var maximum = Math.Min(input.MaximumBrightness, hardware.BrightnessRange.Max);
+        var points = new List<CalibrationPoint>();
+        var completion = CalibrationCompletion.Converged;
+        var total = minimum <= maximum ? checked((int)(maximum - minimum + 1)) : 0;
+
+        progress?.Report(new(CalibrationStage.Initializing, Total: total));
+        for (var brightness = minimum; brightness <= maximum; brightness++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var current = checked((int)(brightness - minimum + 1));
+            if (input.AlreadyMeasured.Contains(brightness))
+            {
+                if (brightness == uint.MaxValue) break;
+                continue;
+            }
+
+            progress?.Report(new(CalibrationStage.SettingBrightness, current, total));
+            await hardware.SetBrightnessAsync(brightness, cancellationToken).ConfigureAwait(false);
+
+            var whitePoint = await _whitePoint.TuneAsync(
+                hardware, input.WhitePoint, progress, cancellationToken).ConfigureAwait(false);
+            if (whitePoint.Completion == CalibrationCompletion.NotConverged)
+                completion = CalibrationCompletion.NotConverged;
+
+            progress?.Report(new(CalibrationStage.Measuring, current, total));
+            var measurement = await hardware.MeasureAsync(cancellationToken).ConfigureAwait(false);
+            var point = new CalibrationPoint(hardware.CurrentState, measurement);
+            points.Add(point);
+            progress?.Report(new(CalibrationStage.MeasurementCompleted, current, total, point));
+
+            if (brightness == uint.MaxValue) break;
+        }
+
+        progress?.Report(new(CalibrationStage.Completed, total, total));
+        return new BrightnessCalibrationResult(completion, points);
+    }
+
+    public async Task<LowLuminanceCalibrationResult> CalibrateLowLuminanceAsync(
+        ICalibrationHardware hardware,
+        LowLuminanceCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        WhitePointOptimizer.Validate(input.WhitePoint);
+
+        var original = hardware.CurrentState;
+        var points = new List<CalibrationPoint>();
+        var completion = CalibrationCompletion.Converged;
+        var maximum = hardware.GainRanges.Red.Max;
+        var minimum = hardware.GainRanges.Red.Min;
+        var total = checked((int)(maximum - minimum + 1));
+
+        try
+        {
+            await hardware.SetBrightnessAsync(hardware.BrightnessRange.Min, cancellationToken).ConfigureAwait(false);
+            for (var gain = maximum; ; gain--)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var current = checked((int)(maximum - gain + 1));
+                var whitePointInput = input.WhitePoint with { MaximumGain = gain };
+                var whitePoint = await _whitePoint.TuneAsync(
+                    hardware, whitePointInput, progress, cancellationToken).ConfigureAwait(false);
+                if (whitePoint.Completion == CalibrationCompletion.NotConverged)
+                    completion = CalibrationCompletion.NotConverged;
+
+                progress?.Report(new(CalibrationStage.Measuring, current, total));
+                var measurement = await hardware.MeasureAsync(cancellationToken).ConfigureAwait(false);
+                var point = new CalibrationPoint(hardware.CurrentState, measurement);
+                points.Add(point);
+                progress?.Report(new(CalibrationStage.MeasurementCompleted, current, total, point));
+
+                if (whitePoint.Gains.Min <= minimum || gain == minimum) break;
+            }
+
+            progress?.Report(new(CalibrationStage.Completed, points.Count, total));
+            return new LowLuminanceCalibrationResult(completion, points);
+        }
+        finally
+        {
+            await RestoreAsync(hardware, original).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<ContrastCalibrationResult> ProbeContrastAsync(
+        ICalibrationHardware hardware,
+        ContrastCalibrationInput input,
+        IProgress<CalibrationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        var originalGains = hardware.CurrentState.Gains;
+        var minimum = Math.Max(input.MinimumContrast, hardware.ContrastRange.Min);
+        var maximum = Math.Min(input.MaximumContrast, hardware.ContrastRange.Max);
+        var points = new List<ContrastCalibrationPoint>();
+        var totalPerChannel = minimum <= maximum ? checked((int)(maximum - minimum + 1)) : 0;
+        var total = totalPerChannel * 3;
+
+        try
+        {
+            for (var channel = 0; channel < 3; channel++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var gains = new CalibrationRgb(
+                    channel == 0 ? hardware.GainRanges.Red.Max : hardware.GainRanges.Red.Min,
+                    channel == 1 ? hardware.GainRanges.Green.Max : hardware.GainRanges.Green.Min,
+                    channel == 2 ? hardware.GainRanges.Blue.Max : hardware.GainRanges.Blue.Min);
+                await hardware.SetGainsAsync(gains, cancellationToken).ConfigureAwait(false);
+
+                for (var contrast = minimum; contrast <= maximum; contrast++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var current = channel * totalPerChannel + checked((int)(contrast - minimum + 1));
+                    progress?.Report(new(CalibrationStage.SettingContrast, current, total));
+                    await hardware.SetContrastAsync(contrast, cancellationToken).ConfigureAwait(false);
+                    var measurement = await hardware.MeasureAsync(cancellationToken).ConfigureAwait(false);
+                    points.Add(new(ToChannels(channel), contrast, measurement));
+                    if (contrast == uint.MaxValue) break;
+                }
+            }
+
+            progress?.Report(new(CalibrationStage.Completed, total, total));
+            return new ContrastCalibrationResult(points);
+        }
+        finally
+        {
+            await hardware.SetGainsAsync(originalGains, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    static CalibrationChannels ToChannels(int channel) => channel switch
+    {
+        0 => CalibrationChannels.Red,
+        1 => CalibrationChannels.Green,
+        2 => CalibrationChannels.Blue,
+        _ => CalibrationChannels.None,
+    };
+
+    static async Task RestoreAsync(
+        ICalibrationHardware hardware,
+        CalibrationDisplayState state)
+    {
+        await hardware.SetBrightnessAsync(state.Brightness, CancellationToken.None).ConfigureAwait(false);
+        await hardware.SetContrastAsync(state.Contrast, CancellationToken.None).ConfigureAwait(false);
+        await hardware.SetGainsAsync(state.Gains, CancellationToken.None).ConfigureAwait(false);
+    }
+
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/WhitePointOptimizer.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Calibration/WhitePointOptimizer.cs
@@ -1,0 +1,217 @@
+namespace LittleBigMouse.Plugin.Vcp.Calibration;
+
+/// <summary>Coordinate-descent optimizer for the monitor's RGB gain controls.</summary>
+internal sealed class WhitePointOptimizer
+{
+    public async Task<WhitePointCalibrationResult> TuneAsync(
+        ICalibrationHardware hardware,
+        WhitePointCalibrationInput input,
+        IProgress<CalibrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(hardware);
+        Validate(input);
+
+        var gains = hardware.CurrentState.Gains;
+        var cache = new Dictionary<CalibrationRgb, double>();
+        var measurementCount = 0;
+        var stablePasses = 0;
+        var pass = 0;
+        var channel = 0;
+        var phaseCount = input.TestChannelPairs ? 6 : 3;
+        var lastDeltaE = double.NaN;
+
+        while (stablePasses < input.StablePassesRequired && pass < input.MaximumPasses)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var outcome = await TuneChannelAsync(
+                hardware, gains, channel, input, cache, progress,
+                cancellationToken).ConfigureAwait(false);
+
+            gains = outcome.Gains;
+            if (double.IsFinite(outcome.DeltaE)) lastDeltaE = outcome.DeltaE;
+            measurementCount += outcome.MeasurementCount;
+            stablePasses = outcome.Changed ? 0 : stablePasses + 1;
+            pass++;
+            channel = (channel + 1) % phaseCount;
+        }
+
+        await hardware.SetGainsAsync(gains, cancellationToken).ConfigureAwait(false);
+        var completion = stablePasses >= input.StablePassesRequired
+            ? CalibrationCompletion.Converged
+            : CalibrationCompletion.NotConverged;
+        return new(completion, gains, lastDeltaE, measurementCount, pass);
+    }
+
+    static async Task<TuneChannelResult> TuneChannelAsync(
+        ICalibrationHardware hardware,
+        CalibrationRgb startingGains,
+        int phase,
+        WhitePointCalibrationInput input,
+        Dictionary<CalibrationRgb, double> cache,
+        IProgress<CalibrationProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var channels = phase switch
+        {
+            0 or 3 => new[] { 0, 1, 2 },
+            1 or 4 => new[] { 1, 2, 0 },
+            _ => new[] { 2, 0, 1 },
+        };
+        var channelCount = phase < 3 ? 1 : 2;
+        var minimum = channels.Select(c => hardware.GainRanges.Channel(c).Min).ToArray();
+        var maximum = channels.Select(c => input.MaximumGain == 0
+            ? hardware.GainRanges.Channel(c).Max
+            : Math.Min(input.MaximumGain, hardware.GainRanges.Channel(c).Max)).ToArray();
+        var gains = startingGains;
+
+        if (channelCount == 1
+            && gains.Channel(channels[0]) == maximum[0]
+            && gains.Channel(channels[1]) < maximum[1]
+            && gains.Channel(channels[2]) < maximum[2])
+            return new(gains, double.NaN, false, 0);
+
+        if (channelCount == 2
+            && (gains.Channel(channels[0]) == maximum[0]
+                || gains.Channel(channels[1]) == maximum[1])
+            && gains.Channel(channels[2]) < maximum[2])
+            return new(gains, double.NaN, false, 0);
+
+        var original = gains;
+        var reads = 0;
+        var baseline = await MeasureAtGainsAsync(hardware, gains, input.SettleDelay, cache,
+            cancellationToken).ConfigureAwait(false);
+        reads += baseline.WasMeasured ? 1 : 0;
+        var deltaE = baseline.DeltaE;
+        Report(progress, channels, channelCount, CalibrationDirection.Baseline, deltaE, deltaE);
+
+        while (CanMove(gains, channels, channelCount, minimum, down: true))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var previous = deltaE;
+            gains = Move(gains, channels, channelCount, down: true);
+            var measured = await MeasureAtGainsAsync(hardware, gains, input.SettleDelay, cache,
+                cancellationToken).ConfigureAwait(false);
+            reads += measured.WasMeasured ? 1 : 0;
+            deltaE = measured.DeltaE;
+            Report(progress, channels, channelCount, CalibrationDirection.Down, previous, deltaE);
+            if (deltaE > previous) break;
+        }
+
+        while (CanMove(gains, channels, channelCount, maximum, down: false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var previous = deltaE;
+            gains = Move(gains, channels, channelCount, down: false);
+            var measured = await MeasureAtGainsAsync(hardware, gains, input.SettleDelay, cache,
+                cancellationToken).ConfigureAwait(false);
+            reads += measured.WasMeasured ? 1 : 0;
+            deltaE = measured.DeltaE;
+            Report(progress, channels, channelCount, CalibrationDirection.Up, previous, deltaE);
+            if (deltaE <= previous) continue;
+
+            var worse = deltaE;
+            gains = Move(gains, channels, channelCount, down: true);
+            measured = await MeasureAtGainsAsync(hardware, gains, input.SettleDelay, cache,
+                cancellationToken).ConfigureAwait(false);
+            reads += measured.WasMeasured ? 1 : 0;
+            deltaE = measured.DeltaE;
+            Report(progress, channels, channelCount, CalibrationDirection.Revert, worse, deltaE);
+            break;
+        }
+
+        return new(gains, deltaE, gains != original, reads);
+    }
+
+    static async Task<CachedMeasurement> MeasureAtGainsAsync(
+        ICalibrationHardware hardware,
+        CalibrationRgb gains,
+        TimeSpan settleDelay,
+        Dictionary<CalibrationRgb, double> cache,
+        CancellationToken cancellationToken)
+    {
+        if (cache.TryGetValue(gains, out var cached)) return new(cached, false);
+
+        await hardware.SetGainsAsync(gains, cancellationToken).ConfigureAwait(false);
+        if (settleDelay > TimeSpan.Zero)
+            await Task.Delay(settleDelay, cancellationToken).ConfigureAwait(false);
+        var measurement = await hardware.MeasureAsync(cancellationToken).ConfigureAwait(false);
+        if (!double.IsFinite(measurement.DeltaE))
+            throw new CalibrationMeasurementException("The probe returned an invalid Delta E value.");
+        cache[gains] = measurement.DeltaE;
+        return new(measurement.DeltaE, true);
+    }
+
+    static bool CanMove(
+        CalibrationRgb gains,
+        IReadOnlyList<int> channels,
+        int count,
+        IReadOnlyList<uint> boundary,
+        bool down)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var value = gains.Channel(channels[i]);
+            if (down ? value <= boundary[i] : value >= boundary[i]) return false;
+        }
+        return true;
+    }
+
+    static CalibrationRgb Move(
+        CalibrationRgb gains,
+        IReadOnlyList<int> channels,
+        int count,
+        bool down)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var channel = channels[i];
+            var value = gains.Channel(channel);
+            gains = gains.WithChannel(channel, down ? value - 1 : value + 1);
+        }
+        return gains;
+    }
+
+    static void Report(
+        IProgress<CalibrationProgress>? progress,
+        IReadOnlyList<int> channels,
+        int count,
+        CalibrationDirection direction,
+        double previous,
+        double current)
+        => progress?.Report(new(CalibrationStage.AdjustingWhitePoint, Adjustment: new(
+            ToChannels(channels, count), direction, previous, current)));
+
+    static CalibrationChannels ToChannels(IReadOnlyList<int> channels, int count)
+    {
+        var result = CalibrationChannels.None;
+        for (var i = 0; i < count; i++)
+        {
+            result |= channels[i] switch
+            {
+                0 => CalibrationChannels.Red,
+                1 => CalibrationChannels.Green,
+                2 => CalibrationChannels.Blue,
+                _ => CalibrationChannels.None,
+            };
+        }
+        return result;
+    }
+
+    internal static void Validate(WhitePointCalibrationInput input)
+    {
+        if (input.SettleDelay < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(input), "Settle delay cannot be negative.");
+        if (input.StablePassesRequired <= 0)
+            throw new ArgumentOutOfRangeException(nameof(input), "At least one stable pass is required.");
+        if (input.MaximumPasses <= 0)
+            throw new ArgumentOutOfRangeException(nameof(input), "At least one pass is required.");
+    }
+
+    readonly record struct CachedMeasurement(double DeltaE, bool WasMeasured);
+    readonly record struct TuneChannelResult(
+        CalibrationRgb Gains,
+        double DeltaE,
+        bool Changed,
+        int MeasurementCount);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Class1.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace LittleBigMouse.Plugin.Vcp
-{
-    public class Class1
-    {
-
-    }
-}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/LittleBigMouse.Plugin.Vcp.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/LittleBigMouse.Plugin.Vcp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
@@ -103,6 +103,7 @@
 		<ProjectReference Include="..\..\LittleBigMouse.Core\LittleBigMouse.DisplayLayout\LittleBigMouse.DisplayLayout.csproj" />
 		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugin.Layout.Avalonia\LittleBigMouse.Plugin.Layout.Avalonia.csproj" />
 		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugin.Vcp.Avalonia\LittleBigMouse.Plugin.Vcp.Avalonia.csproj" />
+		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugin.Vcp\LittleBigMouse.Plugin.Vcp.csproj" />
 		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugin.Wallpaper.Avalonia\LittleBigMouse.Plugin.Wallpaper.Avalonia.csproj" />
 		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugins.Avalonia\LittleBigMouse.Plugins.Avalonia.csproj" />
 		<ProjectReference Include="..\..\LittleBigMouse.Plugins\LittleBigMouse.Plugins.Core\LittleBigMouse.Plugins.csproj" />

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
@@ -24,6 +24,7 @@ using LittleBigMouse.Plugin.Layout.Avalonia.LocationPlugin;
 using LittleBigMouse.Plugin.Vcp.Avalonia;
 using LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using LittleBigMouse.Plugin.Vcp.Calibration;
 using LittleBigMouse.Plugins;
 using LittleBigMouse.Ui.Avalonia.Main;
 using LittleBigMouse.Ui.Avalonia.Plugins.Debug;
@@ -184,6 +185,7 @@ internal class Program
                 () => ActivatorUtilities.CreateInstance<ApplicationUpdaterViewModel>(sp));
             services.AddSingleton<Func<VcpScreenViewModel, LittleBigMouse.Plugin.Vcp.Avalonia.Patterns.TestPatternButtonViewModel>>(sp =>
                 vm => ActivatorUtilities.CreateInstance<LittleBigMouse.Plugin.Vcp.Avalonia.Patterns.TestPatternButtonViewModel>(sp, vm));
+            services.AddSingleton<ICalibrationService, CalibrationService>();
 
             // SystemMonitorsService stays registered on every OS: its constructor is inert
             // (the Win32 enumeration is lazy behind .Root) and view-models inject it, so


### PR DESCRIPTION
## Summary

- extract calibration workflows from `VcpScreenViewModel` into a UI-neutral `CalibrationService`
- isolate RGB white-point convergence in `WhitePointOptimizer`
- introduce simple input, progress, result, and hardware-port models
- adapt the existing ArgyllCMS probe and DDC/CI controls without changing Samsung/Hisense protocols or XAML
- keep UI orchestration and progress projection in `VcpScreenViewModel`

## Why

`VcpScreenViewModel` previously owned Argyll session handling, measurements, brightness sweeps, gain tuning, convergence logic, persistence, charts, and UI state. The hardware-facing calibration logic was therefore difficult to test independently and coupled to Avalonia/LiveCharts concerns.

The new core calibration project has no Avalonia or LiveCharts dependency. The Avalonia plugin supplies a narrow adapter for the existing probe and monitor controls.

## Impact

- calibration operations are asynchronous and cancellation-aware
- workflows return business results including convergence status and measured points
- white-point tuning has an explicit maximum-pass non-convergence outcome
- `VcpScreenViewModel` drops from 1,303 to 1,094 lines and retains UI orchestration responsibilities
- Samsung Tizen, Hisense VIDAA, and UI markup are unchanged

## Validation

- VCP tests: 84 passed, 0 failed
- full Avalonia application build: succeeded with 0 errors
- `git diff --check`: clean
