### PR TITLE
Split MainService into owned collaborators

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DisplayChangeCoordinatorTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DisplayChangeCoordinatorTests.cs
@@ -1,0 +1,226 @@
+using LittleBigMouse.Ui.Avalonia.Main;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// What the coordinator is for is <em>not</em> rebuilding. A display change arrives as a burst
+/// while the OS is still moving, and every filter here exists because rebuilding once per event
+/// was tried and cost something real: a fully-wired layout generation dropped per spurious
+/// event is what fills gigabytes over a storm (#412), and a rebuild skipped without re-hooking
+/// is what leaves the engine stopped ("blue") after a monitor's power-save blink.
+/// <para>
+/// The timings are shrunk to the millisecond so a burst can be replayed in a test; the
+/// generation counter that collapses it does not depend on how long the windows are.
+/// </para>
+/// </summary>
+public sealed class DisplayChangeCoordinatorTests
+{
+    static readonly DisplayChangeTimings Fast = new(DebounceMs: 1, StabilityStepMs: 1, StabilityMaxSteps: 4);
+
+    /// <summary>
+    /// A display configuration under test: what it reads as, and a record of what was asked of
+    /// it. <see cref="Signature"/> is what a real factory would return from a cheap probe.
+    /// </summary>
+    sealed class Display
+    {
+        public string Signature { get; set; } = "one-monitor";
+        public bool Suspended { get; set; }
+        public int SignatureReads { get; private set; }
+        public int Rebuilds { get; private set; }
+        public int Starts { get; private set; }
+        public int Reconciles { get; private set; }
+
+        public string Read()
+        {
+            SignatureReads++;
+            return Signature;
+        }
+
+        public void Rebuild() => Rebuilds++;
+
+        public Task StartAsync()
+        {
+            Starts++;
+            return Task.CompletedTask;
+        }
+
+        public Task ReconcileAsync()
+        {
+            Reconciles++;
+            return Task.CompletedTask;
+        }
+    }
+
+    static DisplayChangeCoordinator Over(Display display) => new(
+        display.Read,
+        () => display.Suspended,
+        display.Rebuild,
+        display.StartAsync,
+        display.ReconcileAsync,
+        Fast);
+
+    [Fact]
+    public async Task TheFirstChangeAlwaysRebuilds()
+    {
+        var display = new Display();
+        var coordinator = Over(display);
+
+        await coordinator.NotifyAsync();
+
+        Assert.Equal(1, display.Rebuilds);
+        Assert.Equal(1, display.Starts);
+        Assert.Equal("one-monitor", coordinator.LastBuiltSignature);
+    }
+
+    [Fact]
+    public async Task ABurstOfChangesCollapsesIntoASingleRebuild()
+    {
+        // Every notification increments the generation before it awaits anything, so by the
+        // time the debounce expires only the last one still matches — which is the whole of the
+        // trailing debounce. Ten WM_DISPLAYCHANGE, one layout.
+        var display = new Display();
+        var coordinator = Over(display);
+
+        var burst = Enumerable.Range(0, 10).Select(_ => coordinator.NotifyAsync()).ToArray();
+        await Task.WhenAll(burst);
+
+        Assert.Equal(1, display.Rebuilds);
+        Assert.Equal(1, display.Starts);
+    }
+
+    [Fact]
+    public async Task ABurstThatKeepsChangingTheConfigurationStillRebuildsOnce()
+    {
+        // The realistic wake-from-sleep shape: the events arrive while the configuration is
+        // still moving under them. Only the final, settled signature must be built.
+        var display = new Display();
+        var coordinator = Over(display);
+
+        var burst = new List<Task>();
+        foreach (var step in new[] { "detaching", "one-monitor", "two-monitors" })
+        {
+            display.Signature = step;
+            burst.Add(coordinator.NotifyAsync());
+        }
+
+        await Task.WhenAll(burst);
+
+        Assert.Equal(1, display.Rebuilds);
+        Assert.Equal("two-monitors", coordinator.LastBuiltSignature);
+    }
+
+    [Fact]
+    public async Task AConfigurationThatSettlesBackToItselfIsReHookedNotRebuilt()
+    {
+        // A monitor's DPMS power-save blink, a mode re-apply, a stray broadcast: the signature
+        // is the one already built. Rebuilding would drop a live layout generation for nothing —
+        // but the daemon unhooked itself over the change, so somebody has to re-hook.
+        var display = new Display();
+        var coordinator = Over(display);
+
+        await coordinator.NotifyAsync();
+        await coordinator.NotifyAsync();
+
+        Assert.Equal(1, display.Rebuilds);
+        Assert.Equal(1, display.Reconciles);
+    }
+
+    [Fact]
+    public async Task AChangedConfigurationRebuildsAgain()
+    {
+        var display = new Display();
+        var coordinator = Over(display);
+
+        await coordinator.NotifyAsync();
+        display.Signature = "two-monitors";
+        await coordinator.NotifyAsync();
+
+        Assert.Equal(2, display.Rebuilds);
+        Assert.Equal(0, display.Reconciles);
+        Assert.Equal("two-monitors", coordinator.LastBuiltSignature);
+    }
+
+    [Fact]
+    public async Task WhileTheDisplayIsOffNothingIsEvenRead()
+    {
+        // Not "rebuild and discard": the point is that no work starts at all. There is no
+        // desktop to fingerprint, and the daemon's Resumed reconciles once there is.
+        var display = new Display { Suspended = true };
+        var coordinator = Over(display);
+
+        await coordinator.NotifyAsync();
+
+        Assert.Equal(0, display.SignatureReads);
+        Assert.Equal(0, display.Rebuilds);
+        Assert.Equal(0, display.Reconciles);
+    }
+
+    [Fact]
+    public async Task ADisplayGoingOffMidSettleDropsTheRebuild()
+    {
+        // Suspended arrived while this change was being settled. The daemon has unhooked; the
+        // desktop it describes no longer exists.
+        var display = new Display();
+        var coordinator = Over(display);
+
+        var pending = coordinator.NotifyAsync();
+        display.Suspended = true;
+        await pending;
+
+        Assert.Equal(0, display.Rebuilds);
+        Assert.Equal("", coordinator.LastBuiltSignature);
+    }
+
+    [Fact]
+    public async Task RefreshRebuildsWhatTheGuardWouldHaveSkipped()
+    {
+        // The tray's Refresh (#443): the escape hatch for a change the automatic detection
+        // missed. It must go through the idempotence guard, not around and back into it — so it
+        // also realigns the built signature, or the next event would rebuild on its account.
+        var display = new Display();
+        var coordinator = Over(display);
+
+        await coordinator.NotifyAsync();
+        await coordinator.RefreshAsync();
+
+        Assert.Equal(2, display.Rebuilds);
+        Assert.Equal(2, display.Starts);
+
+        await coordinator.NotifyAsync();
+        Assert.Equal(2, display.Rebuilds);
+        Assert.Equal(1, display.Reconciles);
+    }
+
+    [Fact]
+    public async Task RefreshDoesNothingWhileTheDisplayIsOff()
+    {
+        var display = new Display { Suspended = true };
+        var coordinator = Over(display);
+
+        await coordinator.RefreshAsync();
+
+        Assert.Equal(0, display.Rebuilds);
+    }
+
+    [Fact]
+    public async Task AFlappingConfigurationDoesNotHangTheSettleLoop()
+    {
+        // A signature that never repeats would loop forever without the step cap. It builds
+        // whatever it last saw rather than hanging: a wrong layout is recoverable, a frozen UI
+        // is not.
+        var flapping = 0;
+        var display = new Display();
+        var coordinator = new DisplayChangeCoordinator(
+            () => $"flap-{flapping++}",
+            () => display.Suspended,
+            display.Rebuild,
+            display.StartAsync,
+            display.ReconcileAsync,
+            Fast);
+
+        await coordinator.NotifyAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, display.Rebuilds);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/EngineControllerTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/EngineControllerTests.cs
@@ -1,0 +1,248 @@
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Ui.Avalonia.Main;
+using LittleBigMouse.Zoning;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// Hooking the engine is easy; hooking it <em>back</em> is where the bugs are. The daemon
+/// unhooks itself over any display change so the cursor is never confined while the desktop
+/// reshapes, which leaves the UI as the only side that can notice the hook is gone — without
+/// ever forcing it on over a user who turned it off, or over an exclusion the daemon is
+/// deliberately honouring.
+/// </summary>
+public sealed class EngineControllerTests
+{
+    static readonly ResumeWatchdogTimings Fast =
+        new(StepMs: 1, StableSteps: 3, MaxRestarts: 6, MaxSteps: 60);
+
+    sealed class Fixture
+    {
+        public FakeDaemon Daemon { get; } = new();
+        public FakePersistence Persistence { get; } = new();
+        public MonitorsLayout Layout { get; }
+        public EngineController Engine { get; }
+
+        public Fixture(bool enabled = true, bool withLayout = true, ResumeWatchdogTimings? timings = null)
+        {
+            Layout = MainServiceFakes.NewLayout(new LbmOptions(), enabled);
+            var layout = withLayout ? Layout : null;
+            Engine = new EngineController(Daemon, Persistence, () => layout, timings ?? Fast);
+        }
+    }
+
+    [Fact]
+    public async Task AUserStartRecordsItselfBeforeHooking()
+    {
+        // A start that doesn't persist Enabled=true is one the recovery guards — which all test
+        // Options.Enabled — will keep quietly undoing.
+        var f = new Fixture(enabled: false);
+
+        await f.Engine.StartFromUserAsync();
+
+        Assert.True(f.Layout.Options.Enabled);
+        Assert.Equal(true, f.Persistence.LastEnabledWritten);
+        Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task AUserStopRecordsItselfBeforeUnhooking()
+    {
+        var f = new Fixture();
+
+        await f.Engine.StopFromUserAsync();
+
+        Assert.False(f.Layout.Options.Enabled);
+        Assert.Equal(false, f.Persistence.LastEnabledWritten);
+        Assert.Equal(new[] { "Stop" }, f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task StartingWithNoLayoutYetIsANoOpRatherThanAThrow()
+    {
+        // Reachable only before the first build, which the boot sequence does before the tray
+        // exists. A tray click that faults would take the handler down with it.
+        var f = new Fixture(withLayout: false);
+
+        await f.Engine.StartAsync();
+        await f.Engine.StartFromUserAsync();
+
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task AFreshLayoutIsOnlyHandedOverWhenTheUserWantsTheEngine()
+    {
+        var enabled = new Fixture();
+        await enabled.Engine.StartIfEnabledAsync();
+        Assert.Equal(new[] { "Start" }, enabled.Daemon.Commands);
+
+        var disabled = new Fixture(enabled: false);
+        await disabled.Engine.StartIfEnabledAsync();
+        Assert.Empty(disabled.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task ReHookingSkipsAnEngineThatIsAlreadyHooked()
+    {
+        var f = new Fixture();
+        f.Daemon.State = LittleBigMouseEvent.Running;
+
+        await f.Engine.EnsureHookedAsync();
+
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task ReHookingPutsBackAHookTheDaemonDroppedOnItsOwn()
+    {
+        // The case the idempotence guard leaves behind: the configuration settled back to the
+        // one already built, so nothing rebuilds — and nothing else would re-Start it either.
+        var f = new Fixture();
+        f.Daemon.State = LittleBigMouseEvent.Stopped;
+
+        await f.Engine.EnsureHookedAsync();
+
+        Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task ReHookingStandsDownWhileTheDisplayIsOff()
+    {
+        var f = new Fixture();
+        f.Engine.Suspended = true;
+
+        await f.Engine.EnsureHookedAsync();
+
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task ReHookingNeverOverridesAUserWhoTurnedTheEngineOff()
+    {
+        var f = new Fixture(enabled: false);
+
+        await f.Engine.EnsureHookedAsync();
+
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task AResumeThatTakesFirstTimeStartsOnce()
+    {
+        var f = new Fixture();
+
+        await f.Engine.EnsureRunningAfterResumeAsync();
+
+        Assert.Equal(1, f.Daemon.StartCount);
+        Assert.Equal(LittleBigMouseEvent.Running, f.Daemon.State);
+    }
+
+    [Fact]
+    public async Task AResumeReAssertsStartUntilTheHookSticks()
+    {
+        // The race the watchdog exists for: a late WM_DISPLAYCHANGE makes the daemon unhook
+        // itself ~1-2s after Resumed, so the first Start is lost and the engine would sit
+        // stopped ("blue") until a manual Start.
+        var f = new Fixture();
+        f.Daemon.StartsBeforeItSticks = 3;
+
+        await f.Engine.EnsureRunningAfterResumeAsync();
+
+        Assert.Equal(3, f.Daemon.StartCount);
+        Assert.Equal(LittleBigMouseEvent.Running, f.Daemon.State);
+    }
+
+    [Fact]
+    public async Task AResumeGivesUpOnAnEngineThatIsLegitimatelyPaused()
+    {
+        // An excluded app (a game) focused at wake: the daemon accepts Start and stays paused,
+        // for ever, on purpose. Bounded so the watchdog does not spin for the session.
+        var f = new Fixture();
+        f.Daemon.StartsBeforeItSticks = int.MaxValue;
+
+        await f.Engine.EnsureRunningAfterResumeAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(Fast.MaxRestarts, f.Daemon.StartCount);
+        Assert.False(f.Engine.ResumeWatchdogActive);
+    }
+
+    [Fact]
+    public async Task AResumeStopsTheMomentTheDisplayGoesBackToSleep()
+    {
+        var f = new Fixture();
+        f.Daemon.StartsBeforeItSticks = int.MaxValue;
+
+        var watchdog = f.Engine.EnsureRunningAfterResumeAsync();
+        f.Engine.Suspended = true;
+        await watchdog.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(f.Daemon.StartCount < Fast.MaxRestarts);
+    }
+
+    [Fact]
+    public async Task AResumeStopsTheMomentTheUserDisablesTheEngine()
+    {
+        var f = new Fixture();
+        f.Daemon.StartsBeforeItSticks = int.MaxValue;
+
+        var watchdog = f.Engine.EnsureRunningAfterResumeAsync();
+        f.Layout.Options.Enabled = false;
+        await watchdog.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(f.Daemon.StartCount < Fast.MaxRestarts);
+    }
+
+    [Fact]
+    public async Task AResumeIsNotAttemptedAtAllWhenTheEngineIsDisabled()
+    {
+        var f = new Fixture(enabled: false);
+
+        await f.Engine.EnsureRunningAfterResumeAsync();
+
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task ANewerResumeSupersedesTheWatchdogStillRunningForTheOlderOne()
+    {
+        // Two wakes in quick succession must not leave two watchdogs fighting over the daemon.
+        var f = new Fixture();
+        f.Daemon.StartsBeforeItSticks = int.MaxValue;
+
+        var older = f.Engine.EnsureRunningAfterResumeAsync();
+        var newer = f.Engine.EnsureRunningAfterResumeAsync();
+
+        await older.WaitAsync(TimeSpan.FromSeconds(10));
+        f.Daemon.StartsBeforeItSticks = 0;
+        await newer.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.False(f.Engine.ResumeWatchdogActive);
+        Assert.Equal(LittleBigMouseEvent.Running, f.Daemon.State);
+    }
+
+    [Fact]
+    public async Task WhileTheResumeWatchdogRunsTheWeakerReHookStandsAside()
+    {
+        // Both would Start; only one should be driving, and it must be the one that retries.
+        // A single-step watchdog with a long pause gives a window where it is provably the
+        // active driver and provably idle, so anything that happens is the re-hook's doing.
+        var f = new Fixture(timings: new ResumeWatchdogTimings(StepMs: 300, MaxSteps: 1));
+        f.Daemon.StartsBeforeItSticks = int.MaxValue;
+
+        var watchdog = f.Engine.EnsureRunningAfterResumeAsync();
+        Assert.True(f.Engine.ResumeWatchdogActive);
+        Assert.Equal(1, f.Daemon.StartCount);
+
+        await f.Engine.EnsureHookedAsync();
+        Assert.Equal(1, f.Daemon.StartCount);
+
+        await watchdog.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(f.Engine.ResumeWatchdogActive);
+
+        // Once the watchdog has let go, the re-hook is free to act again.
+        await f.Engine.EnsureHookedAsync();
+        Assert.Equal(2, f.Daemon.StartCount);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceFakes.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceFakes.cs
@@ -1,0 +1,197 @@
+using System.Windows.Input;
+using DynamicData;
+using HLab.Geo;
+using HLab.UserNotification;
+using LittleBigMouse.DisplayLayout;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugins;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using LittleBigMouse.Zoning;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The world <c>MainService</c> and its collaborators talk to, reduced to what can be asserted
+/// on: a daemon that records commands and can be told what state to report, a store that
+/// records writes, a tray that records icons, and a display configuration that can be moved by
+/// hand.
+/// </summary>
+static class MainServiceFakes
+{
+    /// <summary>
+    /// A layout that is real — <c>ComputeZones</c> walks it for every Start — but minimal: one
+    /// monitor, one source, attached.
+    /// </summary>
+    public static MonitorsLayout NewLayout(ILayoutOptions options, bool enabled = true)
+    {
+        var layout = new MonitorsLayout(options) { Id = "TESTMON1", Source = LayoutSource.System };
+        layout.Options.Enabled = enabled;
+
+        var model = new PhysicalMonitorModel("TST1234");
+        model.PhysicalSize.Width = 600;
+        model.PhysicalSize.Height = 340;
+
+        var monitor = new PhysicalMonitor("MON1", layout, model);
+        var displaySource = new DisplaySource("SRC1") { AttachedToDesktop = true };
+        displaySource.InPixel.Set(new Rect(new Point(0, 0), new Size(1920, 1080)));
+
+        var physicalSource = new PhysicalSource("DEV1", monitor, displaySource);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        layout.AddOrUpdatePhysicalSource(physicalSource);
+        return layout;
+    }
+}
+
+/// <summary>
+/// The daemon, as the UI can see it: a command log and a state it publishes. Nothing here
+/// hooks anything — <see cref="State"/> is set by the test to say whether the hook took.
+/// </summary>
+sealed class FakeDaemon : ILittleBigMouseClientService
+{
+    public List<string> Commands { get; } = [];
+    public LittleBigMouseEvent State { get; set; } = LittleBigMouseEvent.Stopped;
+
+    /// <summary>Number of Start commands after which the daemon starts reporting Running.</summary>
+    public int StartsBeforeItSticks { get; set; }
+
+    public int StartCount => Commands.Count(c => c == "Start");
+
+    public event EventHandler<LittleBigMouseServiceEventArgs>? DaemonEventReceived;
+
+    public void Raise(LittleBigMouseEvent daemonEvent, string payload = "")
+        => DaemonEventReceived?.Invoke(this, new LittleBigMouseServiceEventArgs(daemonEvent, payload));
+
+    /// <summary>True while anything is still subscribed — what a released subscription must undo.</summary>
+    public bool HasSubscribers => DaemonEventReceived is not null;
+
+    public Task StartAsync(ZonesLayout zonesLayout, CancellationToken token = default)
+    {
+        Commands.Add("Start");
+        if (StartCount >= StartsBeforeItSticks) State = LittleBigMouseEvent.Running;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken token = default)
+    {
+        Commands.Add("Stop");
+        State = LittleBigMouseEvent.Stopped;
+        return Task.CompletedTask;
+    }
+
+    public Task QuitAsync(CancellationToken token = default)
+    {
+        Commands.Add("Quit");
+        return Task.CompletedTask;
+    }
+
+    public Task SendLiveAsync(ZonesLayout zonesLayout, CancellationToken token = default)
+    {
+        Commands.Add("Live");
+        return Task.CompletedTask;
+    }
+
+    public Task SendShortcutAsync(string shortcut, CancellationToken token = default)
+    {
+        Commands.Add("Shortcut");
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>The store, reduced to what was written to it.</summary>
+sealed class FakePersistence : ILayoutPersistence
+{
+    public bool IsLoading { get; set; }
+    public int EnabledWrites { get; private set; }
+    public bool? LastEnabledWritten { get; private set; }
+    public int LiveOptionWrites { get; private set; }
+
+    public void Load(MonitorsLayout layout) { }
+
+    public bool Save(MonitorsLayout layout) => true;
+
+    public bool SaveEnabled(IMonitorsLayout layout)
+    {
+        EnabledWrites++;
+        LastEnabledWritten = layout.Options.Enabled;
+        return true;
+    }
+
+    public void SaveLive(ILayoutOptions options) => LiveOptionWrites++;
+}
+
+/// <summary>The tray icon, reduced to the icons it was asked to show and the menu it was given.</summary>
+sealed class FakeNotification : IUserNotificationService
+{
+    public List<string> Icons { get; } = [];
+    public List<string> MenuHeaders { get; } = [];
+    public string ToolTipText { get; set; } = "";
+    public bool Visible { get; set; } = true;
+    public bool Shown { get; private set; }
+
+    public string? LastIcon => Icons.Count > 0 ? Icons[^1] : null;
+
+    public event Action<object, object>? Click;
+
+    public void RaiseClick() => Click?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>True while anything is still subscribed — what a released subscription must undo.</summary>
+    public bool HasClickSubscribers => Click is not null;
+
+    public Task AddMenuAsync(int pos, string header, string icon, Func<Task> todo)
+    {
+        MenuHeaders.Add(header);
+        Menu[header] = todo;
+        return Task.CompletedTask;
+    }
+
+    public Task AddMenuAsync(int pos, string header, string icon, ICommand todo)
+    {
+        MenuHeaders.Add(header);
+        return Task.CompletedTask;
+    }
+
+    public Dictionary<string, Func<Task>> Menu { get; } = [];
+
+    public Task SetIconAsync(string icon, int i)
+    {
+        Icons.Add(icon);
+        return Task.CompletedTask;
+    }
+
+    public void Show() => Shown = true;
+}
+
+/// <summary>
+/// The platform's view of the displays: a signature the test moves by hand, a layout it hands
+/// out on request, and the two events the platform raises on its own.
+/// </summary>
+sealed class FakeLayoutFactory(Func<MonitorsLayout> create) : ILayoutFactory
+{
+    public string Signature { get; set; } = "one-monitor";
+    public int Creations { get; private set; }
+    public int WallpaperUpdates { get; private set; }
+
+    public MonitorsLayout Create()
+    {
+        Creations++;
+        return create();
+    }
+
+    public string DisplaySignature() => Signature;
+
+    public event EventHandler? DisplayChanged;
+    public event EventHandler? WallpaperChanged;
+
+    public void RaiseDisplayChanged() => DisplayChanged?.Invoke(this, EventArgs.Empty);
+    public void RaiseWallpaperChanged() => WallpaperChanged?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>True while anything is still subscribed — what a released subscription must undo.</summary>
+    public bool HasDisplaySubscribers => DisplayChanged is not null;
+    public bool HasWallpaperSubscribers => WallpaperChanged is not null;
+
+    public void UpdateWallpaper(MonitorsLayout layout) => WallpaperUpdates++;
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceLifecycleTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceLifecycleTests.cs
@@ -1,0 +1,164 @@
+using HLab.Base.ReactiveUI;
+using HLab.Core.Annotations;
+using HLab.Mvvm.Annotations;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Ui.Avalonia.Main;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// <c>MainService</c> lives as long as the process, which is exactly why its subscriptions are
+/// worth pinning down: a handler that cannot be removed is invisible for as long as that stays
+/// true, and becomes a leak the day it stops. Every event it listens to is held as something it
+/// can give back, and disposing it gives all of them back.
+/// <para>
+/// The rest of what it does — deciding when a display change is worth a rebuild, when the
+/// engine should be hooked — is asserted where it now lives, in
+/// <see cref="DisplayChangeCoordinatorTests"/> and <see cref="EngineControllerTests"/>.
+/// </para>
+/// </summary>
+public sealed class MainServiceLifecycleTests
+{
+    /// <summary>
+    /// The view layer, present only so the service can be built. Any use of it here would be a
+    /// test reaching for the window, which is not what these tests are about.
+    /// </summary>
+    sealed class UnusedMvvmService : IMvvmService
+    {
+        public ServiceState ServiceState => ServiceState.Available;
+        public bool IsPlatformRegistered => true;
+        public IMvvmContext MainContext => throw new NotSupportedException();
+        public HelperFactory<IViewHelper> ViewHelperFactory => throw new NotSupportedException();
+        public void RegisterPlatform<T>() where T : IMvvmPlatformImpl => throw new NotSupportedException();
+        public Type? GetLinkedType(Type getType, Type viewMode, Type viewClass) => throw new NotSupportedException();
+        public void Register() => throw new NotSupportedException();
+        public void Register(Type baseType, Type linkedType, Type viewClass, Type viewMode) => throw new NotSupportedException();
+        public IView GetNotFoundView(Type getType, Type viewMode, Type viewClass) => throw new NotSupportedException();
+        public void PrepareView(IView view) => throw new NotSupportedException();
+        public IWindow ViewAsWindow(IView? view) => throw new NotSupportedException();
+        public IWindow ViewAsWindow<T>(IView? view) where T : IWindow, new() => throw new NotSupportedException();
+    }
+
+    sealed class Fixture
+    {
+        public LbmOptions Options { get; } = new();
+        public FakeDaemon Daemon { get; } = new();
+        public FakePersistence Persistence { get; } = new();
+        public FakeNotification Notify { get; } = new();
+        public FakeLayoutFactory Factory { get; }
+        public MainService Service { get; }
+
+        public Fixture()
+        {
+            Factory = new FakeLayoutFactory(() => MainServiceFakes.NewLayout(Options));
+
+            Service = new MainService(
+                mainViewModelLocator: () => throw new NotSupportedException(),
+                mvvmService: new UnusedMvvmService(),
+                littleBigMouseClientService: Daemon,
+                notify: Notify,
+                layoutFactory: Factory,
+                layoutPersistence: Persistence,
+                processesCollector: new ProcessesCollector(),
+                updaterLocator: () => throw new NotSupportedException(),
+                options: Options);
+        }
+    }
+
+    [Fact]
+    public void BuildingTheServiceSubscribesToTheDaemonAndThePlatform()
+    {
+        var f = new Fixture();
+
+        Assert.True(f.Daemon.HasSubscribers);
+        Assert.True(f.Factory.HasDisplaySubscribers);
+        Assert.True(f.Factory.HasWallpaperSubscribers);
+    }
+
+    [Fact]
+    public void DisposingTheServiceGivesEverySubscriptionBack()
+    {
+        // The whole point of naming the handlers. Before, each of these was a lambda with no
+        // way back out, so the daemon client and the layout factory held the service — and
+        // everything it reaches — for the life of the process whether or not it was still wanted.
+        var f = new Fixture();
+
+        f.Service.Dispose();
+
+        Assert.False(f.Daemon.HasSubscribers);
+        Assert.False(f.Factory.HasDisplaySubscribers);
+        Assert.False(f.Factory.HasWallpaperSubscribers);
+    }
+
+    [Fact]
+    public async Task AfterDisposalAPlatformDisplayChangeDoesNothingAtAll()
+    {
+        // Not "does nothing visible": the layout factory must not even be asked to build.
+        var f = new Fixture();
+        f.Service.Dispose();
+
+        f.Factory.RaiseDisplayChanged();
+        f.Factory.RaiseWallpaperChanged();
+        f.Daemon.Raise(LittleBigMouse.Zoning.LittleBigMouseEvent.DisplayChanged);
+
+        // Long enough that a surviving handler would have cleared its debounce window.
+        await Task.Delay(500);
+
+        Assert.Equal(0, f.Factory.Creations);
+        Assert.Equal(0, f.Factory.WallpaperUpdates);
+        Assert.Empty(f.Daemon.Commands);
+    }
+
+    [Fact]
+    public void DisposingTheServiceReleasesTheTrayIconToo()
+    {
+        var f = new Fixture();
+
+        Assert.False(f.Notify.HasClickSubscribers); // nothing wired before the notifier starts
+        f.Service.Dispose();
+        Assert.False(f.Notify.HasClickSubscribers);
+    }
+
+    [Fact]
+    public void DisposingIsIdempotent()
+    {
+        // Shutdown paths overlap: the container disposes what it owns, and a caller may have
+        // done it already. Neither may be the one that throws.
+        var f = new Fixture();
+
+        f.Service.Dispose();
+        f.Service.Dispose();
+    }
+
+    sealed class DisposeProbe : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public void Dispose() => Disposed = true;
+    }
+
+    [Fact]
+    public void RebuildingTheLayoutDisposesTheGenerationItReplaces()
+    {
+        // Every rebuild drops a fully-wired layout that Avalonia's compositor otherwise keeps
+        // alive; a storm of them left unreleased is what filled gigabytes (#412).
+        var f = new Fixture();
+
+        f.Service.UpdateLayout();
+        var first = (MonitorsLayout)f.Service.MonitorsLayout!;
+        var firstProbe = new DisposeProbe();
+        firstProbe.DisposeWith(first);
+
+        f.Service.UpdateLayout();
+        var second = (MonitorsLayout)f.Service.MonitorsLayout!;
+        var secondProbe = new DisposeProbe();
+        secondProbe.DisposeWith(second);
+
+        Assert.NotSame(first, second);
+        Assert.True(firstProbe.Disposed);
+        Assert.False(secondProbe.Disposed);
+        Assert.Equal(2, f.Factory.Creations);
+
+        f.Service.Dispose();
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/TrayAndWallpaperTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/TrayAndWallpaperTests.cs
@@ -1,0 +1,202 @@
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Ui.Avalonia.Main;
+using LittleBigMouse.Zoning;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The two surfaces that only ever <em>show</em> something: the tray icon and the wallpaper
+/// drawn behind each monitor. Neither decides anything, so what is worth pinning down is the
+/// menu the user is actually offered, the state the icon is allowed to claim, and that both
+/// stop listening when told to.
+/// </summary>
+public sealed class TrayAndWallpaperTests
+{
+    static TrayMenu MenuOver(List<string> log, bool canUpdate = true) => new(
+        CheckUpdateAsync: canUpdate ? () => Record(log, "update") : null,
+        OpenAsync: () => Record(log, "open"),
+        StartAsync: () => Record(log, "start"),
+        StopAsync: () => Record(log, "stop"),
+        RefreshAsync: () => Record(log, "refresh"),
+        QuitAsync: () => Record(log, "quit"));
+
+    static Task Record(List<string> log, string what)
+    {
+        log.Add(what);
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [InlineData(LittleBigMouseEvent.Running, "icon/lbm_on")]
+    [InlineData(LittleBigMouseEvent.Stopped, "icon/lbm_off")]
+    [InlineData(LittleBigMouseEvent.Dead, "icon/lbm_dead")]
+    [InlineData(LittleBigMouseEvent.Paused, "icon/lbm_paused")]
+    // A display asleep and an engine stood down look the same from the tray: not running,
+    // not broken.
+    [InlineData(LittleBigMouseEvent.Suspended, "icon/lbm_paused")]
+    public void TheIconSpeaksForTheStatesThatHaveAState(LittleBigMouseEvent daemonEvent, string icon)
+        => Assert.Equal(icon, TrayIconController.IconFor(daemonEvent));
+
+    [Theory]
+    [InlineData(LittleBigMouseEvent.Resumed)]
+    [InlineData(LittleBigMouseEvent.Connected)]
+    [InlineData(LittleBigMouseEvent.DisplayChanged)]
+    [InlineData(LittleBigMouseEvent.Loaded)]
+    [InlineData(LittleBigMouseEvent.Rescued)]
+    [InlineData(LittleBigMouseEvent.Probed)]
+    public void EventsThatSayNothingAboutTheEngineLeaveTheIconAlone(LittleBigMouseEvent daemonEvent)
+        => Assert.Null(TrayIconController.IconFor(daemonEvent));
+
+    [Fact]
+    public async Task TheMenuOffersEverythingAndTheIconComesUp()
+    {
+        var notify = new FakeNotification();
+        var options = new LbmOptions();
+        using var tray = new TrayIconController(notify, options);
+
+        await tray.InitializeAsync(MenuOver([]));
+
+        Assert.Equal(
+            new[] { "Check for update", "Open", "Start", "Stop", "Refresh", "Exit" },
+            notify.MenuHeaders);
+        Assert.True(notify.Shown);
+        Assert.True(notify.Visible);
+    }
+
+    [Fact]
+    public async Task WhereTheAppCannotUpdateItselfTheEntryIsNotThere()
+    {
+        // A menu item that no-ops is worse than none: on Linux the distribution package owns
+        // updates, and clicking "Check for update" would do nothing at all.
+        var notify = new FakeNotification();
+        using var tray = new TrayIconController(notify, new LbmOptions());
+
+        await tray.InitializeAsync(MenuOver([], canUpdate: false));
+
+        Assert.DoesNotContain("Check for update", notify.MenuHeaders);
+        Assert.Equal("Open", notify.MenuHeaders[0]);
+    }
+
+    [Fact]
+    public async Task AHiddenTrayIsHiddenBeforeTheIconIsEverLoaded()
+    {
+        // SetIconAsync queues a dispatcher lambda that checks visibility; applying the
+        // preference afterwards means the lambda returns early and the icon is never added.
+        var notify = new FakeNotification();
+        var options = new LbmOptions { HideTrayIcon = true };
+        using var tray = new TrayIconController(notify, options);
+
+        await tray.InitializeAsync(MenuOver([]));
+
+        Assert.False(notify.Visible);
+    }
+
+    [Fact]
+    public async Task TheHideOptionIsFollowedAfterStartupToo()
+    {
+        var notify = new FakeNotification();
+        var options = new LbmOptions();
+        using var tray = new TrayIconController(notify, options);
+        await tray.InitializeAsync(MenuOver([]));
+
+        options.HideTrayIcon = true;
+        Assert.False(notify.Visible);
+
+        options.HideTrayIcon = false;
+        Assert.True(notify.Visible);
+    }
+
+    [Fact]
+    public async Task ClickingTheIconOpensTheWindow()
+    {
+        var log = new List<string>();
+        var notify = new FakeNotification();
+        using var tray = new TrayIconController(notify, new LbmOptions());
+        await tray.InitializeAsync(MenuOver(log));
+
+        notify.RaiseClick();
+
+        Assert.Equal(new[] { "open" }, log);
+    }
+
+    [Fact]
+    public async Task ADisposedTrayStopsListeningToBothTheClickAndTheOption()
+    {
+        var log = new List<string>();
+        var notify = new FakeNotification();
+        var options = new LbmOptions();
+        var tray = new TrayIconController(notify, options);
+        await tray.InitializeAsync(MenuOver(log));
+
+        tray.Dispose();
+
+        notify.RaiseClick();
+        options.HideTrayIcon = true;
+
+        Assert.Empty(log);
+        Assert.False(notify.HasClickSubscribers);
+        Assert.True(notify.Visible); // the option changed and nobody acted on it
+    }
+
+    [Fact]
+    public async Task AFailingOpenDoesNotTakeTheProcessDownWithIt()
+    {
+        // The click handler has nowhere to report to. As an async void lambda it used to be an
+        // unobserved exception on the UI thread, which is a crash.
+        var notify = new FakeNotification();
+        using var tray = new TrayIconController(notify, new LbmOptions());
+        await tray.InitializeAsync(new TrayMenu(
+            CheckUpdateAsync: null,
+            OpenAsync: () => Task.FromException(new InvalidOperationException("no window")),
+            StartAsync: () => Task.CompletedTask,
+            StopAsync: () => Task.CompletedTask,
+            RefreshAsync: () => Task.CompletedTask,
+            QuitAsync: () => Task.CompletedTask));
+
+        notify.RaiseClick();
+        await Task.Delay(50);
+    }
+
+    [Fact]
+    public void TheWallpaperIsRefreshedInPlaceWhenThePlatformSaysItChanged()
+    {
+        var options = new LbmOptions();
+        var layout = MainServiceFakes.NewLayout(options);
+        var factory = new FakeLayoutFactory(() => layout);
+        using var refresher = new WallpaperRefresher(factory, () => layout, action => action());
+
+        factory.RaiseWallpaperChanged();
+
+        Assert.Equal(1, factory.WallpaperUpdates);
+        // In place, not a rebuild: edits in progress have to survive a wallpaper change.
+        Assert.Equal(0, factory.Creations);
+    }
+
+    [Fact]
+    public void AWallpaperChangeBeforeTheFirstLayoutIsSimplyIgnored()
+    {
+        IMonitorsLayout? layout = null;
+        var factory = new FakeLayoutFactory(() => throw new NotSupportedException());
+        using var refresher = new WallpaperRefresher(factory, () => layout, action => action());
+
+        factory.RaiseWallpaperChanged();
+
+        Assert.Equal(0, factory.WallpaperUpdates);
+    }
+
+    [Fact]
+    public void ADisposedRefresherStopsWatchingTheDesktop()
+    {
+        var options = new LbmOptions();
+        var layout = MainServiceFakes.NewLayout(options);
+        var factory = new FakeLayoutFactory(() => layout);
+        var refresher = new WallpaperRefresher(factory, () => layout, action => action());
+
+        refresher.Dispose();
+        factory.RaiseWallpaperChanged();
+
+        Assert.Equal(0, factory.WallpaperUpdates);
+        Assert.False(factory.HasWallpaperSubscribers);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/DaemonEventTrace.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/DaemonEventTrace.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using LittleBigMouse.Plugins;
+using LittleBigMouse.Zoning;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// Rolling trace of daemon events.
+/// <para>
+/// Display-event storms — a wake from sleep, an HDR TV flapping its DPMS state — rebuild the
+/// layout every few seconds for hours, and identifying which event was looping is otherwise
+/// impossible after the fact: by the time anyone looks, all that is left is the symptom.
+/// </para>
+/// </summary>
+public static class DaemonEventTrace
+{
+    const long MaxBytes = 1_000_000;
+
+    public static void Write(LittleBigMouseEvent daemonEvent)
+    {
+        try
+        {
+            var dir = LbmPaths.DataDir;
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "daemon-events.log");
+
+            if (File.Exists(file) && new FileInfo(file).Length > MaxBytes)
+                File.WriteAllText(file, "");
+
+            File.AppendAllText(file, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {daemonEvent}\r\n");
+        }
+        catch
+        {
+            // tracing must never take the app down
+        }
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/DisplayChangeCoordinator.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/DisplayChangeCoordinator.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// How long a display-change burst is allowed to take before the layout is rebuilt.
+/// Defaults are the measured ones; tests shrink them so a burst can be replayed in
+/// milliseconds instead of seconds.
+/// </summary>
+/// <param name="DebounceMs">Quiet window absorbing the message burst.</param>
+/// <param name="StabilityStepMs">Spacing between settle re-checks.</param>
+/// <param name="StabilityMaxSteps">Cap on the settle loop, so a flapping config can't hang it.</param>
+public sealed record DisplayChangeTimings(
+    int DebounceMs = 300,
+    int StabilityStepMs = 100,
+    int StabilityMaxSteps = 8)
+{
+    public static readonly DisplayChangeTimings Default = new();
+}
+
+/// <summary>
+/// Decides <em>when</em> a display change deserves a layout rebuild — and, just as often,
+/// that it deserves none.
+/// <para>
+/// Attach/detach, resolution, scaling and primary changes all arrive as a burst of
+/// WM_DISPLAYCHANGE/WM_SETTINGCHANGE (or, where no daemon reports them, as repeated
+/// <see cref="LittleBigMouse.Plugins.ILayoutFactory.DisplayChanged"/> notifications), and the
+/// OS is still moving while they arrive. Three filters, in order:
+/// </para>
+/// <list type="number">
+/// <item>a trailing debounce — a generation counter, so only the newest event of a burst
+/// proceeds and the rest collapse into it;</item>
+/// <item>settle detection — rebuild only once two consecutive
+/// <see cref="LittleBigMouse.Plugins.ILayoutFactory.DisplaySignature"/> reads agree, which on
+/// real switches happens within one sample, so this reacts in a few hundred ms rather than
+/// waiting out a fixed delay;</item>
+/// <item>idempotence — a settled configuration identical to the one already built is not
+/// rebuilt at all. A monitor's DPMS power-save cycle, a mode re-apply or a stray broadcast
+/// settles back to the very same signature, and dropping a fully-wired layout generation that
+/// Avalonia's compositor keeps alive is what fills gigabytes over a storm (#412).</item>
+/// </list>
+/// <para>
+/// Everything it touches is behind delegates: no Avalonia, no daemon, no clock beyond
+/// <see cref="Task.Delay(int)"/>.
+/// </para>
+/// </summary>
+public sealed class DisplayChangeCoordinator
+{
+    readonly Func<string> _readSignature;
+    readonly Func<bool> _isSuspended;
+    readonly Action _rebuildLayout;
+    readonly Func<Task> _startIfEnabledAsync;
+    readonly Func<Task> _reconcileWithoutRebuildAsync;
+    readonly DisplayChangeTimings _timings;
+
+    /// <param name="readSignature">Cheap fingerprint of the current display configuration.</param>
+    /// <param name="isSuspended">True while the display is off: nothing is read or rebuilt then.</param>
+    /// <param name="rebuildLayout">Builds a fresh layout generation. Synchronous, like the model it drives.</param>
+    /// <param name="startIfEnabledAsync">Hands the freshly built layout to the engine, if the user has it enabled.</param>
+    /// <param name="reconcileWithoutRebuildAsync">
+    /// Run when the configuration settled back to the already-built one. The daemon unhooks
+    /// itself over <em>any</em> display change, so skipping the rebuild must not mean skipping
+    /// the re-hook — nothing else would re-Start it and the engine would sit stopped ("blue")
+    /// until a manual Start.
+    /// </param>
+    /// <param name="timings">Defaults to <see cref="DisplayChangeTimings.Default"/>.</param>
+    public DisplayChangeCoordinator(
+        Func<string> readSignature,
+        Func<bool> isSuspended,
+        Action rebuildLayout,
+        Func<Task> startIfEnabledAsync,
+        Func<Task> reconcileWithoutRebuildAsync,
+        DisplayChangeTimings? timings = null)
+    {
+        _readSignature = readSignature;
+        _isSuspended = isSuspended;
+        _rebuildLayout = rebuildLayout;
+        _startIfEnabledAsync = startIfEnabledAsync;
+        _reconcileWithoutRebuildAsync = reconcileWithoutRebuildAsync;
+        _timings = timings ?? DisplayChangeTimings.Default;
+    }
+
+    int _generation;
+
+    /// <summary>
+    /// Signature of the display configuration the current layout was built from. Empty until
+    /// the first build, which is what makes the very first change always rebuild.
+    /// </summary>
+    public string LastBuiltSignature { get; private set; } = "";
+
+    /// <summary>How many rebuilds have actually happened. Lets a burst be counted, not just observed.</summary>
+    public int RebuildCount { get; private set; }
+
+    /// <summary>
+    /// A display change was reported. Returns once this particular notification has been
+    /// resolved — by rebuilding, by reconciling, or by being superseded by a newer one.
+    /// </summary>
+    public async Task NotifyAsync()
+    {
+        // Nothing at all while the display is off: no debounce, no signature reads, no rebuild.
+        // The daemon's Resumed event reconciles once when the desktop is back.
+        if (_isSuspended()) return;
+
+        var gen = Interlocked.Increment(ref _generation);
+
+        // Trailing debounce: wait a short quiet window; if a newer event arrived meanwhile, bail
+        // and let that later call handle it, so a burst collapses to a single rebuild.
+        await Task.Delay(_timings.DebounceMs);
+        if (gen != Volatile.Read(ref _generation)) return;
+
+        // Settle detection: rebuild only once the display config has stopped changing, i.e. two
+        // consecutive signatures match. Capped so a pathological flapping config can't hang here.
+        var signature = _readSignature();
+        for (var i = 0; i < _timings.StabilityMaxSteps; i++)
+        {
+            await Task.Delay(_timings.StabilityStepMs);
+            if (gen != Volatile.Read(ref _generation)) return;
+            var next = _readSignature();
+            if (next == signature) break;
+            signature = next;
+        }
+
+        // The display may have gone off during the debounce/settle: drop the rebuild — the daemon
+        // has unhooked and we wait for Resumed.
+        if (_isSuspended()) return;
+
+        // The settle loop confirms the configuration STOPPED changing, not that it DIFFERS from
+        // what we already built. Re-hook without rebuilding when it does not.
+        if (signature == LastBuiltSignature)
+        {
+            await _reconcileWithoutRebuildAsync();
+            return;
+        }
+
+        _rebuildLayout();
+        RebuildCount++;
+        LastBuiltSignature = signature;
+        await _startIfEnabledAsync();
+    }
+
+    /// <summary>
+    /// Force a rebuild the automatic detection missed (#443) — the tray's Refresh. Deliberately
+    /// bypasses the debounce, the settle loop and the idempotence guard, then realigns the built
+    /// signature so the next display event doesn't rebuild again on its account.
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        // Display off: nothing to rebuild against, the daemon's Resumed event reconciles.
+        if (_isSuspended()) return;
+
+        _rebuildLayout();
+        RebuildCount++;
+        LastBuiltSignature = _readSignature();
+        await _startIfEnabledAsync();
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/EngineController.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/EngineController.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.DisplayLayout.Monitors.Extensions;
+using LittleBigMouse.Plugins;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using LittleBigMouse.Zoning;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// How long the post-resume watchdog keeps re-asserting Start before giving up.
+/// Defaults are the measured ones; tests shrink them.
+/// </summary>
+/// <param name="StepMs">Spacing between engine-state checks.</param>
+/// <param name="StableSteps">Consecutive Running checks that count as converged.</param>
+/// <param name="MaxRestarts">Cap on re-Starts, so a paused/excluded engine can't loop forever.</param>
+/// <param name="MaxSteps">Hard stop against a pathological flapping wake.</param>
+public sealed record ResumeWatchdogTimings(
+    int StepMs = 500,
+    int StableSteps = 3,
+    int MaxRestarts = 6,
+    int MaxSteps = 60)
+{
+    public static readonly ResumeWatchdogTimings Default = new();
+}
+
+/// <summary>
+/// Owns the answer to one question: <em>should the mouse engine be hooked right now, and is
+/// it?</em>
+/// <para>
+/// Starting is never simply "send Start". The daemon unhooks itself over any display change
+/// so the cursor is never confined while the desktop reshapes, which means the UI is the side
+/// that has to notice the hook went away and put it back — without ever forcing it on over a
+/// user who turned it off, or over an exclusion the daemon is honouring.
+/// </para>
+/// <para>
+/// The three ways back in, weakest first: <see cref="StartIfEnabledAsync"/> after a rebuild,
+/// <see cref="EnsureHookedAsync"/> when a display change settled to nothing, and
+/// <see cref="EnsureRunningAfterResumeAsync"/>, which is the only one that retries — a wake
+/// from sleep is the one case where a single Start reliably loses a race.
+/// </para>
+/// </summary>
+public sealed class EngineController(
+    ILittleBigMouseClientService client,
+    ILayoutPersistence persistence,
+    Func<IMonitorsLayout?> currentLayout,
+    ResumeWatchdogTimings? timings = null)
+{
+    readonly ResumeWatchdogTimings _timings = timings ?? ResumeWatchdogTimings.Default;
+
+    /// <summary>
+    /// Set while the display is off (daemon Suspended/Resumed events). Everything that would
+    /// rebuild or re-hook stands down while it is set: there is no desktop to reason about, and
+    /// the daemon has already unhooked itself. Written on the daemon-event thread — a single
+    /// flag, so volatile is enough.
+    /// </summary>
+    public bool Suspended
+    {
+        get => _suspended;
+        set => _suspended = value;
+    }
+    volatile bool _suspended;
+
+    /// <summary>
+    /// The daemon reports Running only while its low-level mouse hook is actually installed, so
+    /// its published state is the source of truth for "is the engine hooked right now".
+    /// </summary>
+    public bool EngineRunning => client.State == LittleBigMouseEvent.Running;
+
+    /// <summary>Has the user asked for the engine at all? Everything else is subordinate to this.</summary>
+    public bool Enabled => currentLayout()?.Options.Enabled ?? false;
+
+    /// <summary>True while <see cref="EnsureRunningAfterResumeAsync"/> owns reconciliation.</summary>
+    public bool ResumeWatchdogActive => _resumeWatchdogActive;
+
+    /// <summary>
+    /// Hand the current layout to the daemon and hook. No-op before the first layout build —
+    /// the boot sequence builds one before the tray exists, so this only guards the impossible.
+    /// </summary>
+    public Task StartAsync()
+    {
+        var layout = currentLayout();
+        return layout is null ? Task.CompletedTask : client.StartAsync(layout.ComputeZones());
+    }
+
+    /// <summary>What a fresh layout generation does with itself: hook, if the user wants it hooked.</summary>
+    public Task StartIfEnabledAsync() => Enabled ? StartAsync() : Task.CompletedTask;
+
+    /// <summary>
+    /// The tray's Start. Persists Enabled=true first: the recovery guards all test
+    /// <c>Options.Enabled</c>, so a start that doesn't record itself is one they will keep
+    /// undoing.
+    /// </summary>
+    public async Task StartFromUserAsync()
+    {
+        if (currentLayout() is not { } layout) return;
+
+        layout.Options.Enabled = true;
+        persistence.SaveEnabled(layout);
+        await StartAsync();
+    }
+
+    /// <summary>The tray's Stop, symmetric to <see cref="StartFromUserAsync"/>.</summary>
+    public async Task StopFromUserAsync()
+    {
+        if (currentLayout() is { } layout)
+        {
+            layout.Options.Enabled = false;
+            persistence.SaveEnabled(layout);
+        }
+
+        await client.StopAsync();
+    }
+
+    /// <summary>
+    /// Re-hook if the engine should be running but is not — WITHOUT rebuilding the layout.
+    /// Called when a display change settled back to the already-built configuration. Safe while
+    /// an excluded app (a game) is focused: the daemon's Run path no-ops when paused, so this can
+    /// never force the hook on over an exclusion.
+    /// </summary>
+    public async Task EnsureHookedAsync()
+    {
+        if (_resumeWatchdogActive) return; // the resume watchdog owns reconciliation
+        if (_suspended) return;            // display off — nothing to do
+        if (!Enabled) return;              // engine disabled by the user
+        if (EngineRunning) return;         // already hooked
+
+        await StartAsync();
+    }
+
+    /// <summary>
+    /// Keep the engine hooked across the display re-enumeration storm that follows a wake from
+    /// sleep. The daemon emits Resumed as soon as the screen turns on, but Windows then
+    /// re-enumerates the GPU/monitors for several seconds, firing a burst of WM_DISPLAYCHANGE.
+    /// One of those, processed just after we re-install the hook, makes the daemon unhook itself
+    /// again (a Stopped ~1-2s after Resumed), and a single Start loses that race — the engine
+    /// stays stopped ("blue") until a manual Start. Re-assert Start until it sticks (Running for
+    /// a short quiet window), bounded so a legitimately-paused engine (excluded app focused at
+    /// wake) can't loop forever.
+    /// </summary>
+    public async Task EnsureRunningAfterResumeAsync()
+    {
+        if (!Enabled) return;
+
+        var myGen = Interlocked.Increment(ref _resumeGeneration);
+        _resumeWatchdogActive = true;
+        try
+        {
+            var restarts = 0;
+            var quiet = 0;
+            for (var i = 0; i < _timings.MaxSteps; i++)
+            {
+                if (myGen != Volatile.Read(ref _resumeGeneration)) return; // a newer resume superseded us
+                if (_suspended) return;                                    // went back to sleep
+                if (!Enabled) return;                                      // user disabled the engine
+
+                if (EngineRunning)
+                {
+                    if (++quiet >= _timings.StableSteps) return; // Running long enough — converged
+                }
+                else if (restarts >= _timings.MaxRestarts)
+                {
+                    return; // gave up — the engine is legitimately paused (excluded app focused at wake)
+                }
+                else
+                {
+                    quiet = 0;
+                    restarts++;
+                    await StartAsync();
+                }
+
+                await Task.Delay(_timings.StepMs);
+            }
+        }
+        finally
+        {
+            _resumeWatchdogActive = false;
+        }
+    }
+
+    // A generation counter so a newer Resumed supersedes an older watchdog run, and a flag
+    // telling EnsureHookedAsync to stand aside while the watchdog is the active driver. Written
+    // on the daemon-event path — volatile is enough.
+    int _resumeGeneration;
+    volatile bool _resumeWatchdogActive;
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
   LittleBigMouse.Ui.Avalonia
   Copyright (c) 2021 Mathieu GRENET.  All right reserved.
 
@@ -23,24 +23,16 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Reactive.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using HLab.Base.Avalonia;
 using HLab.Base.ReactiveUI;
-using HLab.Mvvm;
 using HLab.Mvvm.Annotations;
-using HLab.Mvvm.Avalonia;
 using HLab.UserNotification;
 using LittleBigMouse.DisplayLayout.Monitors;
-using LittleBigMouse.DisplayLayout.Monitors.Extensions;
 using LittleBigMouse.Plugins;
 using LittleBigMouse.Ui.Avalonia.Controls;
-using LittleBigMouse.Ui.Avalonia.Options;
 using LittleBigMouse.Platform.Windows;
 using LittleBigMouse.Ui.Avalonia.Remote;
 using LittleBigMouse.Ui.Avalonia.Updater;
@@ -49,26 +41,37 @@ using ReactiveUI;
 
 namespace LittleBigMouse.Ui.Avalonia.Main;
 
+/// <summary>
+/// The coordinator. It holds the layout the whole application edits, routes what the daemon and
+/// the platform report, and decides what those reports <em>mean</em> — but it performs none of
+/// it itself.
+/// <para>
+/// Five collaborators do the performing, and this class <em>owns</em> them rather than
+/// resolving them: <see cref="DisplayChangeCoordinator"/> decides when a display change
+/// deserves a rebuild, <see cref="EngineController"/> decides whether the mouse engine should
+/// be hooked, <see cref="MainWindowManager"/> and <see cref="TrayIconController"/> put that
+/// state in front of the user, and <see cref="WallpaperRefresher"/> keeps the drawn desktop
+/// current. They are constructed here, wired to each other here, and released here, because
+/// the wiring — a display change may rebuild, or may only re-hook; a resume must do both, in
+/// that order — is the decision this class exists to make.
+/// </para>
+/// </summary>
 public class MainService : ReactiveModel, IMainService
 {
-    readonly IMvvmService _mvvmService;
     readonly ILayoutFactory _layoutFactory;
     readonly ILayoutPersistence _layoutPersistence;
-
-    readonly IUserNotificationService _notify;
     readonly ILittleBigMouseClientService _littleBigMouseClientService;
     readonly IProcessesCollector _processesCollector;
     readonly Func<ApplicationUpdaterViewModel> _updaterLocator;
-    readonly ILayoutOptions _options;
 
+    readonly DisplayChangeCoordinator _displayChanges;
+    readonly EngineController _engine;
+    readonly MainWindowManager _windows;
+    readonly TrayIconController _tray;
 
-    Action<IMainPluginsViewModel>? _actions;
-
-    readonly Func<IMainPluginsViewModel> _mainViewModelLocator;
-
-    public IMonitorsLayout? MonitorsLayout 
-    { 
-        get => _monitorLayout; 
+    public IMonitorsLayout? MonitorsLayout
+    {
+        get => _monitorLayout;
         set => this.RaiseAndSetIfChanged(ref _monitorLayout, value);
     }
     IMonitorsLayout? _monitorLayout;
@@ -85,16 +88,31 @@ public class MainService : ReactiveModel, IMainService
         Func<ApplicationUpdaterViewModel> updaterLocator,
         ILayoutOptions options)
     {
-        _notify = notify;
         _layoutFactory = layoutFactory;
         _layoutPersistence = layoutPersistence;
+        _littleBigMouseClientService = littleBigMouseClientService;
         _processesCollector = processesCollector;
         _updaterLocator = updaterLocator;
-        _littleBigMouseClientService = littleBigMouseClientService;
-        _options = options;
 
-        _mvvmService = mvvmService;
-        _mainViewModelLocator = mainViewModelLocator;
+        _engine = new EngineController(
+            littleBigMouseClientService, layoutPersistence, () => MonitorsLayout);
+
+        _displayChanges = new DisplayChangeCoordinator(
+            layoutFactory.DisplaySignature,
+            () => _engine.Suspended,
+            UpdateLayout,
+            _engine.StartIfEnabledAsync,
+            _engine.EnsureHookedAsync);
+
+        _windows = new MainWindowManager(mvvmService, mainViewModelLocator);
+        _windows.DisposeWith(this);
+
+        _tray = new TrayIconController(notify, options);
+        _tray.DisposeWith(this);
+
+        new WallpaperRefresher(
+                layoutFactory, () => MonitorsLayout, action => Dispatcher.UIThread.Post(action))
+            .DisposeWith(this);
 
         // App-level options never go through the engine start flow: persist them as
         // soon as they change instead of waiting for the save button (#406). The
@@ -120,20 +138,27 @@ public class MainService : ReactiveModel, IMainService
             .Subscribe(_ => (MonitorsLayout as MonitorsLayout)?.UpdateSchedule())
             .DisposeWith(this);
 
-        // Relate service state with notify icon. Post to the UI thread so events
-        // arrive in order (a Task.Run per event could invert Running/Stopped);
-        // the Safely wrapper keeps one failed handler from stopping later events.
-        _littleBigMouseClientService.DaemonEventReceived += (sender, args) =>
-            Dispatcher.UIThread.Post(() => _ = DaemonEventReceivedSafely(sender, args));
+        // Relate service state with the notify icon. Post to the UI thread so events arrive in
+        // order (a Task.Run per event could invert Running/Stopped); the Safely wrapper keeps
+        // one failed handler from stopping later events.
+        void OnDaemonEvent(object? sender, LittleBigMouseServiceEventArgs args)
+            => Dispatcher.UIThread.Post(() => _ = DaemonEventReceivedSafelyAsync(args));
 
-        // The platform watches the OS for wallpaper changes (Windows: a RegNotifyChangeKeyValue
-        // registry watcher) and raises WallpaperChanged. Refresh the wallpaper drawn behind each
-        // monitor in place.
-        _layoutFactory.WallpaperChanged += (_, _) => RefreshWallpaper();
+        OwnedSubscription.Create<EventHandler<LittleBigMouseServiceEventArgs>>(
+                OnDaemonEvent,
+                h => littleBigMouseClientService.DaemonEventReceived += h,
+                h => littleBigMouseClientService.DaemonEventReceived -= h)
+            .DisposeWith(this);
 
         // Platforms without a daemon reporting display changes (Linux) detect them in the
         // factory itself; same debounce/settle/idempotence path as the daemon event.
-        _layoutFactory.DisplayChanged += (_, _) => _ = DisplayChangedAsync();
+        void OnDisplayChanged(object? sender, EventArgs args) => _ = _displayChanges.NotifyAsync();
+
+        OwnedSubscription.Create<EventHandler>(
+                OnDisplayChanged,
+                h => layoutFactory.DisplayChanged += h,
+                h => layoutFactory.DisplayChanged -= h)
+            .DisposeWith(this);
     }
 
     public void UpdateLayout()
@@ -141,7 +166,7 @@ public class MainService : ReactiveModel, IMainService
         // TODO : move to plugin
         var old = MonitorsLayout;
 
-        MonitorsLayout = (_virtualLayoutEnvDisabled ? null : LoadVirtualLayoutFromEnv())
+        MonitorsLayout = (_virtualLayoutEnvDisabled ? null : VirtualLayoutEnvironment.Load())
                          ?? _layoutFactory.Create();
 
         old?.Dispose();
@@ -160,90 +185,11 @@ public class MainService : ReactiveModel, IMainService
         UpdateLayout();
     }
 
-    /// <summary>
-    /// Debug hook: LBM_VIRTUAL_LAYOUT=path-to-export(.json|.gz) replaces the system layout
-    /// with a virtual one, so a user's export can be inspected from the command line
-    /// (same display-only semantics as the "open virtual layout" debug button).
-    /// </summary>
-    static IMonitorsLayout? LoadVirtualLayoutFromEnv()
-    {
-        var path = Environment.GetEnvironmentVariable("LBM_VIRTUAL_LAYOUT");
-        if (string.IsNullOrWhiteSpace(path)) return null;
-
-        try
-        {
-            var bytes = File.ReadAllBytes(path);
-            string json;
-            if (bytes.Length > 2 && bytes[0] == 0x1f && bytes[1] == 0x8b)
-            {
-                using var gzip = new System.IO.Compression.GZipStream(
-                    new MemoryStream(bytes), System.IO.Compression.CompressionMode.Decompress);
-                using var reader = new StreamReader(gzip);
-                json = reader.ReadToEnd();
-            }
-            else
-            {
-                json = System.Text.Encoding.UTF8.GetString(bytes);
-            }
-
-            return VirtualLayoutFactory.FromJson(json, LayoutSource.VirtualFile, path);
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"LBM_VIRTUAL_LAYOUT: failed to load '{path}': {ex}");
-            return null;
-        }
-    }
-
-    Window _mainWindow = null!;
-
     public Task ShowControlAsync()
     {
-        if (_mainWindow?.IsLoaded == true)
-        {
-            _mainWindow.WindowState = WindowState.Normal;
-            _mainWindow.Activate();
-            return Task.CompletedTask;
-        }
-
-        var viewModel = _mainViewModelLocator();
-        viewModel.MainService = this;
-
-        _actions?.Invoke(viewModel);
-
-        var view = _mvvmService
-            .MainContext
-            .GetView<DefaultViewMode>(viewModel, typeof(IDefaultViewClass));
-
-        _mainWindow = view?.AsWindow() ?? throw new Exception("No window found");
-
-        // AsWindow() creates a bare DefaultWindow with no size: restore the last
-        // session's geometry (or a sensible default) and save it back on close.
-        MainWindowGeometry.Attach(_mainWindow);
-
-        _mainWindow.Closed += (s, a) => _mainWindow = null!;
-
-        // Closing the window is not leaving — the layout lives on the service and comes
-        // back with the window — but it is the gesture that reads as "done", and the
-        // moment to say the configuration was never saved. Closing has to be cancelled
-        // to ask, then repeated once answered.
-        var closeConfirmed = false;
-        _mainWindow.Closing += async (s, e) =>
-        {
-            if (closeConfirmed || s is not Window window) return;
-
-            e.Cancel = true;
-            if (!await ConfirmLeavingAsync(window, leaving: false)) return;
-
-            closeConfirmed = true;
-            window.Close();
-        };
-
-        _mainWindow.Show();
-
+        _windows.Show(this, window => ConfirmLeavingAsync(window, leaving: false));
         return Task.CompletedTask;
     }
-
 
     /// <inheritdoc/>
     public bool LivePreview { get; set; }
@@ -280,127 +226,148 @@ public class MainService : ReactiveModel, IMainService
 
     public async Task StartNotifierAsync()
     {
-        _notify.Click += async (s, a) => await ShowControlAsync();
-
         // When a second instance launches, it signals the single-instance guard; show our
         // window instead of doing nothing. Raised on a background thread.
         if (Program.SingleInstance is { } singleInstance)
         {
-            singleInstance.ShowRequested += () =>
+            void OnShowRequested()
             {
                 Console.Error.WriteLine("Single-instance activation requested: showing the control window.");
                 Dispatcher.UIThread.Post(() => _ = ShowControlAsync());
-            };
+            }
+
+            OwnedSubscription.Create<Action>(
+                    OnShowRequested,
+                    h => singleInstance.ShowRequested += h,
+                    h => singleInstance.ShowRequested -= h)
+                .DisposeWith(this);
         }
 
-        // Apply / react to the "hide tray icon" option. The notify service hides the tray icon
-        // natively (Avalonia TrayIcon.IsVisible) — no per-OS code here.
-        _options.PropertyChanged += (s, e) =>
-        {
-            if (e.PropertyName == nameof(ILayoutOptions.HideTrayIcon))
-                _notify.Visible = !_options.HideTrayIcon;
-        };
-
-        // Hidden where the app cannot update itself (Linux: the distribution package
-        // owns updates) — clicking it would be a no-op.
-        if (_updaterLocator().IsSupported)
-            await _notify.AddMenuAsync(-1, "Check for update","Icon/lbm_on", async () => await _updaterLocator().CheckUpdateAsync(true));
-        await _notify.AddMenuAsync(-1, "Open","Icon/lbm_off", ShowControlAsync);
-        await _notify.AddMenuAsync(-1, "Start","Icon/Start", StartFromUserAsync);
-        await _notify.AddMenuAsync(-1, "Stop","Icon/Stop", () =>
-        {
-            MonitorsLayout.Options.Enabled = false;
-            _layoutPersistence.SaveEnabled(MonitorsLayout);
-            return _littleBigMouseClientService.StopAsync();
-        });
-        await _notify.AddMenuAsync(-1, "Refresh", "Icon/Refresh", RefreshAsync);
-        await _notify.AddMenuAsync(-1, "Exit", "Icon/sys/Close", QuitAsync);
-
-        // Apply the initial "hide tray icon" preference BEFORE loading the icon bitmap.
-        // SetIconAsync queues a dispatcher lambda that checks _visible; if Visible=false
-        // is already set here, the lambda returns early and NIM_ADD never fires.
-        _notify.Visible = !_options.HideTrayIcon;
-
-        await _notify.SetIconAsync("Icon/lbm_off",128);
-
-        _notify.Show();
+        await _tray.InitializeAsync(new TrayMenu(
+            // Hidden where the app cannot update itself (Linux: the distribution package
+            // owns updates) — clicking it would be a no-op.
+            CheckUpdateAsync: _updaterLocator().IsSupported
+                ? () => _updaterLocator().CheckUpdateAsync(true)
+                : null,
+            OpenAsync: ShowControlAsync,
+            StartAsync: _engine.StartFromUserAsync,
+            StopAsync: _engine.StopFromUserAsync,
+            RefreshAsync: _displayChanges.RefreshAsync,
+            QuitAsync: QuitAsync));
     }
 
-    public void AddControlPlugin(Action<IMainPluginsViewModel>? action)
-    {
-        _actions += action;
-    }
+    public void AddControlPlugin(Action<IMainPluginsViewModel>? action) => _windows.AddPlugin(action);
 
     async Task QuitAsync()
     {
         // The one place the edits are actually lost.
-        if (!await ConfirmLeavingAsync(_mainWindow, leaving: true)) return;
+        if (!await ConfirmLeavingAsync(_windows.Current, leaving: true)) return;
 
         // TODO : it should not append by sometimes the QuitAsync does not return
-        var t = Task.Delay(5000).ContinueWith(t => Dispatcher.UIThread.BeginInvokeShutdown(DispatcherPriority.Normal));
+        _ = Task.Delay(5000).ContinueWith(
+            _ => Dispatcher.UIThread.BeginInvokeShutdown(DispatcherPriority.Normal));
         await _littleBigMouseClientService.QuitAsync();
         Dispatcher.UIThread.BeginInvokeShutdown(DispatcherPriority.Normal);
     }
 
-    Task StartAsync() => _littleBigMouseClientService.StartAsync(MonitorsLayout.ComputeZones());
-
-    // Symmetric to the tray Stop: a user Start persists Enabled=true, otherwise
-    // the recovery guards (which test Options.Enabled) never reconcile it.
-    async Task StartFromUserAsync()
+    /// <summary>
+    /// The daemon reported something. The whole of this method is deciding what it means; the
+    /// acting on it belongs to the collaborators.
+    /// </summary>
+    async Task DaemonEventReceivedAsync(LittleBigMouseServiceEventArgs args)
     {
-        MonitorsLayout.Options.Enabled = true;
-        _layoutPersistence.SaveEnabled(MonitorsLayout);
-        await StartAsync();
+        DaemonEventTrace.Write(args.Event);
+
+        // Flags first, and synchronously: they gate paths that can run while the icon update
+        // below is awaiting. Raising Suspended after an await would leave a window in which a
+        // display change still believes there is a desktop.
+        switch (args.Event)
+        {
+            // The daemon detected the display turning off (sleep / session standby / lock-idle)
+            // and already unhooked itself, so the cursor is never left confined without us.
+            // Stop reacting to display events until it comes back.
+            case LittleBigMouseEvent.Suspended:
+                _engine.Suspended = true;
+                break;
+
+            case LittleBigMouseEvent.Resumed:
+                _engine.Suspended = false;
+                break;
+
+            case LittleBigMouseEvent.Connected:
+                _justConnected = true;
+                break;
+
+            case LittleBigMouseEvent.Running:
+                _justConnected = false;
+                break;
+        }
+
+        await _tray.ShowDaemonStateAsync(args.Event);
+
+        switch (args.Event)
+        {
+            // A daemon reporting itself stopped right after connecting has no layout yet: that
+            // is not the user's Stop, it is a daemon waiting to be told what to do.
+            case LittleBigMouseEvent.Stopped:
+                if (MonitorsLayout is not null && MonitorsLayout.Options.Enabled && _justConnected)
+                {
+                    _justConnected = false;
+                    await _engine.StartAsync();
+                }
+                break;
+
+            case LittleBigMouseEvent.SettingsChanged:
+            case LittleBigMouseEvent.DesktopChanged:
+            case LittleBigMouseEvent.DisplayChanged:
+                await _displayChanges.NotifyAsync();
+                break;
+
+            // Display is back: reconcile the layout only if it actually changed while off (the
+            // idempotence guard), then keep re-hooking the daemon through the post-resume
+            // display re-enumeration storm. A single Start loses a race — a late
+            // WM_DISPLAYCHANGE unhooks us ~1-2s after Resumed — and the engine would stay
+            // stopped ("blue") until a manual Start.
+            case LittleBigMouseEvent.Resumed:
+                await _displayChanges.NotifyAsync();
+                await _engine.EnsureRunningAfterResumeAsync();
+                break;
+
+            case LittleBigMouseEvent.FocusChanged:
+                _processesCollector?.AddProcess(args.Payload);
+                break;
+
+            // Load outcome: consumed by the location control (badge/status); nothing
+            // to reconcile at the service level.
+            case LittleBigMouseEvent.Loaded:
+            case LittleBigMouseEvent.LoadFailed:
+                break;
+
+            // The panic shortcut ran. Its two steps announce themselves through the ordinary
+            // events as well — a restore reloads, a stop unhooks — so the tray icon is already
+            // right; the location control is what has to act.
+            case LittleBigMouseEvent.Rescued:
+                break;
+
+            // Anything else, including events only a newer daemon knows about, is not ours to
+            // reconcile. This used to throw, which faulted the handler on every Suspended,
+            // Resumed and Probed.
+            default:
+                break;
+        }
     }
 
     /// <summary>
-    /// Tray-menu escape hatch: force a layout rebuild when the automatic display-change
-    /// detection missed one (#443). Deliberately bypasses the idempotence guard, then
-    /// realigns the built signature so the next display event doesn't rebuild again.
+    /// Set between a daemon connecting and its first Running: the Stopped that arrives in
+    /// between means "I have no layout", not "the user stopped me".
     /// </summary>
-    async Task RefreshAsync()
-    {
-        // display off: nothing to rebuild against, the daemon's Resumed event reconciles
-        if (_suspended) return;
+    bool _justConnected;
 
-        UpdateLayout();
-        _lastBuiltSignature = _layoutFactory.DisplaySignature();
-        if (MonitorsLayout.Options.Enabled)
-            await StartAsync();
-    }
-
-    /// <summary>
-    /// Rolling trace of daemon events: display-event storms (wake from sleep, HDR
-    /// flapping...) rebuild the layout every 5s for hours, and identifying the
-    /// looping event after the fact is otherwise impossible.
-    /// </summary>
-    static void TraceDaemonEvent(LittleBigMouseEvent evt)
+    async Task DaemonEventReceivedSafelyAsync(LittleBigMouseServiceEventArgs args)
     {
         try
         {
-            var dir = LbmPaths.DataDir;
-            Directory.CreateDirectory(dir);
-            var file = Path.Combine(dir, "daemon-events.log");
-
-            if (File.Exists(file) && new FileInfo(file).Length > 1_000_000)
-                File.WriteAllText(file, "");
-
-            File.AppendAllText(file, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {evt}\r\n");
-        }
-        catch
-        {
-            // tracing must never take the app down
-        }
-    }
-
-    bool _justConnected = false;
-
-    async Task DaemonEventReceivedSafely(
-        object? sender, LittleBigMouseServiceEventArgs args)
-    {
-        try
-        {
-            await DaemonEventReceived(sender, args);
+            await DaemonEventReceivedAsync(args);
         }
         catch (Exception error)
         {
@@ -408,249 +375,4 @@ public class MainService : ReactiveModel, IMainService
             Debug.WriteLine($"Daemon event handler failed: {error}");
         }
     }
-    async Task DaemonEventReceived(object? sender, LittleBigMouseServiceEventArgs args)
-    {
-        TraceDaemonEvent(args.Event);
-
-        switch (args.Event)
-        {
-            case LittleBigMouseEvent.Running:
-                _justConnected = false;
-                await _notify.SetIconAsync("icon/lbm_on",32);
-                break;
-
-            case LittleBigMouseEvent.Stopped:
-                await _notify.SetIconAsync("icon/lbm_off",32);
-
-                if (MonitorsLayout is not null && MonitorsLayout.Options.Enabled && _justConnected)
-                {
-                    _justConnected = false;
-                    await StartAsync();
-                }
-                break;
-
-            case LittleBigMouseEvent.Dead:
-                await _notify.SetIconAsync("icon/lbm_dead",32);
-                break;
-
-            case LittleBigMouseEvent.Paused:
-                await _notify.SetIconAsync("icon/lbm_paused",32);
-                break;
-
-            case LittleBigMouseEvent.SettingsChanged:
-            case LittleBigMouseEvent.DesktopChanged:
-            case LittleBigMouseEvent.DisplayChanged:
-                await DisplayChangedAsync();
-                break;
-
-            // The daemon detected the display turning off (sleep / session standby / lock-idle) and
-            // already unhooked itself (so the cursor is never left confined without us). Just stop
-            // reacting to display events until it comes back — no rebuild while there is no desktop.
-            case LittleBigMouseEvent.Suspended:
-                _suspended = true;
-                await _notify.SetIconAsync("icon/lbm_paused", 32);
-                break;
-
-            // Display is back: reconcile the layout only if it actually changed while off (the
-            // idempotence guard), then keep re-hooking the daemon through the post-resume display
-            // re-enumeration storm. A single StartAsync loses a race — a late WM_DISPLAYCHANGE
-            // unhooks us ~1-2s after Resumed — and the engine stays stopped ("blue") until a manual
-            // Start. EnsureRunningAfterResumeAsync re-asserts Start until it sticks.
-            case LittleBigMouseEvent.Resumed:
-                _suspended = false;
-                await DisplayChangedAsync();
-                await EnsureRunningAfterResumeAsync();
-                break;
-
-            case LittleBigMouseEvent.FocusChanged:
-                _processesCollector?.AddProcess(args.Payload);
-                break;
-            case LittleBigMouseEvent.Connected:
-                _justConnected = true;
-                break;
-            // Load outcome: consumed by the location control (badge/status); nothing
-            // to reconcile at the service level.
-            case LittleBigMouseEvent.Loaded:
-            case LittleBigMouseEvent.LoadFailed:
-                break;
-            // The panic shortcut ran. Its two steps announce themselves through the
-            // ordinary events as well — a restore reloads, a stop unhooks — so the tray
-            // icon is already right; the location control is what has to act.
-            case LittleBigMouseEvent.Rescued:
-                break;
-            // Anything else, including events only a newer daemon knows about, is not
-            // ours to reconcile. This used to throw, which faulted the handler on every
-            // Suspended, Resumed and Probed.
-            default:
-                break;
-        }
-    }
-
-    // React to a display change (attach/detach, resolution, scaling, primary) once the OS has
-    // actually SETTLED, without a fixed delay. The daemon forwards a burst of
-    // WM_DISPLAYCHANGE/WM_SETTINGCHANGE per change, so we:
-    //   1. trailing-debounce the burst (a generation counter: only the latest event proceeds),
-    //   2. confirm the config has stopped changing (two identical DisplaySignature reads),
-    // then rebuild. Measured on real switches, the config reaches its final state within one
-    // ~80ms sample, so this reacts in a few hundred ms instead of the former fixed 5s.
-    const int DisplayDebounceMs = 300;      // quiet window absorbing the message burst
-    const int DisplayStabilityStepMs = 100; // spacing between settle re-checks
-    const int DisplayStabilityMaxSteps = 8; // ~1.1s cap so a flapping config can't hang the settle loop
-    int _displayChangeGeneration;
-
-    async Task DisplayChangedAsync()
-    {
-        // Do nothing at all while the display is off: no debounce, no signature reads, no rebuild.
-        // The daemon's Resumed event reconciles once when the desktop is back.
-        if (_suspended) return;
-
-        var gen = Interlocked.Increment(ref _displayChangeGeneration);
-
-        // Trailing debounce: wait a short quiet window; if a newer event arrived meanwhile, bail
-        // and let that later call handle it (so a burst collapses to a single rebuild).
-        await Task.Delay(DisplayDebounceMs);
-        if (gen != Volatile.Read(ref _displayChangeGeneration)) return;
-
-        // Settle detection: rebuild only once the display config has stopped changing, i.e. two
-        // consecutive signatures match. Capped so a pathological flapping config can't hang here.
-        var signature = _layoutFactory.DisplaySignature();
-        for (var i = 0; i < DisplayStabilityMaxSteps; i++)
-        {
-            await Task.Delay(DisplayStabilityStepMs);
-            if (gen != Volatile.Read(ref _displayChangeGeneration)) return;
-            var next = _layoutFactory.DisplaySignature();
-            if (next == signature) break;
-            signature = next;
-        }
-
-        // A Suspended event may have arrived during the debounce/settle (the display went off while
-        // this display-change was being handled): drop the rebuild — the daemon has unhooked and we
-        // wait for Resumed.
-        if (_suspended) return;
-
-        // Idempotence guard: the settle loop confirms the config STOPPED changing, but not that it
-        // actually DIFFERS from the generation we already built. A spurious WM_DISPLAYCHANGE (a
-        // monitor's DPMS power-save on/off — e.g. an HDR TV —, a mode re-apply, a stray broadcast)
-        // settles to the very same signature we last built. Rebuilding it drops a fresh, fully-wired
-        // MonitorsLayout generation that Avalonia's compositor/animation clock keeps alive (#412): a
-        // storm of identical events is what fills gigabytes. Skip when nothing changed.
-        if (signature == _lastBuiltSignature)
-        {
-            // Skip the REBUILD, but still make sure the engine is hooked. The daemon unhooks itself
-            // over ANY display change (so the cursor is never confined while the desktop reshapes);
-            // when the config settles back to the same signature, nothing else would re-Start it, so
-            // the engine would stay stopped ("blue") until a manual Start. Re-hook without rebuilding.
-            await EnsureEngineHookedAsync();
-            return;
-        }
-
-        UpdateLayout();
-        _lastBuiltSignature = signature;
-        if (MonitorsLayout.Options.Enabled)
-            await StartAsync();
-    }
-
-    // The daemon reports Running only while its low-level mouse hook is actually installed, so its
-    // published State is the source of truth for "is the engine hooked right now".
-    bool EngineRunning => _littleBigMouseClientService.State == LittleBigMouseEvent.Running;
-
-    /// <summary>
-    /// Re-hook the daemon if the engine should be running but is not — WITHOUT rebuilding the layout.
-    /// Called from the idempotence guard when a display change settles to the already-built config:
-    /// the daemon unhooks itself over any display change, and when the config comes back identical
-    /// nothing else re-Starts it. Safe while an excluded app (a game) is focused — the daemon's Run
-    /// path no-ops when paused, so this can never force the hook on over an exclusion.
-    /// </summary>
-    async Task EnsureEngineHookedAsync()
-    {
-        if (_resumeWatchdogActive) return;                        // the resume watchdog owns reconciliation
-        if (_suspended) return;                                   // display off — nothing to do
-        if (!(MonitorsLayout?.Options.Enabled ?? false)) return;  // engine disabled by the user
-        if (EngineRunning) return;                                // already hooked
-        await StartAsync();
-    }
-
-    /// <summary>
-    /// Keep the engine hooked across the display re-enumeration storm that follows a wake from sleep.
-    /// The daemon emits Resumed as soon as the screen turns on, but Windows then re-enumerates the
-    /// GPU/monitors for several seconds, firing a burst of WM_DISPLAYCHANGE. One of those, processed
-    /// just after we re-install the hook, makes the daemon unhook itself again (a Stopped ~1-2s after
-    /// Resumed), and a single StartAsync loses that race — the engine stays stopped ("blue") until a
-    /// manual Start. Re-assert Start until it sticks (Running for a short quiet window), bounded so a
-    /// legitimately-paused engine (excluded app focused at wake) can't loop forever.
-    /// </summary>
-    async Task EnsureRunningAfterResumeAsync()
-    {
-        if (!(MonitorsLayout?.Options.Enabled ?? false)) return;
-
-        var myGen = Interlocked.Increment(ref _resumeGeneration);
-        _resumeWatchdogActive = true;
-        try
-        {
-            var restarts = 0;
-            var quiet = 0;
-            for (var i = 0; i < ResumeWatchdogMaxSteps; i++)
-            {
-                if (myGen != Volatile.Read(ref _resumeGeneration)) return; // a newer resume superseded us
-                if (_suspended) return;                                    // went back to sleep
-                if (!(MonitorsLayout?.Options.Enabled ?? false)) return;   // user disabled the engine
-
-                if (EngineRunning)
-                {
-                    if (++quiet >= ResumeWatchdogStableSteps) return; // Running long enough — converged
-                }
-                else if (restarts >= ResumeWatchdogMaxRestarts)
-                {
-                    return; // gave up — the engine is legitimately paused (excluded app focused at wake)
-                }
-                else
-                {
-                    quiet = 0;
-                    restarts++;
-                    await StartAsync();
-                }
-
-                await Task.Delay(ResumeWatchdogStepMs);
-            }
-        }
-        finally
-        {
-            _resumeWatchdogActive = false;
-        }
-    }
-
-    const int ResumeWatchdogStepMs = 500;      // spacing between engine-state checks
-    const int ResumeWatchdogStableSteps = 3;   // consecutive Running checks that count as converged (~1.5s)
-    const int ResumeWatchdogMaxRestarts = 6;   // cap re-Starts so a paused/excluded engine can't loop forever
-    const int ResumeWatchdogMaxSteps = 60;     // hard stop (~30s) against a pathological flapping wake
-
-    // Guards the post-resume watchdog: a generation counter so a newer Resumed supersedes an older
-    // watchdog run, and a flag telling the idempotence-guard reconcile to stand aside while the
-    // watchdog is the active driver. Written on the daemon-event path — volatile is enough.
-    int _resumeGeneration;
-    volatile bool _resumeWatchdogActive;
-
-    // Signature of the display configuration the current MonitorsLayout was built from. Lets
-    // DisplayChangedAsync skip a rebuild when a display event settles to an already-built config.
-    string _lastBuiltSignature = "";
-
-    // Set while the display is off (daemon Suspended/Resumed events): DisplayChangedAsync
-    // short-circuits while set, so the UI does nothing while there is no desktop. Written on the
-    // daemon-event thread — volatile is enough (a single flag).
-    volatile bool _suspended;
-
-    /// <summary>
-    /// Refresh the wallpaper drawn behind each monitor after the registry watcher reports a change.
-    /// Runs the in-place read on the UI thread; <see cref="ILayoutFactory.UpdateWallpaper"/> gates on
-    /// a cheap signature, so the several registry writes Windows makes per change collapse to a
-    /// single actual refresh, and unchanged notifications cost almost nothing.
-    /// </summary>
-    void RefreshWallpaper()
-    {
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (MonitorsLayout is MonitorsLayout layout) _layoutFactory.UpdateWallpaper(layout);
-        });
-    }
-
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainWindowManager.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainWindowManager.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Reactive.Disposables;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using HLab.Mvvm;
+using HLab.Mvvm.Annotations;
+using HLab.Mvvm.Avalonia;
+using LittleBigMouse.Plugins;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// The configuration window: building it on demand, bringing back the one that already exists,
+/// and letting it go when it closes.
+/// <para>
+/// Closing is not leaving — the layout lives on the service and comes back with the window —
+/// but it is the gesture that reads as "done", so it is also the moment to say the
+/// configuration was never saved. Avalonia gives no way to ask a question mid-close, so the
+/// close is cancelled, the question asked, and the close repeated once answered.
+/// </para>
+/// </summary>
+public sealed class MainWindowManager(
+    IMvvmService mvvmService,
+    Func<IMainPluginsViewModel> viewModelLocator) : IDisposable
+{
+    Action<IMainPluginsViewModel>? _plugins;
+    Window? _window;
+
+    /// <summary>
+    /// Handlers on the live window. They die with the window either way, but naming them makes
+    /// "the window is gone and so is everything watching it" a statement the code makes rather
+    /// than one the garbage collector eventually agrees with.
+    /// </summary>
+    CompositeDisposable? _windowSubscriptions;
+
+    /// <summary>The open window, or null when there is none.</summary>
+    public Window? Current => _window;
+
+    /// <summary>Contribute to the window's view-model when it is next built.</summary>
+    public void AddPlugin(Action<IMainPluginsViewModel>? action) => _plugins += action;
+
+    /// <summary>
+    /// Show the configuration window: restore the existing one, or build, place and open a new one.
+    /// </summary>
+    /// <param name="mainService">Handed to the view-model, which drives the layout through it.</param>
+    /// <param name="confirmClose">
+    /// Asked before the window actually closes. False means the user chose to stay.
+    /// </param>
+    public void Show(IMainService mainService, Func<Window, Task<bool>> confirmClose)
+    {
+        if (_window?.IsLoaded == true)
+        {
+            _window.WindowState = WindowState.Normal;
+            _window.Activate();
+            return;
+        }
+
+        var viewModel = viewModelLocator();
+        viewModel.MainService = mainService;
+
+        _plugins?.Invoke(viewModel);
+
+        var view = mvvmService
+            .MainContext
+            .GetView<DefaultViewMode>(viewModel, typeof(IDefaultViewClass));
+
+        var window = view?.AsWindow() ?? throw new Exception("No window found");
+
+        // AsWindow() creates a bare DefaultWindow with no size: restore the last
+        // session's geometry (or a sensible default) and save it back on close.
+        MainWindowGeometry.Attach(window);
+
+        var subscriptions = new CompositeDisposable();
+        var closeConfirmed = false;
+
+        void OnClosed(object? sender, EventArgs e)
+        {
+            _window = null;
+            ReleaseWindowSubscriptions();
+        }
+
+        async void OnClosing(object? sender, WindowClosingEventArgs e)
+        {
+            if (closeConfirmed || sender is not Window closing) return;
+
+            e.Cancel = true;
+            if (!await confirmClose(closing)) return;
+
+            closeConfirmed = true;
+            closing.Close();
+        }
+
+        subscriptions.Add(OwnedSubscription.Create<EventHandler>(
+            OnClosed, h => window.Closed += h, h => window.Closed -= h));
+        subscriptions.Add(OwnedSubscription.Create<EventHandler<WindowClosingEventArgs>>(
+            OnClosing, h => window.Closing += h, h => window.Closing -= h));
+
+        // Let go of the window being replaced before adopting this one. There is a narrow way to
+        // get here with one still outstanding — a second show landing before the first window
+        // reports IsLoaded — and its Closed handler would otherwise fire later and null out
+        // _window, leaving the open window unreachable and the next show building a third.
+        ReleaseWindowSubscriptions();
+        _windowSubscriptions = subscriptions;
+        _window = window;
+
+        window.Show();
+    }
+
+    void ReleaseWindowSubscriptions()
+    {
+        _windowSubscriptions?.Dispose();
+        _windowSubscriptions = null;
+    }
+
+    /// <summary>
+    /// Release what watches the window. The window itself is left alone: tearing it down here
+    /// would make disposing the service a visible event for the user, which it is not.
+    /// <para>
+    /// This does drop the unsaved-changes prompt, so anything disposing the manager is
+    /// committing to the edits being lost. Only shutdown does, and shutdown asks the question
+    /// itself, on its way out.
+    /// </para>
+    /// </summary>
+    public void Dispose() => ReleaseWindowSubscriptions();
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/OwnedSubscription.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/OwnedSubscription.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Reactive.Disposables;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// Turns a classic .NET event into a subscription that can actually be released.
+/// <para>
+/// <c>source.Event += (s, e) => ...</c> is a one-way door: the delegate has no name left to
+/// hand back to <c>-=</c>, so the handler — and everything it captured — lives exactly as
+/// long as the event <em>source</em> does, not as long as the subscriber. That costs nothing
+/// while the subscriber is a process-lifetime singleton and turns into a leak the day it
+/// stops being one, which is the kind of change nobody remembers to audit for.
+/// </para>
+/// <para>
+/// Pairing the add with its remove at the call site makes the lifetime a local decision and
+/// hands back an <see cref="IDisposable"/> the owner keeps with the rest of its resources.
+/// </para>
+/// </summary>
+static class OwnedSubscription
+{
+    /// <summary>
+    /// Subscribe <paramref name="handler"/> through <paramref name="add"/> and return the
+    /// token that undoes it. The handler must be a named method or a variable — passing a
+    /// lambda expression here works, because the same delegate instance reaches both
+    /// <paramref name="add"/> and <paramref name="remove"/>.
+    /// </summary>
+    public static IDisposable Create<THandler>(
+        THandler handler, Action<THandler> add, Action<THandler> remove)
+    {
+        add(handler);
+        return Disposable.Create(() => remove(handler));
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/TrayIconController.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/TrayIconController.cs
@@ -1,0 +1,123 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Disposables;
+using System.Threading.Tasks;
+using HLab.UserNotification;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Zoning;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// What the tray menu can do. Each entry is the action itself, not a service to look it up
+/// on: the tray shows what it was handed and knows nothing about layouts, daemons or updaters.
+/// </summary>
+/// <param name="CheckUpdateAsync">
+/// Null where the app cannot update itself (Linux: the distribution package owns updates), and
+/// then the entry is not shown at all — a menu item that no-ops is worse than none.
+/// </param>
+public sealed record TrayMenu(
+    Func<Task>? CheckUpdateAsync,
+    Func<Task> OpenAsync,
+    Func<Task> StartAsync,
+    Func<Task> StopAsync,
+    Func<Task> RefreshAsync,
+    Func<Task> QuitAsync);
+
+/// <summary>
+/// The tray icon: its menu, its visibility, and the one thing it says about the engine — which
+/// of the four states it is in. Everything it reacts to (a click, the "hide tray icon" option)
+/// is held as a subscription it can give back.
+/// </summary>
+public sealed class TrayIconController(IUserNotificationService notify, ILayoutOptions options)
+    : IDisposable
+{
+    readonly CompositeDisposable _subscriptions = [];
+
+    /// <summary>
+    /// The icon that stands for a daemon state, or null for the events the icon says nothing
+    /// about. Suspended shares the paused icon: from the tray's point of view a display that
+    /// went to sleep and an engine that stood down look the same — not running, not broken.
+    /// </summary>
+    public static string? IconFor(LittleBigMouseEvent daemonEvent) => daemonEvent switch
+    {
+        LittleBigMouseEvent.Running => "icon/lbm_on",
+        LittleBigMouseEvent.Stopped => "icon/lbm_off",
+        LittleBigMouseEvent.Dead => "icon/lbm_dead",
+        LittleBigMouseEvent.Paused or LittleBigMouseEvent.Suspended => "icon/lbm_paused",
+        _ => null
+    };
+
+    /// <summary>Reflect a daemon state, if it is one the icon has something to say about.</summary>
+    public Task ShowDaemonStateAsync(LittleBigMouseEvent daemonEvent)
+        => IconFor(daemonEvent) is { } icon ? notify.SetIconAsync(icon, 32) : Task.CompletedTask;
+
+    /// <summary>Build the menu, wire the click and the visibility option, and show the icon.</summary>
+    public async Task InitializeAsync(TrayMenu menu)
+    {
+        void OnClick(object sender, object args) => FireAndForget(menu.OpenAsync, "Tray icon click");
+
+        _subscriptions.Add(OwnedSubscription.Create<Action<object, object>>(
+            OnClick, h => notify.Click += h, h => notify.Click -= h));
+
+        // Apply / react to the "hide tray icon" option. The notify service hides the tray icon
+        // natively (Avalonia TrayIcon.IsVisible) — no per-OS code here.
+        void OnOptionChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ILayoutOptions.HideTrayIcon)) ApplyVisibility();
+        }
+
+        _subscriptions.Add(OwnedSubscription.Create<PropertyChangedEventHandler>(
+            OnOptionChanged, h => options.PropertyChanged += h, h => options.PropertyChanged -= h));
+
+        if (menu.CheckUpdateAsync is { } checkUpdate)
+            await notify.AddMenuAsync(-1, "Check for update", "Icon/lbm_on", checkUpdate);
+
+        await notify.AddMenuAsync(-1, "Open", "Icon/lbm_off", menu.OpenAsync);
+        await notify.AddMenuAsync(-1, "Start", "Icon/Start", menu.StartAsync);
+        await notify.AddMenuAsync(-1, "Stop", "Icon/Stop", menu.StopAsync);
+        await notify.AddMenuAsync(-1, "Refresh", "Icon/Refresh", menu.RefreshAsync);
+        await notify.AddMenuAsync(-1, "Exit", "Icon/sys/Close", menu.QuitAsync);
+
+        // Apply the initial "hide tray icon" preference BEFORE loading the icon bitmap.
+        // SetIconAsync queues a dispatcher lambda that checks _visible; if Visible=false
+        // is already set here, the lambda returns early and NIM_ADD never fires.
+        ApplyVisibility();
+
+        await notify.SetIconAsync("Icon/lbm_off", 128);
+
+        notify.Show();
+    }
+
+    void ApplyVisibility() => notify.Visible = !options.HideTrayIcon;
+
+    /// <summary>
+    /// A tray click has nowhere to report a failure to, and an <c>async void</c> handler would
+    /// take the process down with it — which is what the click used to be.
+    /// <para>
+    /// Surviving it costs something though: from the user's side a click that fails now looks
+    /// exactly like a click that did nothing. So this goes to <see cref="Console.Error"/>, where
+    /// the app's other startup diagnostics go and where a Release build still has it, rather
+    /// than to <c>Debug.WriteLine</c>, which would leave nothing at all behind.
+    /// </para>
+    /// </summary>
+    static void FireAndForget(Func<Task> action, string what)
+    {
+        _ = Run();
+        return;
+
+        async Task Run()
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine($"{what} failed: {error}");
+            }
+        }
+    }
+
+    public void Dispose() => _subscriptions.Dispose();
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/VirtualLayoutEnvironment.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/VirtualLayoutEnvironment.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using LittleBigMouse.DisplayLayout.Monitors;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// Debug hook: <c>LBM_VIRTUAL_LAYOUT=path-to-export(.json|.gz)</c> replaces the system layout
+/// with a virtual one, so a user's export can be inspected straight from the command line —
+/// same display-only semantics as the "open virtual layout" debug button.
+/// </summary>
+public static class VirtualLayoutEnvironment
+{
+    public const string Variable = "LBM_VIRTUAL_LAYOUT";
+
+    /// <summary>
+    /// The layout named by the environment variable, or null when it is unset or unreadable.
+    /// A bad path is reported and ignored: this is a diagnostic aid, and one that refused to
+    /// start the app would be a poor one.
+    /// </summary>
+    public static IMonitorsLayout? Load()
+    {
+        var path = Environment.GetEnvironmentVariable(Variable);
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        try
+        {
+            return VirtualLayoutFactory.FromJson(ReadJson(path), LayoutSource.VirtualFile, path);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"{Variable}: failed to load '{path}': {ex}");
+            return null;
+        }
+    }
+
+    /// <summary>Reads the export, transparently un-gzipping one that was saved compressed.</summary>
+    static string ReadJson(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+
+        if (bytes.Length <= 2 || bytes[0] != 0x1f || bytes[1] != 0x8b)
+            return Encoding.UTF8.GetString(bytes);
+
+        using var gzip = new GZipStream(new MemoryStream(bytes), CompressionMode.Decompress);
+        using var reader = new StreamReader(gzip);
+        return reader.ReadToEnd();
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/WallpaperRefresher.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/WallpaperRefresher.cs
@@ -1,0 +1,55 @@
+using System;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugins;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// Keeps the wallpaper drawn behind each monitor in step with the desktop's.
+/// <para>
+/// The platform watches the OS (on Windows, a <c>RegNotifyChangeKeyValue</c> registry watcher)
+/// and raises <see cref="ILayoutFactory.WallpaperChanged"/> from a background thread. The
+/// refresh is in place — no layout teardown, so edits in progress survive it — and
+/// <see cref="ILayoutFactory.UpdateWallpaper"/> gates on a cheap signature, which is what
+/// collapses the several registry writes Windows makes per change into a single actual read.
+/// </para>
+/// <para>
+/// A whole class for six lines of work, because the six lines are not the point: the
+/// subscription is, and it now has an owner that can end it.
+/// </para>
+/// </summary>
+public sealed class WallpaperRefresher : IDisposable
+{
+    readonly ILayoutFactory _layoutFactory;
+    readonly Func<IMonitorsLayout?> _currentLayout;
+    readonly Action<Action> _postToUiThread;
+    readonly IDisposable _subscription;
+
+    /// <param name="postToUiThread">
+    /// The model is read and written on the UI thread; the event does not arrive on it.
+    /// </param>
+    public WallpaperRefresher(
+        ILayoutFactory layoutFactory,
+        Func<IMonitorsLayout?> currentLayout,
+        Action<Action> postToUiThread)
+    {
+        _layoutFactory = layoutFactory;
+        _currentLayout = currentLayout;
+        _postToUiThread = postToUiThread;
+
+        _subscription = OwnedSubscription.Create<EventHandler>(
+            OnWallpaperChanged,
+            h => _layoutFactory.WallpaperChanged += h,
+            h => _layoutFactory.WallpaperChanged -= h);
+    }
+
+    void OnWallpaperChanged(object? sender, EventArgs e) => Refresh();
+
+    /// <summary>Re-read the desktop wallpaper into the current layout, on the UI thread.</summary>
+    public void Refresh() => _postToUiThread(() =>
+    {
+        if (_currentLayout() is MonitorsLayout layout) _layoutFactory.UpdateWallpaper(layout);
+    });
+
+    public void Dispose() => _subscription.Dispose();
+}


### PR DESCRIPTION
`MainService` had grown to 656 lines and seven jobs: deciding when a display change deserved a layout rebuild, whether the mouse engine should be hooked, what the tray icon showed, when the window opened and closed, when the wallpaper was re-read, plus the `LBM_VIRTUAL_LAYOUT` loader and the daemon event log.

The three that carry the hard concurrency — debounce/settle/idempotence, the resume watchdog, and the daemon event routing — shared their state as bare fields on the class, so none of them could be exercised without an Avalonia dispatcher and a live daemon.

## What moved

`MainService` stays the **coordinator**, not a service locator: it constructs, wires and disposes these itself rather than resolving them from the container, because the wiring is the decision it exists to make — a display change may rebuild *or* may only re-hook; a resume must do both, in that order.

| | |
|---|---|
| `DisplayChangeCoordinator` | trailing debounce, settle detection, idempotence guard — behind delegates, no Avalonia, no daemon |
| `EngineController` | Start/Stop from the user, `StartIfEnabled` after a rebuild, `EnsureHooked` when a change settled to nothing, the resume watchdog; owns the `Suspended` flag |
| `MainWindowManager` / `TrayIconController` / `WallpaperRefresher` | the surfaces that only *show* something |
| `VirtualLayoutEnvironment` / `DaemonEventTrace` | self-contained statics |

`MainService.cs` goes 656 → 378 lines. The DI signature is unchanged; `Program.cs` is untouched.

The timing constants move into `DisplayChangeTimings` and `ResumeWatchdogTimings` records defaulting to the measured values, so tests replay a display storm in milliseconds instead of seconds.

## Subscriptions

The five permanent event lambdas — `DaemonEventReceived`, `DisplayChanged`, `WallpaperChanged`, `notify.Click`, `options.PropertyChanged` — become `OwnedSubscription`: an add paired with its remove at the call site, returning a token disposed with the owner.

`x.Event += (s, e) => ...` leaves no name to pass back to `-=`, so each handler was held by the event *source* for the life of the process. Invisible while `MainService` is a singleton, and a leak the day it stops being one.

## Behaviour changes — two, both deliberate

1. **Tray-icon left click** was an `async void` handler, so anything thrown by the show path (including its own `throw new Exception("No window found")`) reached the dispatcher unhandled and took the process down. It is now caught and written to `Console.Error`, where a Release build still has it. A click that fails now looks like a click that did nothing, which is the price of not crashing.

2. **Orphaned window.** Releasing the previous window's handlers fixes a latent bug: a second `ShowControlAsync` landing before the first window reported `IsLoaded` built a second window, and the orphan's `Closed` handler later nulled `_mainWindow`, so the next show built a *third* instead of activating the visible one.

Everything else was diffed statement by statement against the original and is unchanged: icon names and sizes, menu order, the daemon event switch and its flags-before-await ordering, all guard orders, `QuitAsync`, `ConfirmLeaving`, the two options subscriptions, the sticky `LBM_VIRTUAL_LAYOUT` opt-out. The null-layout guards added to Start/Stop are unreachable in practice — `MainBootloader` builds a layout before the tray exists.

## Tests

+53, for a total of 213 in `Ui.Avalonia.Tests` (was 160). Full `LittleBigMouse-Linux.slnf` suite: **428 passing, 0 failing.**

- **display bursts** — 10 notifications collapse to 1 rebuild; a burst whose configuration keeps moving builds only the settled signature; a config settling back to itself re-hooks without rebuilding; display off means not even a signature read; extinction mid-settle; a config that never stabilizes does not hang
- **start / stop** — user actions persist `Enabled` before commanding the daemon; the four re-hook guards
- **resume** — takes first time / must re-assert until it sticks / gives up on a legitimately paused engine (excluded app focused at wake) / interrupted by re-sleep or by the user / a newer resume supersedes the older watchdog
- **disposal** — after `Dispose()`, a platform display change does not even reach `ILayoutFactory.Create()`

**Not covered:** the orphaned-window path needs a real Avalonia `Window`, and the test project has no headless setup for one. That fix is reasoned, not tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
