### PR TITLE
Persist RescueShortcut on Windows

### DIFF
--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -66,6 +66,7 @@ public class RegistryLayoutStore : ILayoutStore
         // "ShowAttachDetachWarning" is the former name of the option, read as fallback.
         ShowMonitorActionWarning = root.TryGetBool("ShowMonitorActionWarning") ?? root.TryGetBool("ShowAttachDetachWarning"),
         BorderValues = root.TryGetString("BorderValues"),
+        RescueShortcut = root.TryGetString("RescueShortcut"),
         HideTrayIcon = root.TryGetBool("HideTrayIcon"),
         ExcludedDefaultsVersion = root.TryGetInt("ExcludedDefaultsVersion")
     };
@@ -263,6 +264,7 @@ public class RegistryLayoutStore : ILayoutStore
         Set(root, "VcpControl", o.VcpControl);
         Set(root, "ShowMonitorActionWarning", o.ShowMonitorActionWarning);
         Set(root, "BorderValues", o.BorderValues);
+        Set(root, "RescueShortcut", o.RescueShortcut);
         Set(root, "HideTrayIcon", o.HideTrayIcon);
         Set(root, "ExcludedDefaultsVersion", o.ExcludedDefaultsVersion);
     }


### PR DESCRIPTION
The rescue shortcut is the way out when the cursor is trapped where no click can reach the UI — and it is the one option **only Windows exposes**: `LbmOptionsViewModel.RescueShortcutSupported` is `OperatingSystem.IsWindows()`.

`RegistryLayoutStore` never read nor wrote it. So Windows, the only platform where the shortcut can be changed, was the only one not keeping the change.

A customized shortcut worked for the session — it travels to the daemon with the layout through `ZonesLayoutFactory` — and was back to `Ctrl+Alt+Shift+M` at the next start, silently. Nobody notices until the day they need it.

## The fix

Two lines, in the DTO's own order:

```csharp
RescueShortcut = root.TryGetString("RescueShortcut"),   // ReadGlobalOptions
Set(root, "RescueShortcut", o.RescueShortcut);          // WriteGlobalOptions
```

**Nothing to migrate.** An absent registry value reads as `null`, which the mapper already treats as "keep the current value", so an installation that has never seen this option keeps exactly the default it has today. The Linux JSON backend already persisted it (the serializer covers every DTO property), so this only closes the gap between the two.

## Not covered by a test

`RegistryLayoutStore` talks to `HKCU` directly: it cannot run on Linux, and a Windows-only test would write to the real `SOFTWARE\Mgth\LittleBigMouse` of whoever runs the suite locally.

Making the root key injectable would fix that for the whole store — **it currently has no test at all, which is how this stayed hidden** — but that is a change of its own, and I did not want to bundle a constructor change with a two-line bug fix. Happy to do it next if you want the Windows backend covered.

Found while splitting `LayoutPersistence` (#557); independent of it, branches off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
