### PR TITLE
Keep Excluded.txt comments out of the exclusion list

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
@@ -375,25 +375,29 @@ public class LayoutPersistenceGoldenTests : IDisposable
     }
 
     [Fact]
-    public void Load_ExcludedFileCommentLines_BecomeEntries_KnownQuirk()
+    public void Load_ExcludedFileCommentLines_StayOutOfTheListAndSurviveASave()
     {
-        // Characterization, NOT an endorsement: the daemon ignores ':'-prefixed lines, and
-        // LittleBigMouseClientService.CreateExcludedFile writes ExcludedProcessDefaults.Header
-        // atop the file when IT is the one seeding it. The persistence layer has no notion of
-        // comments — every line is an entry, shown as such in the options UI and written back
-        // on every save. Filtering them here would silently delete a user's own annotations,
-        // so the behavior is recorded rather than changed.
+        // A real file as CreateExcludedFile seeds it, plus a line the user added by hand.
+        // The daemon skips ':' lines and empty ones (daemon::load_excluded), so neither is
+        // an exclusion — but neither may be lost when the app rewrites the file either.
         var dir = Fixture("v5.6-current"); // ExcludedDefaultsVersion 2: no top-up interference
         var excluded = Path.Combine(_work, "commented", "Excluded.txt");
         Directory.CreateDirectory(Path.GetDirectoryName(excluded)!);
         File.WriteAllLines(excluded,
-            [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All, ":my own note"]);
+            [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All, "", ":my own note"]);
 
         var layout = NewLayout(out _, out _);
-        new TestPersistence(new JsonLayoutStore(dir), excluded).Load(layout);
+        var persistence = new TestPersistence(new JsonLayoutStore(dir), excluded);
+        persistence.Load(layout);
 
-        Assert.Equal(ExcludedProcessDefaults.Header, layout.Options.ExcludedList[0]);
-        Assert.Contains(":my own note", layout.Options.ExcludedList);
+        Assert.Equal(ExcludedProcessDefaults.All, layout.Options.ExcludedList);
+
+        persistence.SaveLive(layout.Options);
+
+        var written = File.ReadAllLines(excluded);
+        Assert.Equal(ExcludedProcessDefaults.Header, written[0]);
+        Assert.Equal(":my own note", written[1]);
+        Assert.Equal(ExcludedProcessDefaults.All, written[2..]);
     }
 
     //==================//

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
@@ -286,8 +286,40 @@ public class LayoutPersistenceTests
         var layout = NewLayout(out _, out _);
         persistence.Load(layout);
 
+        // The header is a comment for the daemon, so it is not an entry of the list —
+        // but the seeded file carries it, exactly like the one CreateExcludedFile writes.
         Assert.Equal(ExcludedProcessDefaults.All, layout.Options.ExcludedList);
-        Assert.Equal(ExcludedProcessDefaults.All, File.ReadAllLines(excluded));
+        string[] expectedFile = [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All];
+        Assert.Equal(expectedFile, File.ReadAllLines(excluded));
+    }
+
+    [Fact]
+    public void ExcludedList_CommentsStayOutOfTheListAndSurviveASave()
+    {
+        var store = new FakeStore
+        {
+            // Current version: the top-up must not interfere with what is asserted here.
+            GlobalOptions = new GlobalOptionsDto { ExcludedDefaultsVersion = ExcludedProcessDefaults.Version }
+        };
+        var excluded = TempExcludedFile();
+        File.WriteAllLines(excluded, [ExcludedProcessDefaults.Header, @"\steamapps\", "", ":my own note"]);
+        var persistence = new TestPersistence(store, excluded);
+
+        var layout = NewLayout(out _, out _);
+        persistence.Load(layout);
+
+        // Only the exclusions reach the model: the daemon skips ':' lines and empty ones,
+        // and the options list is what the user edits — it must hold the same thing.
+        Assert.Equal([@"\steamapps\"], layout.Options.ExcludedList);
+
+        layout.Options.ExcludedList.Add(@"\my\game\");
+        persistence.SaveLive(layout.Options);
+
+        // The comments are still on disk, above the entries: they were never the list's
+        // to drop, and one of them may be the user's own annotation.
+        Assert.Equal(
+            [ExcludedProcessDefaults.Header, ":my own note", @"\steamapps\", @"\my\game\"],
+            File.ReadAllLines(excluded));
     }
 
     [Fact]

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/ExcludedListPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/ExcludedListPersistence.cs
@@ -28,6 +28,17 @@ public sealed class ExcludedListPersistence(ILayoutStore store, Func<string> exc
     public int? AppliedDefaultsVersion { get; private set; }
 
     /// <summary>
+    /// The ':'-prefixed lines found in the file, kept aside at load and re-emitted on top
+    /// at every write. The daemon skips them (<c>daemon::load_excluded</c>), so they are
+    /// not exclusions and have no business in the options model — the seeded
+    /// <see cref="ExcludedProcessDefaults.Header"/> used to show up in the UI list as an
+    /// entry the user could neither understand nor usefully delete. Holding them here
+    /// rather than dropping them is what lets someone annotate their own file: the
+    /// annotations disappear from the list, not from the disk.
+    /// </summary>
+    IReadOnlyList<string> _comments = [];
+
+    /// <summary>
     /// Fill <paramref name="options"/> from the file, seeding or topping up the defaults as
     /// needed. <paramref name="global"/> is the options document as READ from the store: it
     /// carries the applied version in, and the top-up writes it back through it — mutating
@@ -43,25 +54,38 @@ public sealed class ExcludedListPersistence(ILayoutStore store, Func<string> exc
         var file = excludedListFile();
         if (!File.Exists(file))
         {
-            // First run: seed the defaults and write the file the daemon reads. The version
-            // is remembered so the next global-options write records the top-up as applied.
+            // First run: seed the defaults and write the file the daemon reads. Same
+            // content as LittleBigMouseClientService.CreateExcludedFile, header included,
+            // since either of the two can be the one to create it. The version is
+            // remembered so the next global-options write records the top-up as applied.
+            _comments = [ExcludedProcessDefaults.Header];
             foreach (var entry in ExcludedProcessDefaults.All) options.ExcludedList.Add(entry);
             AppliedDefaultsVersion = ExcludedProcessDefaults.Version;
             Write(file, options.ExcludedList);
             return;
         }
 
-        foreach (var line in File.ReadAllLines(file)) options.ExcludedList.Add(line);
+        // Split the file the way the daemon does: an empty line is nothing, a ':' line is
+        // a comment, everything else is an exclusion. Diverging here would mean the list
+        // the user edits and the list that actually filters are not the same list.
+        var comments = new List<string>();
+        foreach (var line in File.ReadAllLines(file))
+        {
+            if (line.StartsWith(':')) { comments.Add(line); continue; }
+            if (line.Length == 0) continue;
+            options.ExcludedList.Add(line);
+        }
+        _comments = comments;
 
         MigrateDefaults(options.ExcludedList, global, file);
     }
 
-    /// <summary>Rewrite the file the daemon reads. Best effort.</summary>
+    /// <summary>Rewrite the file the daemon reads, comments first. Best effort.</summary>
     public void Write(IEnumerable<string> entries) => Write(excludedListFile(), entries);
 
-    static void Write(string file, IEnumerable<string> entries)
+    void Write(string file, IEnumerable<string> entries)
     {
-        try { File.WriteAllLines(file, entries); }
+        try { File.WriteAllLines(file, _comments.Concat(entries)); }
         catch { /* the in-memory list is authoritative; the next full save retries */ }
     }
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -202,6 +202,14 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
         }
     }
 
+    /// <summary>
+    /// Last-resort seed of the exclusion list, right before the daemon starts reading it.
+    /// <see cref="LittleBigMouse.Plugins.Persistence.ExcludedListPersistence"/> normally
+    /// gets there first (loading a layout precedes launching the daemon) and writes the
+    /// same content, header included; this stays as the guard for any path that reaches
+    /// the daemon without a load, where the alternative is a daemon running with no
+    /// exclusions at all. Both must keep writing the same thing.
+    /// </summary>
     void CreateExcludedFile()
     {
         var dir = LbmPaths.DataDir;


### PR DESCRIPTION
> Stacked on #557 — base branch is `agent/split-layout-persistence`, review that one first.

The daemon splits `Excluded.txt` into exclusions, empty lines and `:` comments ([`daemon::load_excluded`](https://github.com/mgth/LittleBigMouse/blob/master/LittleBigMouse-Hook-Rust/src/daemon/mod.rs)). The C# side had no such notion: it loaded **every** line as an entry.

So `:Excluded processes` — the header `LittleBigMouseClientService.CreateExcludedFile` writes when it is the one seeding the file — appeared in the options list as an exclusion the user can neither understand nor usefully delete, and was written back at every save. The list the user edits and the list that actually filters were not the same list.

## What changes

Split the file the way the daemon does.

Comments are **kept aside in the persistence object and re-emitted on top at every write**, rather than dropped. The header will always come back on its own, but a line someone added by hand is theirs — deleting it to fix a cosmetic wart would be the worse bug. Empty lines carry nothing and are not re-emitted.

```
:Excluded processes        →  list: \steamapps\           →  :Excluded processes
\steamapps\                                                  :my own note
                                                             \steamapps\
:my own note                                                 \my\game\
```

## The two seeders

The seed path now writes the header too, so both writers produce the same file.

`CreateExcludedFile` **stays**: loading a layout precedes launching the daemon, so the shared seeder normally gets there first, but removing the guard would mean a daemon running with *no exclusions at all* on any path that reaches it without a load. That is not a trade I'd make for a cosmetic fix. It is now documented as the second writer of a shared format, with the constraint that both must keep writing the same thing.

## Tests

138 in `DisplayLayout.Tests` (+2). The characterization test that recorded the old behaviour is inverted: an annotated file loads to its exclusions only, and comes back out of a save with its comments intact. The first-run seed test now expects the header in the file and not in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
