### PR TITLE
Persist ExperimentalFeatures

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
@@ -452,6 +452,36 @@ public class LayoutPersistenceTests
     }
 
     [Fact]
+    public void ExperimentalFeatures_SurviveARestart()
+    {
+        var store = new FakeStore();
+
+        var layout = NewLayout(out _, out _);
+        layout.Options.ExperimentalFeatures = true;
+        NewPersistence(store).SaveLive(layout.Options);
+
+        Assert.True(store.GlobalOptions?.ExperimentalFeatures);
+
+        var restored = NewLayout(out _, out _);
+        NewPersistence(store).Load(restored);
+
+        Assert.True(restored.Options.ExperimentalFeatures);
+    }
+
+    [Fact]
+    public void ExperimentalFeatures_AbsentFromTheStore_KeepsTheDefault()
+    {
+        // Every installation predating this option: the value is not there, and off is
+        // what it has always been at start.
+        var store = new FakeStore { GlobalOptions = new GlobalOptionsDto { Pinned = true } };
+
+        var layout = NewLayout(out _, out _);
+        NewPersistence(store).Load(layout);
+
+        Assert.False(layout.Options.ExperimentalFeatures);
+    }
+
+    [Fact]
     public void Load_TransposesPre541OrientedStoredSize()
     {
         // Pre-5.4.1 the model persisted the size ORIENTED to the rotation at save time:

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
@@ -9,6 +9,7 @@
   "StartMinimized": true,
   "StartElevated": false,
   "DebugTools": false,
+  "ExperimentalFeatures": false,
   "ShowMonitorActionWarning": false,
   "BorderValues": "PerMonitor",
   "RescueShortcut": "Ctrl\u002BAlt\u002BShift\u002BM",

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -62,6 +62,7 @@ public class RegistryLayoutStore : ILayoutStore
         StartMinimized = root.TryGetBool("StartMinimized") ?? layoutKey?.TryGetBool("StartMinimized"),
         StartElevated = root.TryGetBool("StartElevated") ?? layoutKey?.TryGetBool("StartElevated"),
         DebugTools = root.TryGetBool("DebugTools"),
+        ExperimentalFeatures = root.TryGetBool("ExperimentalFeatures"),
         VcpControl = root.TryGetBool("VcpControl"),
         // "ShowAttachDetachWarning" is the former name of the option, read as fallback.
         ShowMonitorActionWarning = root.TryGetBool("ShowMonitorActionWarning") ?? root.TryGetBool("ShowAttachDetachWarning"),
@@ -260,6 +261,7 @@ public class RegistryLayoutStore : ILayoutStore
         Set(root, "StartMinimized", o.StartMinimized);
         Set(root, "StartElevated", o.StartElevated);
         Set(root, "DebugTools", o.DebugTools);
+        Set(root, "ExperimentalFeatures", o.ExperimentalFeatures);
         Set(root, "VcpControl", o.VcpControl);
         Set(root, "ShowMonitorActionWarning", o.ShowMonitorActionWarning);
         Set(root, "BorderValues", o.BorderValues);

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
@@ -35,6 +35,7 @@ public static class LayoutDtoMapper
         o.StartMinimized = dto.StartMinimized ?? o.StartMinimized;
         o.StartElevated = dto.StartElevated ?? o.StartElevated;
         o.DebugTools = dto.DebugTools ?? o.DebugTools;
+        o.ExperimentalFeatures = dto.ExperimentalFeatures ?? o.ExperimentalFeatures;
         o.VcpControl = dto.VcpControl ?? o.VcpControl;
         o.ShowMonitorActionWarning = dto.ShowMonitorActionWarning ?? o.ShowMonitorActionWarning;
         o.BorderValues = dto.BorderValues ?? o.BorderValues;
@@ -179,6 +180,7 @@ public static class LayoutDtoMapper
         StartMinimized = o.StartMinimized,
         StartElevated = o.StartElevated,
         DebugTools = o.DebugTools,
+        ExperimentalFeatures = o.ExperimentalFeatures,
         VcpControl = o.VcpControl,
         ShowMonitorActionWarning = o.ShowMonitorActionWarning,
         BorderValues = o.BorderValues,

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -26,6 +26,7 @@ public class GlobalOptionsDto
     public bool? StartMinimized { get; set; }
     public bool? StartElevated { get; set; }
     public bool? DebugTools { get; set; }
+    public bool? ExperimentalFeatures { get; set; }
     public bool? ShowMonitorActionWarning { get; set; }
     public string? BorderValues { get; set; }
     public string? RescueShortcut { get; set; }


### PR DESCRIPTION
> Stacked on #557 — base branch is `agent/split-layout-persistence`, review that one first.

`ExperimentalFeatures` has a toggle in the layout options panel ([`LayoutOptions.axaml`](https://github.com/mgth/LittleBigMouse/blob/master/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Options/LayoutOptions.axaml)) and gates the experimental tools of the VCP panel (`VcpScreenViewModel`) — but it has no DTO property. It fell back to `false` at every start, whatever the user had set.

`DebugTools`, the sibling toggle right next to it, has always been persisted. This one was simply missed.

## The change

One DTO property, its two mapping lines, and the two registry lines — all placed next to `DebugTools`, since that is what it is: an advanced toggle.

**Backward compatible** in the only direction that matters: an installation with no such value stored reads `null`, which the mapper treats as "keep the current value" — `false`, exactly today's behaviour. The Linux store gains a JSON key, the registry a value; an older version reading a newer store ignores what it does not know.

## One thing to decide separately

It is written by the **save button**, not live. `ExperimentalFeatures` uses `SetUnsavedValue` in `LbmOptions`, like `HideTrayIcon` and `RescueShortcut`, so flipping it lights the save button rather than writing immediately — whereas `DebugTools` is in the live-save list in `MainService` and writes on the spot.

That is a UI decision, not a persistence one, so I left it alone. If the toggle should behave like `DebugTools`, it is one line added to that `WhenAnyValue`.

## Tests

139 in `DisplayLayout.Tests` (+2): it round-trips, and an old store without the key keeps the default. The golden save output gained exactly one line — `"ExperimentalFeatures": false` after `DebugTools` — which is the whole visible format change, regenerated and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
