### PR TITLE
Store the process priority in one place

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
@@ -186,13 +186,10 @@ public class LayoutPersistenceGoldenTests : IDisposable
         // A save right after a load must not change what the user has: every byte the
         // current version writes is compared against the committed expectation.
         //
-        // Two differences from the loaded document are visible in the golden and are
-        // PRE-EXISTING behavior this test only records — neither is endorsed here:
-        //  - options.json comes back with "Priority": "Realtime", the value the LAYOUT
-        //    document overrode it with. Both levels map to the same ILayoutOptions
-        //    property, so a per-layout priority is written back as the app-level one at
-        //    the next save (and the layout keeps its copy). The two levels are not
-        //    actually independent once a layout has been saved.
+        // Two differences from the loaded document are visible in the golden:
+        //  - the layout's Priority/PriorityUnhooked moved to options.json, which is the
+        //    one place they are stored now — see
+        //    SaveAfterLoad_PromotesTheLayoutPriorityToTheAppLevelAndDropsIt.
         //  - RescueShortcut comes back with every '+' written as a unicode escape: that
         //    is the default JSON encoder, and the string parses back identically, so a
         //    hand-edited file keeps working. Only the bytes differ.
@@ -232,15 +229,13 @@ public class LayoutPersistenceGoldenTests : IDisposable
     }
 
     [Fact]
-    public void SaveAfterLoad_MergesTheTwoPriorityLevels_KnownQuirk()
+    public void SaveAfterLoad_PromotesTheLayoutPriorityToTheAppLevelAndDropsIt()
     {
-        // Characterization, NOT an endorsement: Priority/PriorityUnhooked exist both in
-        // the global options and in the layout document, but both load into the same
-        // ILayoutOptions property, and the save writes that one property to both places.
-        // So the per-layout override becomes the app-level value, and a layout that had
-        // no override gets one — the two levels stop being distinguishable after the
-        // first save. Nothing here reinterprets it; it is recorded so a future fix
-        // (separate model properties) starts from a failing test instead of a surprise.
+        // A layout carrying its own Priority still wins at load — that is what keeps an
+        // upgrade from changing anybody's setting. The save then stores it once, at the
+        // app level, and the layout copy is gone: the two locations were never two
+        // settings (both load into the same options property), and keeping the copy is
+        // what used to hand one layout's value to all the others.
         var dir = Fixture("v5.6-current");
         var store = new JsonLayoutStore(dir);
 
@@ -253,7 +248,39 @@ public class LayoutPersistenceGoldenTests : IDisposable
 
         persistence.Save(layout);
 
-        Assert.Equal("Realtime", store.Read(LayoutId, []).GlobalOptions!.Priority);
+        var saved = store.Read(LayoutId, []);
+        Assert.Equal("Realtime", saved.GlobalOptions!.Priority);
+        Assert.Equal("Idle", saved.GlobalOptions.PriorityUnhooked);
+        Assert.Null(saved.Layout!.Options!.Priority);
+        Assert.Null(saved.Layout.Options.PriorityUnhooked);
+
+        // And it stays there: a reload finds one value, in one place.
+        var reloaded = NewLayout(out _, out _);
+        NewPersistence(new JsonLayoutStore(dir)).Load(reloaded);
+        Assert.Equal("Realtime", reloaded.Options.Priority);
+    }
+
+    [Fact]
+    public void SaveEnabled_DoesNotPutTheLayoutPriorityBack()
+    {
+        // SaveEnabled rewrites the document it just read, so without care it would
+        // restore the legacy keys a full save had migrated away.
+        var dir = Fixture("v5.6-current");
+        var store = new JsonLayoutStore(dir);
+
+        var layout = NewLayout(out _, out _);
+        var persistence = NewPersistence(store);
+        persistence.Load(layout);
+
+        layout.Options.Enabled = false;
+        Assert.True(persistence.SaveEnabled(layout));
+
+        var saved = store.Read(LayoutId, []).Layout!;
+        Assert.False(saved.Options!.Enabled);
+        Assert.Null(saved.Options.Priority);
+        // Everything else the document held is still there.
+        Assert.Equal("CornerCrossing", saved.Options.Algorithm);
+        Assert.True(saved.Monitors.ContainsKey(MonitorId));
     }
 
     static string? ReadFixtureGlobalPriority(string fixture) =>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.2-pre-sections-saved/layouts/TST1234_1920x1080.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.2-pre-sections-saved/layouts/TST1234_1920x1080.json
@@ -10,9 +10,7 @@
     "LoopY": false,
     "Enabled": true,
     "AdjustPointer": false,
-    "AdjustSpeed": false,
-    "Priority": "High",
-    "PriorityUnhooked": "Idle"
+    "AdjustSpeed": false
   },
   "Monitors": {
     "TST1234_0": {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/layouts/TST1234_1920x1080.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/layouts/TST1234_1920x1080.json
@@ -10,9 +10,7 @@
     "LoopY": false,
     "Enabled": true,
     "AdjustPointer": false,
-    "AdjustSpeed": false,
-    "Priority": "Realtime",
-    "PriorityUnhooked": "Idle"
+    "AdjustSpeed": false
   },
   "Monitors": {
     "TST1234_0": {

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -286,8 +286,13 @@ public class RegistryLayoutStore : ILayoutStore
             Set(key, "Enabled", o.Enabled);
             Set(key, "AdjustPointer", o.AdjustPointer);
             Set(key, "AdjustSpeed", o.AdjustSpeed);
-            Set(key, "Priority", o.Priority);
-            Set(key, "PriorityUnhooked", o.PriorityUnhooked);
+
+            // Priority/PriorityUnhooked belong to the root key. Deleting is what ends the
+            // migration ReadGlobalOptions has been half-doing for versions: Set() skips a
+            // null but never removes, so a value left here would go on overriding the root
+            // one at every load. Same reason WriteSide deletes the pre-split edge value.
+            key.DeleteValue("Priority", throwOnMissingValue: false);
+            key.DeleteValue("PriorityUnhooked", throwOnMissingValue: false);
         }
 
         foreach (var (id, monitor) in layout.Monitors)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
@@ -57,6 +57,10 @@ public static class LayoutDtoMapper
         o.Enabled = dto.Enabled ?? o.Enabled;
         o.AdjustPointer = dto.AdjustPointer ?? o.AdjustPointer;
         o.AdjustSpeed = dto.AdjustSpeed ?? o.AdjustSpeed;
+
+        // READ-ONLY legacy: the app-level values are applied first, and a layout that
+        // still carries its own overrides them so nobody's priority changes on upgrade.
+        // Nothing writes them back (see ToDto below), so this ends at the first save.
         o.Priority = dto.Priority ?? o.Priority;
         o.PriorityUnhooked = dto.PriorityUnhooked ?? o.PriorityUnhooked;
     }
@@ -193,6 +197,11 @@ public static class LayoutDtoMapper
         Monitors = layout.PhysicalMonitors.ToDictionary(m => m.Id, ToDto)
     };
 
+    // Priority/PriorityUnhooked are deliberately absent: they are app-level options that
+    // once lived here too, and both locations load into the SAME options property. Writing
+    // the property back to both made a layout's leftover value the app-level one at the
+    // next save, and gave a copy of it to every other layout after that. They are written
+    // to the app level only; the layout copy is read as a fallback and then dropped.
     public static LayoutOptionsDto ToDto(ILayoutOptions o) => new()
     {
         AllowOverlaps = o.AllowOverlaps,
@@ -205,9 +214,7 @@ public static class LayoutDtoMapper
         LoopY = o.LoopY,
         Enabled = o.Enabled,
         AdjustPointer = o.AdjustPointer,
-        AdjustSpeed = o.AdjustSpeed,
-        Priority = o.Priority,
-        PriorityUnhooked = o.PriorityUnhooked
+        AdjustSpeed = o.AdjustSpeed
     };
 
     // Sections only: the per-edge resistance is gone, and writing it back would

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -45,7 +45,7 @@ public class LayoutDto
     public Dictionary<string, MonitorDto> Monitors { get; set; } = [];
 }
 
-/// <summary>Per-layout options. Priority/PriorityUnhooked here override the global ones.</summary>
+/// <summary>Per-layout options.</summary>
 public class LayoutOptionsDto
 {
     public bool? AllowOverlaps { get; set; }
@@ -59,7 +59,17 @@ public class LayoutOptionsDto
     public bool? Enabled { get; set; }
     public bool? AdjustPointer { get; set; }
     public bool? AdjustSpeed { get; set; }
+
+    /// <summary>
+    /// READ-ONLY legacy pair. These are app-level options (see <see cref="GlobalOptionsDto"/>)
+    /// that older versions also stored per layout; both locations load into the same options
+    /// property, and only the app-level one is written from now on. Kept so a layout that
+    /// still carries them keeps its priority on upgrade — after which it is stored once, at
+    /// the app level, and this reads null forever.
+    /// </summary>
     public string? Priority { get; set; }
+
+    /// <inheritdoc cref="Priority"/>
     public string? PriorityUnhooked { get; set; }
 }
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
@@ -210,6 +210,13 @@ public abstract class LayoutPersistence : ILayoutPersistence
         var dto = _store.Read(layout.Id, []).Layout ?? new LayoutDto();
         dto.Options ??= new LayoutOptionsDto();
         dto.Options.Enabled = layout.Options.Enabled;
+
+        // Everything else read is written back as-is, EXCEPT the two app-level options a
+        // layout may still carry: re-emitting them here would put back what a full save
+        // just migrated away (see LayoutDtoMapper.ToDto).
+        dto.Options.Priority = null;
+        dto.Options.PriorityUnhooked = null;
+
         _store.WriteLayout(layout.Id, dto);
 
         SetAutostart(layout, layout.Options.LoadAtStartup, layout.Options.StartElevated);


### PR DESCRIPTION
> Stacked on #557 — base branch is `agent/split-layout-persistence`, review that one first.

`Priority` and `PriorityUnhooked` are stored **twice** — in the app-level options and in each layout document — but they load into the *same* `ILayoutOptions` property, and the save wrote that one property back to both.

So a layout carrying an old value made it the app-level value at the first save, and every other layout inherited it at the save after that. The UI has a single control for it, so a per-layout priority was never something anyone could set on purpose: it is a leftover that quietly rewrites a global setting.

`RegistryLayoutStore` has been half-migrating this for versions — reading the layout key as a fallback *"so old configs keep their values (they reach the root key at the next save)"* — while `ToDto` kept recreating the very key that fallback exists for.

## Finishing it

| | |
|---|---|
| `LayoutDtoMapper.ToDto` | no longer emits them. The **read** side still applies the layout value over the app-level one, so nobody's priority changes on upgrade — it is simply stored at the app level from then on |
| `LayoutPersistence.SaveEnabled` | writes back the document it just read, so it nulls the two fields explicitly; otherwise it would restore what a full save had just migrated away, and the JSON backend would disagree with the registry one |
| `RegistryLayoutStore.WriteLayout` | **deletes** the two values instead of writing them |

That deletion is the part that actually ends it: `Set()` skips a null but never removes, so a value left in the layout key would go on overriding the root one at every load, forever. Same pattern as `WriteSide` deleting the pre-split edge value. On the JSON side a null field is simply not serialized.

## What an existing installation sees

The priority the user last saw is the one kept — promoted once to the app level. The layout copy disappears at the first save. Nothing else in the layout document is touched:

```diff
   "AdjustPointer": false,
-  "AdjustSpeed": false,
-  "Priority": "Realtime",
-  "PriorityUnhooked": "Idle"
+  "AdjustSpeed": false
```

(the whole golden diff, on both saved fixtures — `options.json` already held the promoted value)

## Tests

138 in `DisplayLayout.Tests`. The characterization test that recorded the merge is replaced by two that pin the migration: a layout value is promoted and dropped, a reload finds one value in one place, and `SaveEnabled` does not put it back while preserving everything else in the document.

**Not covered:** the registry deletion itself, which needs `HKCU`. The JSON path covers the shared engine, and the `DeleteValue` call mirrors an existing, working one — but the Windows store still has no test of its own (see #558).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
