### PR TITLE
Land the persistence stack that stopped at the branch

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
@@ -186,13 +186,10 @@ public class LayoutPersistenceGoldenTests : IDisposable
         // A save right after a load must not change what the user has: every byte the
         // current version writes is compared against the committed expectation.
         //
-        // Two differences from the loaded document are visible in the golden and are
-        // PRE-EXISTING behavior this test only records — neither is endorsed here:
-        //  - options.json comes back with "Priority": "Realtime", the value the LAYOUT
-        //    document overrode it with. Both levels map to the same ILayoutOptions
-        //    property, so a per-layout priority is written back as the app-level one at
-        //    the next save (and the layout keeps its copy). The two levels are not
-        //    actually independent once a layout has been saved.
+        // Two differences from the loaded document are visible in the golden:
+        //  - the layout's Priority/PriorityUnhooked moved to options.json, which is the
+        //    one place they are stored now — see
+        //    SaveAfterLoad_PromotesTheLayoutPriorityToTheAppLevelAndDropsIt.
         //  - RescueShortcut comes back with every '+' written as a unicode escape: that
         //    is the default JSON encoder, and the string parses back identically, so a
         //    hand-edited file keeps working. Only the bytes differ.
@@ -232,15 +229,13 @@ public class LayoutPersistenceGoldenTests : IDisposable
     }
 
     [Fact]
-    public void SaveAfterLoad_MergesTheTwoPriorityLevels_KnownQuirk()
+    public void SaveAfterLoad_PromotesTheLayoutPriorityToTheAppLevelAndDropsIt()
     {
-        // Characterization, NOT an endorsement: Priority/PriorityUnhooked exist both in
-        // the global options and in the layout document, but both load into the same
-        // ILayoutOptions property, and the save writes that one property to both places.
-        // So the per-layout override becomes the app-level value, and a layout that had
-        // no override gets one — the two levels stop being distinguishable after the
-        // first save. Nothing here reinterprets it; it is recorded so a future fix
-        // (separate model properties) starts from a failing test instead of a surprise.
+        // A layout carrying its own Priority still wins at load — that is what keeps an
+        // upgrade from changing anybody's setting. The save then stores it once, at the
+        // app level, and the layout copy is gone: the two locations were never two
+        // settings (both load into the same options property), and keeping the copy is
+        // what used to hand one layout's value to all the others.
         var dir = Fixture("v5.6-current");
         var store = new JsonLayoutStore(dir);
 
@@ -253,7 +248,39 @@ public class LayoutPersistenceGoldenTests : IDisposable
 
         persistence.Save(layout);
 
-        Assert.Equal("Realtime", store.Read(LayoutId, []).GlobalOptions!.Priority);
+        var saved = store.Read(LayoutId, []);
+        Assert.Equal("Realtime", saved.GlobalOptions!.Priority);
+        Assert.Equal("Idle", saved.GlobalOptions.PriorityUnhooked);
+        Assert.Null(saved.Layout!.Options!.Priority);
+        Assert.Null(saved.Layout.Options.PriorityUnhooked);
+
+        // And it stays there: a reload finds one value, in one place.
+        var reloaded = NewLayout(out _, out _);
+        NewPersistence(new JsonLayoutStore(dir)).Load(reloaded);
+        Assert.Equal("Realtime", reloaded.Options.Priority);
+    }
+
+    [Fact]
+    public void SaveEnabled_DoesNotPutTheLayoutPriorityBack()
+    {
+        // SaveEnabled rewrites the document it just read, so without care it would
+        // restore the legacy keys a full save had migrated away.
+        var dir = Fixture("v5.6-current");
+        var store = new JsonLayoutStore(dir);
+
+        var layout = NewLayout(out _, out _);
+        var persistence = NewPersistence(store);
+        persistence.Load(layout);
+
+        layout.Options.Enabled = false;
+        Assert.True(persistence.SaveEnabled(layout));
+
+        var saved = store.Read(LayoutId, []).Layout!;
+        Assert.False(saved.Options!.Enabled);
+        Assert.Null(saved.Options.Priority);
+        // Everything else the document held is still there.
+        Assert.Equal("CornerCrossing", saved.Options.Algorithm);
+        Assert.True(saved.Monitors.ContainsKey(MonitorId));
     }
 
     static string? ReadFixtureGlobalPriority(string fixture) =>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
@@ -375,25 +375,29 @@ public class LayoutPersistenceGoldenTests : IDisposable
     }
 
     [Fact]
-    public void Load_ExcludedFileCommentLines_BecomeEntries_KnownQuirk()
+    public void Load_ExcludedFileCommentLines_StayOutOfTheListAndSurviveASave()
     {
-        // Characterization, NOT an endorsement: the daemon ignores ':'-prefixed lines, and
-        // LittleBigMouseClientService.CreateExcludedFile writes ExcludedProcessDefaults.Header
-        // atop the file when IT is the one seeding it. The persistence layer has no notion of
-        // comments — every line is an entry, shown as such in the options UI and written back
-        // on every save. Filtering them here would silently delete a user's own annotations,
-        // so the behavior is recorded rather than changed.
+        // A real file as CreateExcludedFile seeds it, plus a line the user added by hand.
+        // The daemon skips ':' lines and empty ones (daemon::load_excluded), so neither is
+        // an exclusion — but neither may be lost when the app rewrites the file either.
         var dir = Fixture("v5.6-current"); // ExcludedDefaultsVersion 2: no top-up interference
         var excluded = Path.Combine(_work, "commented", "Excluded.txt");
         Directory.CreateDirectory(Path.GetDirectoryName(excluded)!);
         File.WriteAllLines(excluded,
-            [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All, ":my own note"]);
+            [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All, "", ":my own note"]);
 
         var layout = NewLayout(out _, out _);
-        new TestPersistence(new JsonLayoutStore(dir), excluded).Load(layout);
+        var persistence = new TestPersistence(new JsonLayoutStore(dir), excluded);
+        persistence.Load(layout);
 
-        Assert.Equal(ExcludedProcessDefaults.Header, layout.Options.ExcludedList[0]);
-        Assert.Contains(":my own note", layout.Options.ExcludedList);
+        Assert.Equal(ExcludedProcessDefaults.All, layout.Options.ExcludedList);
+
+        persistence.SaveLive(layout.Options);
+
+        var written = File.ReadAllLines(excluded);
+        Assert.Equal(ExcludedProcessDefaults.Header, written[0]);
+        Assert.Equal(":my own note", written[1]);
+        Assert.Equal(ExcludedProcessDefaults.All, written[2..]);
     }
 
     //==================//

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
@@ -286,8 +286,40 @@ public class LayoutPersistenceTests
         var layout = NewLayout(out _, out _);
         persistence.Load(layout);
 
+        // The header is a comment for the daemon, so it is not an entry of the list —
+        // but the seeded file carries it, exactly like the one CreateExcludedFile writes.
         Assert.Equal(ExcludedProcessDefaults.All, layout.Options.ExcludedList);
-        Assert.Equal(ExcludedProcessDefaults.All, File.ReadAllLines(excluded));
+        string[] expectedFile = [ExcludedProcessDefaults.Header, .. ExcludedProcessDefaults.All];
+        Assert.Equal(expectedFile, File.ReadAllLines(excluded));
+    }
+
+    [Fact]
+    public void ExcludedList_CommentsStayOutOfTheListAndSurviveASave()
+    {
+        var store = new FakeStore
+        {
+            // Current version: the top-up must not interfere with what is asserted here.
+            GlobalOptions = new GlobalOptionsDto { ExcludedDefaultsVersion = ExcludedProcessDefaults.Version }
+        };
+        var excluded = TempExcludedFile();
+        File.WriteAllLines(excluded, [ExcludedProcessDefaults.Header, @"\steamapps\", "", ":my own note"]);
+        var persistence = new TestPersistence(store, excluded);
+
+        var layout = NewLayout(out _, out _);
+        persistence.Load(layout);
+
+        // Only the exclusions reach the model: the daemon skips ':' lines and empty ones,
+        // and the options list is what the user edits — it must hold the same thing.
+        Assert.Equal([@"\steamapps\"], layout.Options.ExcludedList);
+
+        layout.Options.ExcludedList.Add(@"\my\game\");
+        persistence.SaveLive(layout.Options);
+
+        // The comments are still on disk, above the entries: they were never the list's
+        // to drop, and one of them may be the user's own annotation.
+        Assert.Equal(
+            [ExcludedProcessDefaults.Header, ":my own note", @"\steamapps\", @"\my\game\"],
+            File.ReadAllLines(excluded));
     }
 
     [Fact]

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
@@ -452,6 +452,36 @@ public class LayoutPersistenceTests
     }
 
     [Fact]
+    public void ExperimentalFeatures_SurviveARestart()
+    {
+        var store = new FakeStore();
+
+        var layout = NewLayout(out _, out _);
+        layout.Options.ExperimentalFeatures = true;
+        NewPersistence(store).SaveLive(layout.Options);
+
+        Assert.True(store.GlobalOptions?.ExperimentalFeatures);
+
+        var restored = NewLayout(out _, out _);
+        NewPersistence(store).Load(restored);
+
+        Assert.True(restored.Options.ExperimentalFeatures);
+    }
+
+    [Fact]
+    public void ExperimentalFeatures_AbsentFromTheStore_KeepsTheDefault()
+    {
+        // Every installation predating this option: the value is not there, and off is
+        // what it has always been at start.
+        var store = new FakeStore { GlobalOptions = new GlobalOptionsDto { Pinned = true } };
+
+        var layout = NewLayout(out _, out _);
+        NewPersistence(store).Load(layout);
+
+        Assert.False(layout.Options.ExperimentalFeatures);
+    }
+
+    [Fact]
     public void Load_TransposesPre541OrientedStoredSize()
     {
         // Pre-5.4.1 the model persisted the size ORIENTED to the rotation at save time:

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.2-pre-sections-saved/layouts/TST1234_1920x1080.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.2-pre-sections-saved/layouts/TST1234_1920x1080.json
@@ -10,9 +10,7 @@
     "LoopY": false,
     "Enabled": true,
     "AdjustPointer": false,
-    "AdjustSpeed": false,
-    "Priority": "High",
-    "PriorityUnhooked": "Idle"
+    "AdjustSpeed": false
   },
   "Monitors": {
     "TST1234_0": {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/layouts/TST1234_1920x1080.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/layouts/TST1234_1920x1080.json
@@ -10,9 +10,7 @@
     "LoopY": false,
     "Enabled": true,
     "AdjustPointer": false,
-    "AdjustSpeed": false,
-    "Priority": "Realtime",
-    "PriorityUnhooked": "Idle"
+    "AdjustSpeed": false
   },
   "Monitors": {
     "TST1234_0": {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
@@ -9,6 +9,7 @@
   "StartMinimized": true,
   "StartElevated": false,
   "DebugTools": false,
+  "ExperimentalFeatures": false,
   "ShowMonitorActionWarning": false,
   "BorderValues": "PerMonitor",
   "RescueShortcut": "Ctrl\u002BAlt\u002BShift\u002BM",

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -62,6 +62,7 @@ public class RegistryLayoutStore : ILayoutStore
         StartMinimized = root.TryGetBool("StartMinimized") ?? layoutKey?.TryGetBool("StartMinimized"),
         StartElevated = root.TryGetBool("StartElevated") ?? layoutKey?.TryGetBool("StartElevated"),
         DebugTools = root.TryGetBool("DebugTools"),
+        ExperimentalFeatures = root.TryGetBool("ExperimentalFeatures"),
         VcpControl = root.TryGetBool("VcpControl"),
         // "ShowAttachDetachWarning" is the former name of the option, read as fallback.
         ShowMonitorActionWarning = root.TryGetBool("ShowMonitorActionWarning") ?? root.TryGetBool("ShowAttachDetachWarning"),
@@ -260,6 +261,7 @@ public class RegistryLayoutStore : ILayoutStore
         Set(root, "StartMinimized", o.StartMinimized);
         Set(root, "StartElevated", o.StartElevated);
         Set(root, "DebugTools", o.DebugTools);
+        Set(root, "ExperimentalFeatures", o.ExperimentalFeatures);
         Set(root, "VcpControl", o.VcpControl);
         Set(root, "ShowMonitorActionWarning", o.ShowMonitorActionWarning);
         Set(root, "BorderValues", o.BorderValues);

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -286,8 +286,13 @@ public class RegistryLayoutStore : ILayoutStore
             Set(key, "Enabled", o.Enabled);
             Set(key, "AdjustPointer", o.AdjustPointer);
             Set(key, "AdjustSpeed", o.AdjustSpeed);
-            Set(key, "Priority", o.Priority);
-            Set(key, "PriorityUnhooked", o.PriorityUnhooked);
+
+            // Priority/PriorityUnhooked belong to the root key. Deleting is what ends the
+            // migration ReadGlobalOptions has been half-doing for versions: Set() skips a
+            // null but never removes, so a value left here would go on overriding the root
+            // one at every load. Same reason WriteSide deletes the pre-split edge value.
+            key.DeleteValue("Priority", throwOnMissingValue: false);
+            key.DeleteValue("PriorityUnhooked", throwOnMissingValue: false);
         }
 
         foreach (var (id, monitor) in layout.Monitors)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/ExcludedListPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/ExcludedListPersistence.cs
@@ -28,6 +28,17 @@ public sealed class ExcludedListPersistence(ILayoutStore store, Func<string> exc
     public int? AppliedDefaultsVersion { get; private set; }
 
     /// <summary>
+    /// The ':'-prefixed lines found in the file, kept aside at load and re-emitted on top
+    /// at every write. The daemon skips them (<c>daemon::load_excluded</c>), so they are
+    /// not exclusions and have no business in the options model — the seeded
+    /// <see cref="ExcludedProcessDefaults.Header"/> used to show up in the UI list as an
+    /// entry the user could neither understand nor usefully delete. Holding them here
+    /// rather than dropping them is what lets someone annotate their own file: the
+    /// annotations disappear from the list, not from the disk.
+    /// </summary>
+    IReadOnlyList<string> _comments = [];
+
+    /// <summary>
     /// Fill <paramref name="options"/> from the file, seeding or topping up the defaults as
     /// needed. <paramref name="global"/> is the options document as READ from the store: it
     /// carries the applied version in, and the top-up writes it back through it — mutating
@@ -43,25 +54,38 @@ public sealed class ExcludedListPersistence(ILayoutStore store, Func<string> exc
         var file = excludedListFile();
         if (!File.Exists(file))
         {
-            // First run: seed the defaults and write the file the daemon reads. The version
-            // is remembered so the next global-options write records the top-up as applied.
+            // First run: seed the defaults and write the file the daemon reads. Same
+            // content as LittleBigMouseClientService.CreateExcludedFile, header included,
+            // since either of the two can be the one to create it. The version is
+            // remembered so the next global-options write records the top-up as applied.
+            _comments = [ExcludedProcessDefaults.Header];
             foreach (var entry in ExcludedProcessDefaults.All) options.ExcludedList.Add(entry);
             AppliedDefaultsVersion = ExcludedProcessDefaults.Version;
             Write(file, options.ExcludedList);
             return;
         }
 
-        foreach (var line in File.ReadAllLines(file)) options.ExcludedList.Add(line);
+        // Split the file the way the daemon does: an empty line is nothing, a ':' line is
+        // a comment, everything else is an exclusion. Diverging here would mean the list
+        // the user edits and the list that actually filters are not the same list.
+        var comments = new List<string>();
+        foreach (var line in File.ReadAllLines(file))
+        {
+            if (line.StartsWith(':')) { comments.Add(line); continue; }
+            if (line.Length == 0) continue;
+            options.ExcludedList.Add(line);
+        }
+        _comments = comments;
 
         MigrateDefaults(options.ExcludedList, global, file);
     }
 
-    /// <summary>Rewrite the file the daemon reads. Best effort.</summary>
+    /// <summary>Rewrite the file the daemon reads, comments first. Best effort.</summary>
     public void Write(IEnumerable<string> entries) => Write(excludedListFile(), entries);
 
-    static void Write(string file, IEnumerable<string> entries)
+    void Write(string file, IEnumerable<string> entries)
     {
-        try { File.WriteAllLines(file, entries); }
+        try { File.WriteAllLines(file, _comments.Concat(entries)); }
         catch { /* the in-memory list is authoritative; the next full save retries */ }
     }
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
@@ -57,6 +57,10 @@ public static class LayoutDtoMapper
         o.Enabled = dto.Enabled ?? o.Enabled;
         o.AdjustPointer = dto.AdjustPointer ?? o.AdjustPointer;
         o.AdjustSpeed = dto.AdjustSpeed ?? o.AdjustSpeed;
+
+        // READ-ONLY legacy: the app-level values are applied first, and a layout that
+        // still carries its own overrides them so nobody's priority changes on upgrade.
+        // Nothing writes them back (see ToDto below), so this ends at the first save.
         o.Priority = dto.Priority ?? o.Priority;
         o.PriorityUnhooked = dto.PriorityUnhooked ?? o.PriorityUnhooked;
     }
@@ -193,6 +197,11 @@ public static class LayoutDtoMapper
         Monitors = layout.PhysicalMonitors.ToDictionary(m => m.Id, ToDto)
     };
 
+    // Priority/PriorityUnhooked are deliberately absent: they are app-level options that
+    // once lived here too, and both locations load into the SAME options property. Writing
+    // the property back to both made a layout's leftover value the app-level one at the
+    // next save, and gave a copy of it to every other layout after that. They are written
+    // to the app level only; the layout copy is read as a fallback and then dropped.
     public static LayoutOptionsDto ToDto(ILayoutOptions o) => new()
     {
         AllowOverlaps = o.AllowOverlaps,
@@ -205,9 +214,7 @@ public static class LayoutDtoMapper
         LoopY = o.LoopY,
         Enabled = o.Enabled,
         AdjustPointer = o.AdjustPointer,
-        AdjustSpeed = o.AdjustSpeed,
-        Priority = o.Priority,
-        PriorityUnhooked = o.PriorityUnhooked
+        AdjustSpeed = o.AdjustSpeed
     };
 
     // Sections only: the per-edge resistance is gone, and writing it back would

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
@@ -35,6 +35,7 @@ public static class LayoutDtoMapper
         o.StartMinimized = dto.StartMinimized ?? o.StartMinimized;
         o.StartElevated = dto.StartElevated ?? o.StartElevated;
         o.DebugTools = dto.DebugTools ?? o.DebugTools;
+        o.ExperimentalFeatures = dto.ExperimentalFeatures ?? o.ExperimentalFeatures;
         o.VcpControl = dto.VcpControl ?? o.VcpControl;
         o.ShowMonitorActionWarning = dto.ShowMonitorActionWarning ?? o.ShowMonitorActionWarning;
         o.BorderValues = dto.BorderValues ?? o.BorderValues;
@@ -179,6 +180,7 @@ public static class LayoutDtoMapper
         StartMinimized = o.StartMinimized,
         StartElevated = o.StartElevated,
         DebugTools = o.DebugTools,
+        ExperimentalFeatures = o.ExperimentalFeatures,
         VcpControl = o.VcpControl,
         ShowMonitorActionWarning = o.ShowMonitorActionWarning,
         BorderValues = o.BorderValues,

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -26,6 +26,7 @@ public class GlobalOptionsDto
     public bool? StartMinimized { get; set; }
     public bool? StartElevated { get; set; }
     public bool? DebugTools { get; set; }
+    public bool? ExperimentalFeatures { get; set; }
     public bool? ShowMonitorActionWarning { get; set; }
     public string? BorderValues { get; set; }
     public string? RescueShortcut { get; set; }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -45,7 +45,7 @@ public class LayoutDto
     public Dictionary<string, MonitorDto> Monitors { get; set; } = [];
 }
 
-/// <summary>Per-layout options. Priority/PriorityUnhooked here override the global ones.</summary>
+/// <summary>Per-layout options.</summary>
 public class LayoutOptionsDto
 {
     public bool? AllowOverlaps { get; set; }
@@ -59,7 +59,17 @@ public class LayoutOptionsDto
     public bool? Enabled { get; set; }
     public bool? AdjustPointer { get; set; }
     public bool? AdjustSpeed { get; set; }
+
+    /// <summary>
+    /// READ-ONLY legacy pair. These are app-level options (see <see cref="GlobalOptionsDto"/>)
+    /// that older versions also stored per layout; both locations load into the same options
+    /// property, and only the app-level one is written from now on. Kept so a layout that
+    /// still carries them keeps its priority on upgrade — after which it is stored once, at
+    /// the app level, and this reads null forever.
+    /// </summary>
     public string? Priority { get; set; }
+
+    /// <inheritdoc cref="Priority"/>
     public string? PriorityUnhooked { get; set; }
 }
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
@@ -210,6 +210,13 @@ public abstract class LayoutPersistence : ILayoutPersistence
         var dto = _store.Read(layout.Id, []).Layout ?? new LayoutDto();
         dto.Options ??= new LayoutOptionsDto();
         dto.Options.Enabled = layout.Options.Enabled;
+
+        // Everything else read is written back as-is, EXCEPT the two app-level options a
+        // layout may still carry: re-emitting them here would put back what a full save
+        // just migrated away (see LayoutDtoMapper.ToDto).
+        dto.Options.Priority = null;
+        dto.Options.PriorityUnhooked = null;
+
         _store.WriteLayout(layout.Id, dto);
 
         SetAutostart(layout, layout.Options.LoadAtStartup, layout.Options.StartElevated);

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -202,6 +202,14 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
         }
     }
 
+    /// <summary>
+    /// Last-resort seed of the exclusion list, right before the daemon starts reading it.
+    /// <see cref="LittleBigMouse.Plugins.Persistence.ExcludedListPersistence"/> normally
+    /// gets there first (loading a layout precedes launching the daemon) and writes the
+    /// same content, header included; this stays as the guard for any path that reaches
+    /// the daemon without a load, where the alternative is a daemon running with no
+    /// exclusions at all. Both must keep writing the same thing.
+    /// </summary>
     void CreateExcludedFile()
     {
         var dir = LbmPaths.DataDir;


### PR DESCRIPTION
## Three merged PRs never reached master

#560, #561 and #562 are marked **merged** on GitHub, and their code is **not on `master`**.

They were stacked on `agent/split-layout-persistence` (#557). That branch was merged to master first, and the three merge buttons afterwards landed them *on the branch* — where they have been sitting since. Nothing warned about it: each PR shows green and merged.

This PR is the branch itself, brought to master. No new work:

| | |
|---|---|
| #560 | Keep `Excluded.txt` comments out of the exclusion list |
| #561 | Persist `ExperimentalFeatures` |
| #562 | Store the process priority in one place |

## Verified, not assumed

`master` moved on after #557 — it gained #558 (`RescueShortcut` in the registry store) and #559 (write-only field docs), and both touch files these three also touch. I merged master into the branch locally to check:

- **auto-merge is clean**, no conflict — the overlaps in `RegistryLayoutStore.cs` and `LayoutDtos.cs` are in different regions
- full `LittleBigMouse-Linux.slnf` build: 0 errors
- `DisplayLayout.Tests`: **141 passing, 0 failing**
- the three additions to `RegistryLayoutStore` coexist as intended: `RescueShortcut` read+write, `ExperimentalFeatures` read+write, and the legacy `Priority` delete

I did not push that trial merge — the branch is unchanged, so the merge here is GitHub's own, which produces the same result.

## Worth doing after

The stacking is what made this possible: a PR whose base is another PR's branch merges into the branch, not into master, and the base disappearing does not stop it. If this recurs, `agent/*` branches merged into a non-`master` base are worth a look before deleting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
