### PR TITLE
Use SortAndBind for the main command list

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainViewModel.cs
@@ -60,8 +60,7 @@ public class MainViewModel : ViewModel, IMainViewModel, IMainPluginsViewModel
         CloseCommand = ReactiveCommand.CreateFromTask(CloseAsync);
 
         _commandsCache.Connect()
-            .Sort(SortExpressionComparer<IUiCommand>.Ascending(t => t.Id))
-            .Bind(out _commands)
+            .SortAndBind(out _commands, SortExpressionComparer<IUiCommand>.Ascending(t => t.Id))
             .Subscribe().DisposeWith(this);
 
         MaximizeCommand = ReactiveCommand.Create(() =>


### PR DESCRIPTION
DynamicData 9.4.31 marks `ObservableCacheEx.Sort` obsolete in favour of `SortAndBind`, which avoids maintaining a whole sorted change set just to feed the binding. `MonitorsLayout` was migrated in #565; this is the one remaining cache-based call site, and it removes the last DynamicData `CS0618` from the Linux build.

`_commandsCache` is a `SourceCache<IUiCommand, string>`, so this is a direct swap of the same shape already used in `MonitorsLayout`.

### Not changed

`ProbeLut.cs:64` and `:71` look like the same pattern but are not. `_lut` and `_smoothLut` are `SourceList<Tune>`, so those bind to the *list* operator `ObservableListEx.Sort`, which is not deprecated — only the cache overload is. A forced non-incremental rebuild of `HLab.Sys.Windows.MonitorVcp` emits no `CS0618` on either line (no `NoWarn`, no `#pragma` in play), so there is nothing to fix or suppress there.

### Verification

```
dotnet build LittleBigMouse-Linux.slnf -c Debug -p:AllowMissingPrunePackageData=true | grep CS0618
```

No DynamicData warnings remain; the only surviving `CS0618` is an unrelated Avalonia `Bitmap.Save` deprecation. `LittleBigMouse.Ui.Avalonia.Tests`: 213 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)