### PR TITLE
Mutualise the placement geometry, and refuse corner-only contacts

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutGeometryTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutGeometryTests.cs
@@ -1,0 +1,139 @@
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// The primitives both placement directions are built on, tested on plain rectangles. They are
+/// shared precisely because the two directions must agree on what "adjacent", "overlapping" and
+/// "the shared span" mean; if they drift apart here, they drift apart everywhere.
+/// </summary>
+public class LayoutGeometryTests
+{
+    [Fact]
+    public void On_ReadsTheRequestedAxis()
+    {
+        var rect = new Rect(10, 20, 30, 40);
+
+        Assert.Equal(new Interval(10, 30), rect.On(Axis.Horizontal));
+        Assert.Equal(new Interval(20, 40), rect.On(Axis.Vertical));
+    }
+
+    [Fact]
+    public void Perpendicular_IsTheOtherAxis()
+    {
+        Assert.Equal(Axis.Vertical, Axis.Horizontal.Perpendicular());
+        Assert.Equal(Axis.Horizontal, Axis.Vertical.Perpendicular());
+    }
+
+    [Fact]
+    public void OverlapWith_IsNegativeForAGap()
+    {
+        Assert.Equal(5, new Interval(0, 10).OverlapWith(new Interval(5, 10)));
+
+        // Touching is zero overlap, not positive: a shared edge is not a crossable corridor.
+        Assert.Equal(0, new Interval(0, 10).OverlapWith(new Interval(10, 10)));
+
+        // Disjoint: the value is the gap, which is what the callers order islands by.
+        Assert.Equal(-3, new Interval(0, 10).OverlapWith(new Interval(13, 10)));
+    }
+
+    [Fact]
+    public void SharedMidpoint_IsDefinedEvenWithoutOverlap()
+    {
+        // Overlapping: midpoint of the shared part.
+        Assert.Equal(7.5, new Interval(0, 10).SharedMidpoint(new Interval(5, 10)));
+
+        // Disjoint: midpoint of the GAP. Neither solver special-cases two panels that only meet
+        // through their bezels, because this keeps returning the right anchor for them.
+        Assert.Equal(11.5, new Interval(0, 10).SharedMidpoint(new Interval(13, 10)));
+    }
+
+    [Fact]
+    public void Overlap_NeedsSurface_NotJustASharedEdge()
+    {
+        var a = new Rect(0, 0, 10, 10);
+
+        Assert.True(LayoutGeometry.Overlap(a, new Rect(5, 5, 10, 10)));
+
+        // Edge to edge, and corner to corner: neither is an overlap.
+        Assert.False(LayoutGeometry.Overlap(a, new Rect(10, 0, 10, 10)));
+        Assert.False(LayoutGeometry.Overlap(a, new Rect(10, 10, 10, 10)));
+    }
+
+    [Fact]
+    public void ContactBetween_ReadsBothSides()
+    {
+        var anchor = new Interval(0, 10);
+
+        Assert.Equal(EdgeContact.After, LayoutGeometry.ContactBetween(anchor, new Interval(10, 5), 0));
+        Assert.Equal(EdgeContact.Before, LayoutGeometry.ContactBetween(anchor, new Interval(-5, 5), 0));
+        Assert.Equal(EdgeContact.None, LayoutGeometry.ContactBetween(anchor, new Interval(12, 5), 0));
+    }
+
+    [Fact]
+    public void ContactBetween_ToleranceIsWhatSeparatesTheTwoDirections()
+    {
+        var anchor = new Interval(0, 10);
+        var threeAway = new Interval(13, 5);
+
+        // Pixel edges are integers the system reports verbatim: 3 apart is not adjacent.
+        Assert.Equal(EdgeContact.None, LayoutGeometry.ContactBetween(anchor, threeAway, 0));
+
+        // Bezel widths are hand-entered millimetres: 3mm of air still counts.
+        Assert.Equal(EdgeContact.After, LayoutGeometry.ContactBetween(anchor, threeAway, 5));
+    }
+
+    [Fact]
+    public void ToPixelAndToMm_AreInverses()
+    {
+        // A 27" 4K panel at scale 2: 597.7mm of glass over 1920 logical pixels.
+        var profile = new AxisProfile(new Interval(100, 597.7), new Interval(2560, 1920));
+
+        Assert.Equal(2560, profile.ToPixel(100), 9);
+        Assert.Equal(100, profile.ToMm(2560), 9);
+        Assert.Equal(1234.5, profile.ToPixel(profile.ToMm(1234.5)), 6);
+    }
+
+    [Fact]
+    public void HasPixels_IsFalseForAMonitorReportingNone()
+    {
+        Assert.False(new AxisProfile(new Interval(0, 300), new Interval(0, 0)).HasPixels);
+        Assert.True(new AxisProfile(new Interval(0, 300), new Interval(0, 1080)).HasPixels);
+    }
+
+    /// <summary>
+    /// The invariant itself: whichever unknown you solve for, the shared physical midpoint lands
+    /// on the same coordinate on both monitors. This is the single property that makes the two
+    /// directions each other's inverse.
+    /// </summary>
+    [Fact]
+    public void PixelOriginAndMillimetreOrigin_SolveTheSameInvariant()
+    {
+        // 27" 4K at scale 2 next to a 24" FHD, physically centred: different pitches, which is
+        // the case a closed-form pixel midpoint gets wrong.
+        var anchor = new AxisProfile(new Interval(0, 336.2), new Interval(0, 1080));
+        var targetMm = new Interval(18.6, 299);
+        var target = new AxisProfile(targetMm, new Interval(0, 1080));
+
+        // Forward: where does the target go in pixels?
+        var pixelLo = EdgeProjection.PixelOrigin(anchor, target);
+
+        // Backward: given that pixel answer, where does it go in millimetres?
+        var mmLo = EdgeProjection.MillimetreOrigin(anchor, target.AtPixel(pixelLo));
+
+        Assert.Equal(targetMm.Lo, mmLo, 6);
+    }
+
+    [Fact]
+    public void MillimetreOrigin_MatchesTheClosedFormWhenPitchesAreEqual()
+    {
+        // Same pitch on both: the pixel midpoint and the mm midpoint agree, so the iteration
+        // must land exactly on the plain proportional answer.
+        var anchor = new AxisProfile(new Interval(0, 270), new Interval(0, 1080));
+        var target = new AxisProfile(new Interval(0, 270), new Interval(-219, 1080));
+
+        // 219 pixels up, at 0.25 mm/px.
+        Assert.Equal(-54.75, EdgeProjection.MillimetreOrigin(anchor, target), 9);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LocationSolverRoundTripTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LocationSolverRoundTripTests.cs
@@ -1,0 +1,436 @@
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout.Monitors.Extensions;
+using Xunit.Abstractions;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// The two placement directions are inverses of each other, and this is where that claim is
+/// checked: read a system pixel configuration into millimetres with
+/// <see cref="SystemLocationSolver"/>, push the result back out with
+/// <see cref="PixelLocationSolver"/>, and land on the configuration you started from.
+/// <para>
+/// It only holds where it can. A physical layout cannot express "300 pixels of nothing between
+/// these two screens", and a millimetre arrangement carries information no integer pixel grid
+/// can carry back; the second half of this file pins down exactly which configurations are lost
+/// and what they become, so that a future change to either solver has to say so out loud.
+/// </para>
+/// <para>
+/// Both directions run here as pure functions on <see cref="MonitorSnapshot"/> — no reactive
+/// model. <see cref="PlaceFromSystemTests"/> keeps covering the same pair through the live one.
+/// </para>
+/// </summary>
+public class LocationSolverRoundTripTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// A monitor as a freshly built layout has it: known panel size and bezels, known pixel rect,
+    /// and no millimetre position yet — everything stacked at the origin.
+    /// </summary>
+    static MonitorSnapshot Monitor(
+        string id, double widthMm, double heightMm,
+        double pixelX, double pixelY, double pixelWidth, double pixelHeight,
+        bool primary = false, double bezel = 10)
+        => new(
+            id,
+            new Rect(0, 0, widthMm, heightMm),
+            new Rect(-bezel, -bezel, widthMm + 2 * bezel, heightMm + 2 * bezel),
+            new Rect(pixelX, pixelY, pixelWidth, pixelHeight),
+            primary);
+
+    /// <summary>
+    /// "Place from system" end to end, as <see cref="MonitorsLocationsFromSystemExtensions.SetLocationsFromSystemConfiguration"/>
+    /// runs it: solve the walk, then compact — monitors the walk could not claim only get their
+    /// final position from <see cref="CompactionSolver"/>, and that second step is where the
+    /// information a round trip loses actually gets lost.
+    /// </summary>
+    static IReadOnlyList<MonitorSnapshot> PlaceFromSystem(IReadOnlyList<MonitorSnapshot> monitors)
+    {
+        var solved = SystemLocationSolver.Solve(monitors);
+        var placed = monitors
+            .Select(m => solved.TryGetValue(m.Id, out var p) ? m.MovedTo(p) : m)
+            .ToList();
+
+        var offsets = CompactionSolver.Solve(
+            [.. placed.Select(m => m.ForCompaction())],
+            new CompactionOptions(AllowOverlaps: false, AllowDiscontinuity: false, MinimalEdgeOverlap: 20));
+
+        return [.. placed.Select(m => offsets.TryGetValue(m.Id, out var v)
+            ? m.MovedTo(new Point(m.MmBounds.X + v.X, m.MmBounds.Y + v.Y))
+            : m)];
+    }
+
+    /// <summary>Pixel positions relative to the primary — the anchor both directions agree on.</summary>
+    static Dictionary<string, Point> SystemPixels(IReadOnlyList<MonitorSnapshot> monitors)
+    {
+        var origin = monitors.Single(m => m.Primary).PixelBounds.Location;
+        return monitors.ToDictionary(m => m.Id,
+            m => new Point(m.PixelBounds.X - origin.X, m.PixelBounds.Y - origin.Y));
+    }
+
+    string Describe(IReadOnlyList<MonitorSnapshot> placed, IReadOnlyDictionary<string, Point> back)
+        => string.Join(" | ", placed.OrderBy(m => m.Id).Select(m =>
+            $"{m.Id} mm({m.MmBounds.X:F1},{m.MmBounds.Y:F1}) -> px({back[m.Id].X},{back[m.Id].Y})"));
+
+    /// <summary>
+    /// System pixels in, the same system pixels out. One pixel of slack: the outbound direction
+    /// rounds, because the system only accepts integers.
+    /// </summary>
+    void AssertRoundTrips(IReadOnlyList<MonitorSnapshot> monitors)
+    {
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        var expected = SystemPixels(monitors);
+
+        output.WriteLine(Describe(placed, back));
+
+        foreach (var monitor in monitors)
+        {
+            var want = expected[monitor.Id];
+            var got = back[monitor.Id];
+
+            Assert.True(Math.Abs(got.X - want.X) <= 1,
+                $"{monitor.Id} X: got {got.X}, expected {want.X}");
+            Assert.True(Math.Abs(got.Y - want.Y) <= 1,
+                $"{monitor.Id} Y: got {got.Y}, expected {want.Y}");
+        }
+    }
+
+    // ---------------------------------------------------------------- invertible
+
+    [Fact]
+    public void SideBySide_RoundTrips()
+    {
+        AssertRoundTrips([
+            Monitor("A", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("B", 600, 340, 2560, 0, 2560, 1440),
+        ]);
+    }
+
+    /// <summary>
+    /// The desktop this whole pair exists for: different panel sizes, wildly different pitches,
+    /// and a neighbour hanging 219 px lower. Nobody bolts their screens to a shelf.
+    /// </summary>
+    [Fact]
+    public void MixedPitchesAndVerticalOffset_RoundTrips()
+    {
+        AssertRoundTrips([
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("SIDE", 600, 340, 2560, -219, 2560, 1440),
+            Monitor("TV", 1650, 920, 5120, 0, 1280, 720),
+        ]);
+    }
+
+    [Fact]
+    public void VerticalStackOfDifferentWidths_RoundTrips()
+    {
+        AssertRoundTrips([
+            Monitor("TOP", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("LAPTOP", 302, 189, 320, 1440, 1920, 1200),
+        ]);
+    }
+
+    [Fact]
+    public void PrimaryInTheMiddle_RoundTrips()
+    {
+        AssertRoundTrips([
+            Monitor("LEFT", 520, 320, -1920, 0, 1920, 1080),
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("RIGHT", 700, 400, 2560, 0, 1920, 1080),
+        ]);
+    }
+
+    /// <summary>
+    /// Bezel widths are the one thing the system never sees. They must survive the outbound trip
+    /// anyway — as exact pixel contact, since the system has nowhere to put them.
+    /// </summary>
+    [Fact]
+    public void ThickBezels_RoundTripAsExactPixelContact()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true, bezel: 25),
+            Monitor("B", 600, 340, 1920, 0, 1920, 1080, bezel: 25),
+        };
+
+        AssertRoundTrips(monitors);
+
+        var placed = PlaceFromSystem(monitors);
+        var a = placed.Single(m => m.Id == "A");
+        var b = placed.Single(m => m.Id == "B");
+
+        // 50mm of frame between the two panels, and the bezels themselves flush.
+        Assert.Equal(50, b.MmBounds.X - a.MmBounds.Right, 6);
+        Assert.Equal(a.MmOutsideBounds.Right, b.MmOutsideBounds.X, 6);
+    }
+
+    /// <summary>
+    /// Running "place from system" twice must give what running it once gave. Both entry points
+    /// (first launch, and the menu item) call the same thing, so a result that depends on where
+    /// the monitors already were means the button and the first launch disagree.
+    /// </summary>
+    [Fact]
+    public void PlacingIsIdempotent()
+    {
+        var monitors = new[]
+        {
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("SIDE", 600, 340, 2560, -219, 2560, 1440),
+            Monitor("TV", 1650, 920, 5120, 0, 1280, 720),
+        };
+
+        var once = PlaceFromSystem(monitors);
+        var twice = PlaceFromSystem(once);
+
+        foreach (var monitor in once)
+        {
+            var again = twice.Single(m => m.Id == monitor.Id);
+            Assert.Equal(monitor.MmBounds.X, again.MmBounds.X, 9);
+            Assert.Equal(monitor.MmBounds.Y, again.MmBounds.Y, 9);
+        }
+    }
+
+    // ------------------------------------------------------------ not invertible
+
+    /// <summary>
+    /// A gap between two monitors in the system configuration has no physical meaning: the
+    /// millimetre layout is a description of where the panels ARE, and there is no way to say
+    /// "and 300 pixels of nothing here". The gap is closed on the way in and cannot come back.
+    /// </summary>
+    [Fact]
+    public void PixelGap_IsClosed_AndDoesNotComeBack()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 1920 + 300, 0, 1920, 1080),
+        };
+
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        // Not where it was: the gap is gone.
+        Assert.NotEqual(2220, back["B"].X);
+
+        // What it becomes is worth being explicit about. No pixel edge is shared, so the walk
+        // never claims B — only the "same top edge, same bottom edge" alignment hints fire, and
+        // those leave it exactly on top of the primary. Compaction then has a total overlap to
+        // break and picks the shortest push, which on two identical panels is vertical. Two
+        // screens the user has side by side come back stacked.
+        Assert.Equal(new Point(0, 1080), back["B"]);
+
+        // Whatever it chose, the desktop is connected and free of overlap, which is the part
+        // both platforms actually require.
+        var a = new Rect(back["A"], monitors[0].PixelSize);
+        var b = new Rect(back["B"], monitors[1].PixelSize);
+        Assert.False(LayoutGeometry.Overlap(a, b));
+        Assert.Equal(a.Bottom, b.Y);
+    }
+
+    /// <summary>
+    /// A 2x2 grid does NOT round-trip, and the reason is worth stating: the diagonal neighbour
+    /// shares a pixel edge on BOTH axes at once, so the inbound walk claims it as adjacent twice
+    /// over. Each contact then runs the perpendicular projection on the other axis, and the two
+    /// projections overwrite both coordinates the contact rules had set — the diagonal monitor
+    /// ends up panel-flush instead of bezel-flush, its frame overlapping the primary's, and
+    /// compaction pushes the grid into a skew to separate them.
+    /// <para>
+    /// Pinned here as it stands rather than corrected: this is what users' saved layouts were
+    /// built from. Changing it is a deliberate behaviour change, not a refactor.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void DiagonalNeighbourInAGrid_IsClaimedOnBothAxes_AndSkewsTheGrid()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 1920, 0, 1920, 1080),
+            Monitor("C", 600, 340, 0, 1080, 1920, 1080),
+            Monitor("D", 600, 340, 1920, 1080, 1920, 1080),
+        };
+
+        // The walk alone, before compaction: D is claimed by A, not by B or C, and lands
+        // panel-flush on the diagonal — 600, not the 620 a bezel-flush dock would give.
+        var walked = SystemLocationSolver.Solve(monitors);
+        Assert.Equal(new Point(600, 340), walked["D"]);
+        Assert.Equal(new Point(620, 0), walked["B"]);
+        Assert.Equal(new Point(0, 360), walked["C"]);
+
+        // D's bezels then overlap A's by exactly one bezel width on each axis, and compaction
+        // has to break the tie somewhere: the row and the column each shift by 20mm.
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        Assert.Equal(new Point(620, -20), placed.Single(m => m.Id == "B").MmLocation);
+        Assert.Equal(new Point(-20, 360), placed.Single(m => m.Id == "C").MmLocation);
+        Assert.Equal(new Point(620, 340), placed.Single(m => m.Id == "D").MmLocation);
+
+        // What survives the trip: the grid is still a grid in pixels, one screen per cell.
+        Assert.Equal(new Point(1920, 1080), back["D"]);
+        Assert.Equal(1920, back["B"].X);
+        Assert.Equal(1080, back["C"].Y);
+
+        // What does not: the skew shows up as a vertical shift the system never asked for.
+        Assert.NotEqual(0, back["B"].Y);
+    }
+
+    /// <summary>
+    /// Two monitors overlapping in the system configuration: same story the other way. The
+    /// physical layout cannot describe two panels occupying the same space, so the overlap is
+    /// resolved on the way in and the round trip returns a layout that merely touches.
+    /// </summary>
+    [Fact]
+    public void PixelOverlap_IsResolved_AndDoesNotComeBack()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 960, 540, 1920, 1080),
+        };
+
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        Assert.NotEqual(new Point(960, 540), back["B"]);
+
+        var a = new Rect(back["A"], monitors[0].PixelSize);
+        var b = new Rect(back["B"], monitors[1].PixelSize);
+        Assert.False(LayoutGeometry.Overlap(a, b), $"A{a} still overlaps B{b}");
+    }
+
+    /// <summary>
+    /// Two monitors meeting corner to corner. A corner is not crossable — the cursor has nowhere
+    /// to pass — so nothing downstream is willing to keep it: compaction slides the monitor until
+    /// the panels share the 20mm corridor the layout options ask for, and the outbound direction
+    /// only ever docks along an edge with real overlap. The diagonal comes back as a side by
+    /// side, on purpose.
+    /// </summary>
+    [Fact]
+    public void CornerToCornerContact_IsNotInvertible()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 1920, 1080, 1920, 1080),
+        };
+
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        var a = placed.Single(m => m.Id == "A");
+        var b = placed.Single(m => m.Id == "B");
+
+        // Inbound, the walk claims the contact on both axes and puts B panel-flush on the
+        // diagonal, bezels overlapping; compaction docks it to the right with the frames flush
+        // and slides it up until the two panels share the 20mm corridor the options demand.
+        Assert.Equal(a.MmOutsideBounds.Right, b.MmOutsideBounds.X, 6);
+        Assert.Equal(20, LayoutGeometry.OverlapOn(a.MmBounds, b.MmBounds, Axis.Vertical), 6);
+
+        // Outbound: not a corner any more. B is docked on one axis with a real shared edge.
+        var pa = new Rect(back["A"], monitors[0].PixelSize);
+        var pb = new Rect(back["B"], monitors[1].PixelSize);
+        var sharedEdge =
+            (pa.Right == pb.X || pb.Right == pa.X) && LayoutGeometry.OverlapOn(pa, pb, Axis.Vertical) > 0
+            || (pa.Bottom == pb.Y || pb.Bottom == pa.Y) && LayoutGeometry.OverlapOn(pa, pb, Axis.Horizontal) > 0;
+
+        Assert.True(sharedEdge, $"corner became {pa} / {pb}, still not crossable");
+        Assert.NotEqual(new Point(1920, 1080), back["B"]);
+    }
+
+    /// <summary>
+    /// A monitor touching nothing in the system configuration is placed by compaction, not by the
+    /// walk — its position comes from "dock it nearest first", not from the pixel configuration,
+    /// so there is nothing to invert. It must nevertheless end up part of the single connected
+    /// block both platforms require.
+    /// </summary>
+    [Fact]
+    public void DetachedMonitor_IsDockedRatherThanInverted()
+    {
+        var monitors = new[]
+        {
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("FAR", 520, 300, 6000, 4000, 1920, 1080),
+        };
+
+        var placed = PlaceFromSystem(monitors);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        Assert.NotEqual(new Point(6000, 4000), back["FAR"]);
+
+        var main = new Rect(back["MAIN"], monitors[0].PixelSize);
+        var far = new Rect(back["FAR"], monitors[1].PixelSize);
+        Assert.False(LayoutGeometry.Overlap(main, far));
+
+        var touching =
+            (main.Right == far.X || far.Right == main.X) && LayoutGeometry.OverlapOn(main, far, Axis.Vertical) > 0
+            || (main.Bottom == far.Y || far.Bottom == main.Y) && LayoutGeometry.OverlapOn(main, far, Axis.Horizontal) > 0;
+
+        Assert.True(touching, $"island left disconnected: {main} / {far}");
+    }
+
+    /// <summary>
+    /// A monitor reporting no pixels has no pitch, so the shared-midpoint projection cannot run
+    /// for it. It must not produce a NaN position, and it must not take the rest of the layout
+    /// down with it — the walk goes through half-built states on every layout rebuild.
+    /// </summary>
+    [Fact]
+    public void MonitorWithoutPixels_IsPlacedWithoutProjection()
+    {
+        var monitors = new[]
+        {
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("GHOST", 520, 300, 2560, 0, 0, 0),
+        };
+
+        var placed = PlaceFromSystem(monitors);
+        output.WriteLine(string.Join(" | ", placed.Select(m => $"{m.Id}({m.MmBounds.X:F1},{m.MmBounds.Y:F1})")));
+
+        foreach (var monitor in placed)
+        {
+            Assert.False(double.IsNaN(monitor.MmBounds.X), $"{monitor.Id} X is NaN");
+            Assert.False(double.IsNaN(monitor.MmBounds.Y), $"{monitor.Id} Y is NaN");
+        }
+    }
+
+    /// <summary>
+    /// No primary yet — the state every layout passes through while it is being built. Nothing is
+    /// anchored, so nothing may move: a walk with no root would otherwise pick an arbitrary
+    /// monitor and scatter the layout around it.
+    /// </summary>
+    [Fact]
+    public void NoPrimary_MovesNothing()
+    {
+        var solved = SystemLocationSolver.Solve([
+            Monitor("A", 600, 340, 0, 0, 2560, 1440),
+            Monitor("B", 520, 300, 2560, 0, 1920, 1080),
+        ]);
+
+        Assert.Empty(solved);
+    }
+
+    /// <summary>
+    /// Monitors already placed are excluded from the walk: they neither move nor anchor anything.
+    /// This is the <c>placeAll: false</c> path the platform factories take on startup, so a saved
+    /// layout is not silently re-derived from the system.
+    /// </summary>
+    [Fact]
+    public void MonitorsNotOfferedForPlacement_StayPut()
+    {
+        var monitors = new[]
+        {
+            Monitor("MAIN", 600, 340, 0, 0, 2560, 1440, primary: true),
+            Monitor("SIDE", 600, 340, 2560, -219, 2560, 1440),
+        };
+
+        var solved = SystemLocationSolver.Solve(monitors, new HashSet<string>());
+        Assert.Empty(solved);
+
+        // Offered, and then it does move.
+        Assert.True(SystemLocationSolver.Solve(monitors, new HashSet<string> { "SIDE" }).ContainsKey("SIDE"));
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LocationSolverRoundTripTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LocationSolverRoundTripTests.cs
@@ -43,7 +43,8 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
     /// final position from <see cref="CompactionSolver"/>, and that second step is where the
     /// information a round trip loses actually gets lost.
     /// </summary>
-    static IReadOnlyList<MonitorSnapshot> PlaceFromSystem(IReadOnlyList<MonitorSnapshot> monitors)
+    static IReadOnlyList<MonitorSnapshot> PlaceFromSystem(
+        IReadOnlyList<MonitorSnapshot> monitors, double minimalEdgeOverlap = 20)
     {
         var solved = SystemLocationSolver.Solve(monitors);
         var placed = monitors
@@ -52,7 +53,8 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
 
         var offsets = CompactionSolver.Solve(
             [.. placed.Select(m => m.ForCompaction())],
-            new CompactionOptions(AllowOverlaps: false, AllowDiscontinuity: false, MinimalEdgeOverlap: 20));
+            new CompactionOptions(AllowOverlaps: false, AllowDiscontinuity: false,
+                MinimalEdgeOverlap: minimalEdgeOverlap));
 
         return [.. placed.Select(m => offsets.TryGetValue(m.Id, out var v)
             ? m.MovedTo(new Point(m.MmBounds.X + v.X, m.MmBounds.Y + v.Y))
@@ -189,6 +191,48 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
         }
     }
 
+    /// <summary>
+    /// A 2x2 grid, which is where the diagonal neighbour has to be refused. D shares a pixel edge
+    /// with the primary on BOTH axes at once — a corner, which the cursor cannot cross — and a
+    /// contact with no overlap across it does not claim. So D is not consumed on the diagonal: it
+    /// waits for B (or C), whose edge with it is real, and docks bezel-flush like everything else.
+    /// Nothing overlaps, compaction finds nothing to do, and the grid comes back as a grid.
+    /// <para>
+    /// This used to be the one configuration in this file that did not survive the trip: both
+    /// corner contacts fired, each ran the perpendicular projection on the other axis, and the two
+    /// projections overwrote both coordinates the contact rules had set. D landed panel-flush at
+    /// (600,340) with its frame inside the primary's, and compaction skewed the whole grid by a
+    /// bezel width on each axis to pull them apart — B to (620,-20), C to (-20,360).
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void DiagonalNeighbourInAGrid_IsRefused_AndTheGridRoundTrips()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 1920, 0, 1920, 1080),
+            Monitor("C", 600, 340, 0, 1080, 1920, 1080),
+            Monitor("D", 600, 340, 1920, 1080, 1920, 1080),
+        };
+
+        // The walk alone, before compaction: every monitor bezel-flush against its neighbours,
+        // D at 620 rather than the 600 a panel-flush diagonal dock used to give.
+        var walked = SystemLocationSolver.Solve(monitors);
+        Assert.Equal(new Point(620, 0), walked["B"]);
+        Assert.Equal(new Point(0, 360), walked["C"]);
+        Assert.Equal(new Point(620, 360), walked["D"]);
+
+        // Bezels touching on all four inner edges, so compaction has nothing left to separate and
+        // the grid keeps its shape.
+        var placed = PlaceFromSystem(monitors);
+        Assert.Equal(new Point(620, 0), placed.Single(m => m.Id == "B").MmLocation);
+        Assert.Equal(new Point(0, 360), placed.Single(m => m.Id == "C").MmLocation);
+        Assert.Equal(new Point(620, 360), placed.Single(m => m.Id == "D").MmLocation);
+
+        AssertRoundTrips(monitors);
+    }
+
     // ------------------------------------------------------------ not invertible
 
     /// <summary>
@@ -225,55 +269,6 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
         var b = new Rect(back["B"], monitors[1].PixelSize);
         Assert.False(LayoutGeometry.Overlap(a, b));
         Assert.Equal(a.Bottom, b.Y);
-    }
-
-    /// <summary>
-    /// A 2x2 grid does NOT round-trip, and the reason is worth stating: the diagonal neighbour
-    /// shares a pixel edge on BOTH axes at once, so the inbound walk claims it as adjacent twice
-    /// over. Each contact then runs the perpendicular projection on the other axis, and the two
-    /// projections overwrite both coordinates the contact rules had set — the diagonal monitor
-    /// ends up panel-flush instead of bezel-flush, its frame overlapping the primary's, and
-    /// compaction pushes the grid into a skew to separate them.
-    /// <para>
-    /// Pinned here as it stands rather than corrected: this is what users' saved layouts were
-    /// built from. Changing it is a deliberate behaviour change, not a refactor.
-    /// </para>
-    /// </summary>
-    [Fact]
-    public void DiagonalNeighbourInAGrid_IsClaimedOnBothAxes_AndSkewsTheGrid()
-    {
-        var monitors = new[]
-        {
-            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
-            Monitor("B", 600, 340, 1920, 0, 1920, 1080),
-            Monitor("C", 600, 340, 0, 1080, 1920, 1080),
-            Monitor("D", 600, 340, 1920, 1080, 1920, 1080),
-        };
-
-        // The walk alone, before compaction: D is claimed by A, not by B or C, and lands
-        // panel-flush on the diagonal — 600, not the 620 a bezel-flush dock would give.
-        var walked = SystemLocationSolver.Solve(monitors);
-        Assert.Equal(new Point(600, 340), walked["D"]);
-        Assert.Equal(new Point(620, 0), walked["B"]);
-        Assert.Equal(new Point(0, 360), walked["C"]);
-
-        // D's bezels then overlap A's by exactly one bezel width on each axis, and compaction
-        // has to break the tie somewhere: the row and the column each shift by 20mm.
-        var placed = PlaceFromSystem(monitors);
-        var back = PixelLocationSolver.Solve(placed);
-        output.WriteLine(Describe(placed, back));
-
-        Assert.Equal(new Point(620, -20), placed.Single(m => m.Id == "B").MmLocation);
-        Assert.Equal(new Point(-20, 360), placed.Single(m => m.Id == "C").MmLocation);
-        Assert.Equal(new Point(620, 340), placed.Single(m => m.Id == "D").MmLocation);
-
-        // What survives the trip: the grid is still a grid in pixels, one screen per cell.
-        Assert.Equal(new Point(1920, 1080), back["D"]);
-        Assert.Equal(1920, back["B"].X);
-        Assert.Equal(1080, back["C"].Y);
-
-        // What does not: the skew shows up as a vertical shift the system never asked for.
-        Assert.NotEqual(0, back["B"].Y);
     }
 
     /// <summary>
@@ -317,6 +312,14 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
             Monitor("B", 600, 340, 1920, 1080, 1920, 1080),
         };
 
+        // Inbound, the walk refuses the contact on both axes — neither has any overlap across it
+        // — so B is never claimed and no projection runs on it. The contact rule still SUGGESTS a
+        // position, which is the whole difference between a corner-only neighbour and one that
+        // touches nothing: B keeps the diagonal it was on, bezel-flush at (620,360) rather than
+        // staying stacked on the primary at the origin.
+        var walked = SystemLocationSolver.Solve(monitors);
+        Assert.Equal(new Point(620, 360), walked["B"]);
+
         var placed = PlaceFromSystem(monitors);
         var back = PixelLocationSolver.Solve(placed);
         output.WriteLine(Describe(placed, back));
@@ -324,9 +327,8 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
         var a = placed.Single(m => m.Id == "A");
         var b = placed.Single(m => m.Id == "B");
 
-        // Inbound, the walk claims the contact on both axes and puts B panel-flush on the
-        // diagonal, bezels overlapping; compaction docks it to the right with the frames flush
-        // and slides it up until the two panels share the 20mm corridor the options demand.
+        // Compaction then keeps the frames flush on the right and slides B up until the two
+        // panels share the 20mm corridor the options demand.
         Assert.Equal(a.MmOutsideBounds.Right, b.MmOutsideBounds.X, 6);
         Assert.Equal(20, LayoutGeometry.OverlapOn(a.MmBounds, b.MmBounds, Axis.Vertical), 6);
 
@@ -339,6 +341,42 @@ public class LocationSolverRoundTripTests(ITestOutputHelper output)
 
         Assert.True(sharedEdge, $"corner became {pa} / {pb}, still not crossable");
         Assert.NotEqual(new Point(1920, 1080), back["B"]);
+    }
+
+    /// <summary>
+    /// The same corner, for the user who asked to keep corners: <c>MinimalEdgeOverlap = 0</c> is
+    /// how bare corner contact is accepted, and with the walk leaving B bezel-flush on the
+    /// diagonal there is nothing for compaction to undo. The physical layout the user sees is
+    /// then the one the system reported, which is the payoff for a refused contact still
+    /// SUGGESTING a position: were B left unplaced it would sit on the primary and be shoved off
+    /// to one side instead.
+    /// <para>
+    /// Only the millimetre half survives — the trip back out still cannot express it, since
+    /// <see cref="PixelLocationSolver"/> refuses corners whatever the options say and treats B as
+    /// a detached island to be snapped into contact. Two solvers, one option: the corridor rule
+    /// is layout editing, the pixel grid has to stay crossable regardless.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void CornerToCornerContact_SurvivesWhenNoCorridorIsDemanded()
+    {
+        var monitors = new[]
+        {
+            Monitor("A", 600, 340, 0, 0, 1920, 1080, primary: true),
+            Monitor("B", 600, 340, 1920, 1080, 1920, 1080),
+        };
+
+        var placed = PlaceFromSystem(monitors, minimalEdgeOverlap: 0);
+        var back = PixelLocationSolver.Solve(placed);
+        output.WriteLine(Describe(placed, back));
+
+        var a = placed.Single(m => m.Id == "A");
+        var b = placed.Single(m => m.Id == "B");
+
+        // Frames meeting at the single point (610, 350), panels still 20mm apart on each axis.
+        Assert.Equal(new Point(620, 360), b.MmLocation);
+        Assert.Equal(a.MmOutsideBounds.Right, b.MmOutsideBounds.X, 6);
+        Assert.Equal(a.MmOutsideBounds.Bottom, b.MmOutsideBounds.Y, 6);
     }
 
     /// <summary>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PixelLocationSolverTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PixelLocationSolverTests.cs
@@ -7,21 +7,25 @@ public class PixelLocationSolverTests
 {
     const double Bezel = 20.0;
 
-    /// <summary>Build a monitor whose panel sits at (x,y) mm with uniform bezels.</summary>
-    static PixelPlacementMonitor Monitor(
+    /// <summary>
+    /// Build a monitor whose panel sits at (x,y) mm with uniform bezels. Only the SIZE of the
+    /// pixel rect matters to this solver — the positions are what it computes — so the pixel
+    /// origin is left at zero here.
+    /// </summary>
+    static MonitorSnapshot Monitor(
         string id, double x, double y, double widthMm, double heightMm,
         double pixelWidth, double pixelHeight, bool primary = false, double bezel = Bezel)
         => new(
             id,
             new Rect(x, y, widthMm, heightMm),
             new Rect(x - bezel, y - bezel, widthMm + 2 * bezel, heightMm + 2 * bezel),
-            new Size(pixelWidth, pixelHeight),
+            new Rect(0, 0, pixelWidth, pixelHeight),
             primary);
 
-    static Rect RectOf(PixelPlacementMonitor m, IReadOnlyDictionary<string, Point> solved)
+    static Rect RectOf(MonitorSnapshot m, IReadOnlyDictionary<string, Point> solved)
         => new(solved[m.Id], m.PixelSize);
 
-    static void AssertNoOverlap(IReadOnlyList<PixelPlacementMonitor> monitors, IReadOnlyDictionary<string, Point> solved)
+    static void AssertNoOverlap(IReadOnlyList<MonitorSnapshot> monitors, IReadOnlyDictionary<string, Point> solved)
     {
         for (var i = 0; i < monitors.Count; i++)
         for (var j = i + 1; j < monitors.Count; j++)
@@ -172,7 +176,7 @@ public class PixelLocationSolverTests
     }
 
     /// <summary>Every monitor reachable from every other through real shared edges.</summary>
-    static void AssertConnected(IReadOnlyList<PixelPlacementMonitor> monitors, IReadOnlyDictionary<string, Point> solved)
+    static void AssertConnected(IReadOnlyList<MonitorSnapshot> monitors, IReadOnlyDictionary<string, Point> solved)
     {
         var rects = monitors.Select(m => RectOf(m, solved)).ToList();
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PlaceFromSystemTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/PlaceFromSystemTests.cs
@@ -138,12 +138,7 @@ public class PlaceFromSystemTests(ITestOutputHelper output)
         output.WriteLine(Describe(layout));
 
         var solved = PixelLocationSolver.Solve(
-            [.. layout.PhysicalMonitors.Select(m => new PixelPlacementMonitor(
-                m.Id,
-                m.DepthProjection.Bounds,
-                m.DepthProjection.OutsideBounds,
-                new Size(m.ActiveSource.Source.InPixel.Bounds.Width, m.ActiveSource.Source.InPixel.Bounds.Height),
-                m.ActiveSource.Source.Primary))]);
+            [.. layout.PhysicalMonitors.Select(m => m.Snapshot(m.ActiveSource.Source.Primary))]);
 
         // Both sides are anchored on the primary, so compare against the system's own
         // pixel positions relative to it.

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/CompactionSolver.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/CompactionSolver.cs
@@ -10,8 +10,10 @@ namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
 /// Solver input: one monitor reduced to what placement actually depends on — its identity,
 /// its mm panel bounds (display surface, <c>DepthProjection.Bounds</c>) and its mm outside
 /// bounds (panel plus bezels, <c>DepthProjection.OutsideBounds</c>). Plain record so the
-/// geometry stays testable without the reactive model graph, same contract as
-/// <see cref="PixelPlacementMonitor"/>.
+/// geometry stays testable without the reactive model graph — the millimetre half of
+/// <see cref="MonitorSnapshot"/>, which builds one through
+/// <see cref="MonitorSnapshot.ForCompaction"/>. Compaction has no pixel dimension whatsoever, so
+/// it keeps its own input rather than carry a field it must never read.
 /// </summary>
 public sealed record CompactionMonitor(string Id, Rect Bounds, Rect OutsideBounds, bool Primary);
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/LayoutGeometry.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/LayoutGeometry.cs
@@ -1,0 +1,243 @@
+#nullable enable
+using System;
+using HLab.Geo;
+
+namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+/// <summary>
+/// Which of the two coordinate axes a rule is expressed on. Every placement rule in this
+/// folder is written once for one axis and applied to both; naming the axis is what lets the
+/// two directions share the rule instead of each spelling out its own <c>vertical ? Y : X</c>.
+/// </summary>
+public enum Axis
+{
+    Horizontal,
+    Vertical
+}
+
+/// <summary>
+/// A segment <c>[Lo, Lo+Size]</c> on one axis — a monitor's extent along X or Y, in whatever
+/// unit the caller is working in. Both solvers reason on these: the mm span of a panel, the
+/// pixel span the system gives that same panel, the shared part of two spans.
+/// </summary>
+public readonly record struct Interval(double Lo, double Size)
+{
+    public double Hi => Lo + Size;
+
+    /// <summary>The same span moved so it starts at <paramref name="lo"/>.</summary>
+    public Interval MovedTo(double lo) => this with { Lo = lo };
+
+    /// <summary>
+    /// Length shared with <paramref name="other"/>; zero or negative when they do not overlap,
+    /// the negative value being the gap between them.
+    /// </summary>
+    public double OverlapWith(Interval other) => Math.Min(Hi, other.Hi) - Math.Max(Lo, other.Lo);
+
+    /// <summary>
+    /// Midpoint of the part shared with <paramref name="other"/>. Defined even when the two do
+    /// not overlap — it is then the midpoint of the gap — which is why neither solver needs a
+    /// special case for a monitor whose panels only meet through their bezels.
+    /// </summary>
+    public double SharedMidpoint(Interval other)
+        => (Math.Max(Lo, other.Lo) + Math.Min(Hi, other.Hi)) / 2;
+}
+
+/// <summary>How a span sits against another one along the axis they meet on.</summary>
+public enum EdgeContact
+{
+    /// <summary>No edge in common on this axis.</summary>
+    None,
+
+    /// <summary>The span ends where the anchor starts — it sits on the low side.</summary>
+    Before,
+
+    /// <summary>The span starts where the anchor ends — it sits on the high side.</summary>
+    After
+}
+
+/// <summary>
+/// The geometry both placement directions share: read a rect along one axis, measure how two
+/// rects intersect, decide whether they meet along an edge. Deliberately free of any monitor,
+/// layout or ReactiveUI type, so the rules can be exercised on plain rectangles.
+/// </summary>
+public static class LayoutGeometry
+{
+    /// <summary>The axis a contact on <paramref name="axis"/> leaves to be resolved.</summary>
+    public static Axis Perpendicular(this Axis axis)
+        => axis == Axis.Horizontal ? Axis.Vertical : Axis.Horizontal;
+
+    /// <summary>The extent of <paramref name="rect"/> along <paramref name="axis"/>.</summary>
+    public static Interval On(this Rect rect, Axis axis) => axis == Axis.Horizontal
+        ? new Interval(rect.X, rect.Width)
+        : new Interval(rect.Y, rect.Height);
+
+    /// <summary>The same rect moved so its extent along <paramref name="axis"/> starts at <paramref name="lo"/>.</summary>
+    public static Rect MovedOn(this Rect rect, Axis axis, double lo) => axis == Axis.Horizontal
+        ? new Rect(new Point(lo, rect.Y), rect.Size)
+        : new Rect(new Point(rect.X, lo), rect.Size);
+
+    public static Rect Translated(this Rect rect, double dx, double dy)
+        => new(new Point(rect.X + dx, rect.Y + dy), rect.Size);
+
+    /// <summary>Length <paramref name="a"/> and <paramref name="b"/> share along <paramref name="axis"/>.</summary>
+    public static double OverlapOn(Rect a, Rect b, Axis axis) => a.On(axis).OverlapWith(b.On(axis));
+
+    /// <summary>True when the two rects share actual surface, a shared edge alone not counting.</summary>
+    public static bool Overlap(Rect a, Rect b)
+        => OverlapOn(a, b, Axis.Horizontal) > 0 && OverlapOn(a, b, Axis.Vertical) > 0;
+
+    /// <summary>
+    /// Whether <paramref name="other"/> meets <paramref name="anchor"/> along one of their edges
+    /// on this axis, allowing <paramref name="tolerance"/> of slack.
+    /// <para>
+    /// The two directions call this with very different slack and for very different reasons:
+    /// zero on pixel edges, which the system reports as exact integers, and a few millimetres on
+    /// bezel edges, which are hand-entered and rarely add up to exactly zero. The rule itself is
+    /// the same, and so is the precedence — <see cref="EdgeContact.After"/> is tested first.
+    /// Both readings can only hold at once for a span of zero or negative size.
+    /// </para>
+    /// </summary>
+    public static EdgeContact ContactBetween(Interval anchor, Interval other, double tolerance)
+    {
+        if (Math.Abs(other.Lo - anchor.Hi) <= tolerance) return EdgeContact.After;
+        if (Math.Abs(other.Hi - anchor.Lo) <= tolerance) return EdgeContact.Before;
+        return EdgeContact.None;
+    }
+
+    /// <inheritdoc cref="ContactBetween(Interval,Interval,double)"/>
+    public static EdgeContact ContactBetween(Rect anchor, Rect other, Axis axis, double tolerance)
+        => ContactBetween(anchor.On(axis), other.On(axis), tolerance);
+}
+
+/// <summary>
+/// One monitor reduced to a single axis: the mm span of its panel and the pixel span the system
+/// gives that same panel. The two describe the same physical strip, so a coordinate can be
+/// carried from one to the other — which is the whole content of <see cref="EdgeProjection"/>.
+/// </summary>
+public readonly record struct AxisProfile(Interval Mm, Interval Pixel)
+{
+    /// <summary>Millimetres per pixel along this axis.</summary>
+    public double Pitch => Mm.Size / Pixel.Size;
+
+    /// <summary>A monitor reporting no pixels has nothing to be proportional to.</summary>
+    public bool HasPixels => Pixel.Size > 0;
+
+    public double ToPixel(double mm) => Pixel.Lo + (mm - Mm.Lo) / Pitch;
+
+    public double ToMm(double pixel) => Mm.Lo + (pixel - Pixel.Lo) * Pitch;
+
+    public AxisProfile AtMm(double lo) => this with { Mm = Mm.MovedTo(lo) };
+
+    public AxisProfile AtPixel(double lo) => this with { Pixel = Pixel.MovedTo(lo) };
+}
+
+/// <summary>
+/// The single invariant the two placement directions share, and the two ways to solve it.
+/// <para>
+/// When two monitors meet along an edge, their position on the perpendicular axis is fixed by
+/// requiring that <em>the physical midpoint of the span their panels share maps to the same
+/// coordinate on both</em> — the cursor crosses at that point without a jump, which is the least
+/// distortion obtainable without the engine running.
+/// </para>
+/// <para>
+/// "Place from system" knows both pixel positions and solves for the millimetre one;
+/// "apply to system" knows both millimetre positions and solves for the pixel one. Same
+/// equation, opposite unknown, and keeping the two literally the same expression is what makes
+/// a round trip through the pair land where it started instead of drifting on every pass.
+/// </para>
+/// </summary>
+public static class EdgeProjection
+{
+    /// <summary>
+    /// The millimetre-space solve is implicit — the shared span moves with the answer — so it is
+    /// iterated. The overlap can only change while the estimate crosses a span end, and each pass
+    /// settles the estimate that follows from the current one, so a handful of passes reach the
+    /// fixed point and further ones change nothing.
+    /// </summary>
+    const int SettlePasses = 4;
+
+    const double Settled = 1e-9;
+
+    /// <summary>
+    /// Pixel origin <paramref name="target"/> must take for the invariant to hold against
+    /// <paramref name="anchor"/>, whose own pixel origin is already known. Closed form: the mm
+    /// positions of both are given, so the shared span does not depend on the answer. Unrounded —
+    /// the caller decides, since the system only accepts integers.
+    /// </summary>
+    public static double PixelOrigin(AxisProfile anchor, AxisProfile target)
+    {
+        var mid = anchor.Mm.SharedMidpoint(target.Mm);
+        return anchor.ToPixel(mid) - (mid - target.Mm.Lo) / target.Pitch;
+    }
+
+    /// <summary>
+    /// Millimetre origin <paramref name="target"/> must take for the same invariant to hold, both
+    /// pixel origins being known this time.
+    /// <para>
+    /// Seeded from the pixel-space midpoint, which is always defined and is already the answer
+    /// whenever the two spans cover each other, then settled onto the millimetre-space midpoint —
+    /// the one <see cref="PixelOrigin"/> uses. Taking the pixel midpoint and stopping there is
+    /// closed-form and tempting, and it round-trips perfectly right up until two monitors have
+    /// very different pitches, which is the case this code exists for.
+    /// </para>
+    /// </summary>
+    public static double MillimetreOrigin(AxisProfile anchor, AxisProfile target)
+    {
+        var midPixel = anchor.Pixel.SharedMidpoint(target.Pixel);
+        var mm = anchor.ToMm(midPixel) - (midPixel - target.Pixel.Lo) * target.Pitch;
+
+        for (var pass = 0; pass < SettlePasses; pass++)
+        {
+            var mid = anchor.Mm.SharedMidpoint(target.AtMm(mm).Mm);
+            var next = mid - (anchor.ToPixel(mid) - target.Pixel.Lo) * target.Pitch;
+
+            if (Math.Abs(next - mm) < Settled) break;
+            mm = next;
+        }
+
+        return mm;
+    }
+}
+
+/// <summary>
+/// One monitor as the placement solvers see it: an identity, the millimetre rect of its panel
+/// (<c>DepthProjection.Bounds</c>), the millimetre rect including bezels
+/// (<c>DepthProjection.OutsideBounds</c>), the pixel rect the system positions it with
+/// (<c>ActiveSource.Source.InPixel.Bounds</c>) and whether it is the primary.
+/// <para>
+/// A plain record, so the geometry stays testable without building a reactive model graph, and
+/// so both directions can be fed the very same snapshot list — which is what a round-trip test
+/// needs. Each solver reads its own subset: "place from system" treats the pixel rect as the
+/// input and the mm origins as the answer, "apply to system" does the opposite and only needs
+/// the pixel <em>size</em>.
+/// </para>
+/// </summary>
+public sealed record MonitorSnapshot(
+    string Id,
+    Rect MmBounds,
+    Rect MmOutsideBounds,
+    Rect PixelBounds,
+    bool Primary)
+{
+    public Point MmLocation => MmBounds.Location;
+
+    public Size PixelSize => PixelBounds.Size;
+
+    public AxisProfile Profile(Axis axis) => new(MmBounds.On(axis), PixelBounds.On(axis));
+
+    /// <summary>The bezel between the panel and the outside rect, on the low side of this axis.</summary>
+    public double LowBorder(Axis axis) => MmBounds.On(axis).Lo - MmOutsideBounds.On(axis).Lo;
+
+    /// <summary>The same monitor with its panel origin moved to <paramref name="mm"/>, bezels following.</summary>
+    public MonitorSnapshot MovedTo(Point mm) => this with
+    {
+        MmBounds = new Rect(mm, MmBounds.Size),
+        MmOutsideBounds = MmOutsideBounds.Translated(mm.X - MmBounds.X, mm.Y - MmBounds.Y)
+    };
+
+    /// <summary>
+    /// The compaction view of this monitor. Compaction has no pixel dimension at all, so it keeps
+    /// its own input record rather than carry a field it must never read.
+    /// </summary>
+    public CompactionMonitor ForCompaction() => new(Id, MmBounds, MmOutsideBounds, Primary);
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorSnapshotExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorSnapshotExtensions.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using HLab.Geo;
+
+namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+/// <summary>
+/// The one place the reactive model is read into the plain records the solvers work on. Both
+/// placement directions come through here, so "what a snapshot of a monitor is" is stated once:
+/// the panel and bezel rects of its depth projection, and the pixel rect of its active source.
+/// </summary>
+public static class MonitorSnapshotExtensions
+{
+    /// <summary>
+    /// Snapshot <paramref name="monitor"/>. The caller decides which monitor is primary — the
+    /// layout's <c>PrimaryMonitor</c> and the source's <c>Primary</c> flag can disagree while a
+    /// layout is being rebuilt, and each direction anchors on the one it was given.
+    /// </summary>
+    /// <param name="pixelSize">
+    /// Substitute for the source's own pixel size, for the Wayland path that recomputes scales:
+    /// the monitor is to be positioned at the size it will have after the change, not the one it
+    /// has now.
+    /// </param>
+    public static MonitorSnapshot Snapshot(this PhysicalMonitor monitor, bool primary, Size? pixelSize = null)
+    {
+        var pixel = monitor.ActiveSource.Source.InPixel.Bounds;
+
+        return new MonitorSnapshot(
+            monitor.Id,
+            monitor.DepthProjection.Bounds,
+            monitor.DepthProjection.OutsideBounds,
+            pixelSize is { } size ? new Rect(pixel.Location, size) : pixel,
+            primary);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsFromSystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,10 +50,18 @@ public static class MonitorsLocationsFromSystemExtensions
     }
 
     /// <summary>
-    /// try to place windows according to windows placement
+    /// Try to place monitors according to the system's pixel configuration.
+    /// <para>
+    /// The geometry lives in <see cref="SystemLocationSolver"/>, a pure function over immutable
+    /// snapshots; this method only bridges it to the reactive model — snapshot, solve, apply,
+    /// then close whatever gaps the walk left. Same split as
+    /// <see cref="MonitorsLayout.ForceCompact"/> and <see cref="CompactionSolver"/>, and for the
+    /// same reasons: the placement rules can be tested without a reactive graph, and each
+    /// monitor is written at most once instead of once per intermediate rule.
+    /// </para>
     /// </summary>
     /// <param name="layout"></param>
-    /// <param name="placeAll">reset already placed windows</param>
+    /// <param name="placeAll">reset already placed monitors</param>
     public static void SetLocationsFromSystemConfiguration(this IMonitorsLayout layout, bool placeAll = true)
     {
         var primarySource = layout.PrimarySource;
@@ -62,141 +70,36 @@ public static class MonitorsLocationsFromSystemExtensions
 
         lock (CompactLock)
         {
-            // List all display not positioned
-            var unplacedScreens = placeAll ? layout.PhysicalMonitors.ToList() : layout.PhysicalMonitors.Where(s => !s.Placed).ToList();
+            // A monitor with no active source has no pixel rect to place it from: it goes
+            // through the walk as neither an anchor nor a candidate. Layouts are built one
+            // monitor at a time and this runs on the result, so the half-built states are
+            // reachable and must not take the whole placement down with them.
+            var monitors = layout.PhysicalMonitors.Where(m => m.ActiveSource?.Source != null).ToList();
+
+            // List all displays not positioned
+            var toPlace = (placeAll ? monitors : monitors.Where(m => !m.Placed))
+                .Select(m => m.Id)
+                .ToHashSet();
 
             // Nothing to place: leave the layout untouched — the final compact would
             // otherwise reshape a layout the user deliberately saved.
-            if (unplacedScreens.Count == 0) return;
+            if (toPlace.Count == 0) return;
 
-            // start with primary display
-            Queue<PhysicalMonitor> todo = new();
-            todo.Enqueue(primaryMonitor);
+            var snapshot = monitors
+                .Select(m => m.Snapshot(ReferenceEquals(m, primaryMonitor)))
+                .ToList();
 
-            while (todo.Count > 0)
+            var positions = SystemLocationSolver.Solve(snapshot, toPlace);
+
+            foreach (var monitor in monitors)
             {
-                foreach (var monitor in todo)
+                if (!positions.TryGetValue(monitor.Id, out var position)) continue;
+
+                var projection = monitor.DepthProjection;
+                using (projection.DelayChangeNotifications())
                 {
-                    unplacedScreens.Remove(monitor);
-                }
-
-                var placedScreen = todo.Dequeue();
-
-                foreach (var screenToPlace in unplacedScreens.ToList())
-                {
-                    if (screenToPlace == placedScreen) continue;
-
-                    // Only a real pixel-space edge adjacency PLACES a monitor. The
-                    // alignment equalities below (same X/Y/Right/Bottom) are hints:
-                    // applying them must not consume the monitor, or a monitor whose
-                    // only adjacency is with a later-placed neighbour never gets its
-                    // adjacency rule tested (e.g. P|S|H side by side: H aligned on P
-                    // by Y equality used to be swallowed before S could claim it).
-                    var adjacent = false;
-                    // Which axis the contact is on. The other one is not a matter of
-                    // luck: it is computed below, and must not be left to whichever
-                    // alignment equality happens to hold.
-                    var horizontalContact = false;
-                    var verticalContact = false;
-
-                    //     __
-                    //  __| A
-                    // B  |__
-                    //  __|
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.X == placedScreen.ActiveSource.Source.InPixel.Bounds.Right)
-                    {
-                        screenToPlace.DepthProjection.X = placedScreen.DepthProjection.OutsideBounds.Right + screenToPlace.DepthProjection.LeftBorder;
-                        adjacent = true;
-                        horizontalContact = true;
-                    }
-                    //B |___|_
-                    //A  |    |
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Y == placedScreen.ActiveSource.Source.InPixel.Bounds.Bottom)
-                    {
-                        screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.OutsideBounds.Bottom + screenToPlace.DepthProjection.TopBorder;
-                        adjacent = true;
-                        verticalContact = true;
-                    }
-
-                    //     __
-                    //  __| B
-                    // A  |__
-                    //  __|
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Right == placedScreen.ActiveSource.Source.InPixel.Bounds.X)
-                    {
-                        screenToPlace.DepthProjection.X = placedScreen.DepthProjection.OutsideBounds.Left -
-                            screenToPlace.DepthProjection.OutsideBounds.Width + screenToPlace.DepthProjection.LeftBorder;
-                        adjacent = true;
-                        horizontalContact = true;
-                    }
-
-                    //A |___|_
-                    //B  |    |
-
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Bottom == placedScreen.ActiveSource.Source.InPixel.Y)
-                    {
-                        screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.OutsideBounds.Top -
-                            screenToPlace.DepthProjection.OutsideBounds.Height + screenToPlace.DepthProjection.TopBorder;
-                        adjacent = true;
-                        verticalContact = true;
-                    }
-
-
-                    //  __
-                    // |
-                    // |__
-                    //  __
-                    // |
-                    // |__
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.X == placedScreen.ActiveSource.Source.InPixel.Bounds.X)
-                    {
-                        screenToPlace.DepthProjection.X = placedScreen.DepthProjection.X;
-                    }
-
-                    //  ___   ___
-                    // |   | |   |
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Y == placedScreen.ActiveSource.Source.InPixel.Bounds.Y)
-                    {
-                        screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.Y;
-                    }
-
-                    // __
-                    //   |
-                    // __|
-                    // __
-                    //   |
-                    // __|
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Right == placedScreen.ActiveSource.Source.InPixel.Bounds.Right)
-                    {
-                        screenToPlace.DepthProjection.X = placedScreen.DepthProjection.Bounds.Right - screenToPlace.DepthProjection.Bounds.Width;
-                    }
-
-                    //|___||___|
-                    if (screenToPlace.ActiveSource.Source.InPixel.Bounds.Bottom == placedScreen.ActiveSource.Source.InPixel.Bounds.Bottom)
-                    {
-                        screenToPlace.DepthProjection.Y = placedScreen.DepthProjection.Bounds.Bottom -
-                                               screenToPlace.DepthProjection.Bounds.Height;
-                    }
-                    // The offset along the contact edge. Last, so it overrides the
-                    // alignment equalities above: those only fire on an exact match, and
-                    // a monitor sitting 219px higher than its neighbour matches none of
-                    // them — it used to keep whatever it had and be shoved by the
-                    // compact, landing a whole screen height away.
-                    if (horizontalContact) PlaceAlongEdge(placedScreen, screenToPlace, vertical: true);
-                    if (verticalContact) PlaceAlongEdge(placedScreen, screenToPlace, vertical: false);
-
-                    if (adjacent)
-                    {
-                        unplacedScreens.Remove(screenToPlace);
-                        // No compacting here. Every monitor not yet reached is still
-                        // stacked at the origin, so a compact run mid-walk resolves
-                        // overlaps against screens that have no position yet — and shoves
-                        // the ones just placed correctly out of the way. It is why
-                        // running this twice used to give a better answer than running it
-                        // once: the second pass started from a layout that was already
-                        // spread out, so the same compacts found nothing to do.
-                        todo.Enqueue(screenToPlace);
-                    }
+                    projection.X = position.X;
+                    projection.Y = position.Y;
                 }
             }
 
@@ -206,76 +109,5 @@ public static class MonitorsLocationsFromSystemExtensions
         }
 
         layout.UpdatePhysicalMonitors();
-    }
-
-    /// <summary>
-    /// Position <paramref name="toPlace"/> along the edge it shares with
-    /// <paramref name="placed"/> — the axis the contact is not on.
-    /// <para>
-    /// Exactly the inverse of <see cref="PixelLocationSolver"/>'s rule, and deliberately
-    /// so: there, the physical midpoint of the shared span projects to the same pixel on
-    /// both monitors. Here the same invariant is solved the other way round, which is
-    /// what makes "apply to system" and "place from system" round-trip instead of
-    /// drifting a little further apart on each pass.
-    /// </para>
-    /// <para>
-    /// The midpoint is taken in MILLIMETRE space, as the inverse takes it, and that
-    /// makes it implicit: the shared span depends on the position being solved for. It
-    /// is settled by iterating from a pixel-space estimate — the overlap only shifts
-    /// when one monitor's span stops covering the other's end, so a couple of passes
-    /// reach the fixed point and further ones change nothing. Taking the pixel midpoint
-    /// instead is closed-form and tempting, and it round-trips perfectly right up until
-    /// two monitors have very different pitches, which is the case this whole file
-    /// exists for.
-    /// </para>
-    /// </summary>
-    static void PlaceAlongEdge(PhysicalMonitor placed, PhysicalMonitor toPlace, bool vertical)
-    {
-        var placedPx = placed.ActiveSource.Source.InPixel.Bounds;
-        var toPlacePx = toPlace.ActiveSource.Source.InPixel.Bounds;
-
-        // Pixels map to the panel, not to the bezel around it.
-        var placedMm = placed.DepthProjection.Bounds;
-        var toPlaceMm = toPlace.DepthProjection.Bounds;
-
-        var (placedPxLo, placedPxSize) = vertical
-            ? (placedPx.Y, placedPx.Height)
-            : (placedPx.X, placedPx.Width);
-        var (toPlacePxLo, toPlacePxSize) = vertical
-            ? (toPlacePx.Y, toPlacePx.Height)
-            : (toPlacePx.X, toPlacePx.Width);
-        var (placedMmLo, placedMmSize) = vertical
-            ? (placedMm.Y, placedMm.Height)
-            : (placedMm.X, placedMm.Width);
-        var toPlaceMmSize = vertical ? toPlaceMm.Height : toPlaceMm.Width;
-
-        // A monitor reporting no pixels has nothing to be proportional to.
-        if (placedPxSize <= 0 || toPlacePxSize <= 0) return;
-
-        var pitchPlaced = placedMmSize / placedPxSize;
-        var pitchToPlace = toPlaceMmSize / toPlacePxSize;
-
-        // Seed from the pixel-space midpoint: always defined, and already the answer
-        // whenever the two spans cover each other.
-        var sharedPxLo = Math.Max(placedPxLo, toPlacePxLo);
-        var sharedPxHi = Math.Min(placedPxLo + placedPxSize, toPlacePxLo + toPlacePxSize);
-        var midPx = (sharedPxLo + sharedPxHi) / 2;
-        var mm = placedMmLo
-                 + (midPx - placedPxLo) * pitchPlaced
-                 - (midPx - toPlacePxLo) * pitchToPlace;
-
-        // Then settle on the millimetre-space midpoint, which is what the inverse uses.
-        // Four passes: the overlap can only change while the estimate crosses a span
-        // end, and each pass fixes the estimate that follows from the current one.
-        for (var pass = 0; pass < 4; pass++)
-        {
-            var mid = (Math.Max(placedMmLo, mm) + Math.Min(placedMmLo + placedMmSize, mm + toPlaceMmSize)) / 2;
-            var next = mid - pitchToPlace * (placedPxLo - toPlacePxLo + (mid - placedMmLo) / pitchPlaced);
-            if (Math.Abs(next - mm) < 1e-9) break;
-            mm = next;
-        }
-
-        if (vertical) toPlace.DepthProjection.Y = mm;
-        else toPlace.DepthProjection.X = mm;
     }
 }

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsToSystemExtensions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/MonitorsLocationsToSystemExtensions.cs
@@ -6,248 +6,8 @@ using HLab.Geo;
 
 namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
 
-/// <summary>
-/// Solver input: one system-positionable monitor. Mm rects come from DepthProjection
-/// (Bounds = panel, OutsideBounds = with bezels); PixelSize is the size the OS positions
-/// with (logical pixels on Wayland, physical pixels on Windows/X11).
-/// Plain record so the solver stays testable without the reactive model graph.
-/// </summary>
-public sealed record PixelPlacementMonitor(
-    string Id,
-    Rect MmBounds,
-    Rect MmOutsideBounds,
-    Size PixelSize,
-    bool Primary);
-
 /// <summary>Result of <see cref="MonitorsLocationsToSystemExtensions.ComputePixelLocationsFromPhysical"/> for one source.</summary>
 public sealed record SystemPlacement(Rect PixelBounds, double? Scale);
-
-/// <summary>
-/// Inverse of <see cref="MonitorsLocationsFromSystemExtensions.SetLocationsFromSystemConfiguration"/>:
-/// derive integer system pixel positions from the physical (mm) layout. The system knows
-/// neither bezels nor exact scales, so physical adjacency becomes exact pixel edge contact,
-/// and on the perpendicular axis the physical midpoint of the shared span projects to the
-/// same pixel coordinate on both sides (least cursor-crossing distortion without the engine).
-/// </summary>
-public static class PixelLocationSolver
-{
-    /// <summary>
-    /// Physical gaps up to this count as adjacent: bezel measurements are hand-entered,
-    /// so touching monitors rarely land at exactly 0mm.
-    /// </summary>
-    public const double DefaultToleranceMm = 5.0;
-
-    public static IReadOnlyDictionary<string, Point> Solve(
-        IReadOnlyList<PixelPlacementMonitor> monitors,
-        double toleranceMm = DefaultToleranceMm)
-    {
-        var placed = new Dictionary<string, Rect>();
-        if (monitors.Count == 0) return new Dictionary<string, Point>();
-
-        var primary = monitors.FirstOrDefault(m => m.Primary) ?? monitors[0];
-        var order = new List<PixelPlacementMonitor>();
-
-        void Place(PixelPlacementMonitor m, Point pos)
-        {
-            placed[m.Id] = new Rect(new Point(Math.Round(pos.X), Math.Round(pos.Y)), m.PixelSize);
-            order.Add(m);
-        }
-
-        Place(primary, new Point(0, 0));
-
-        // Spanning tree over physical adjacency: first placement wins, grid cycles are
-        // reconciled by the overlap pass below.
-        var todo = new Queue<PixelPlacementMonitor>();
-        todo.Enqueue(primary);
-        while (todo.Count > 0)
-        {
-            var a = todo.Dequeue();
-            foreach (var b in monitors)
-            {
-                if (placed.ContainsKey(b.Id)) continue;
-                if (!TryPlaceAdjacent(a, placed[a.Id], b, toleranceMm, out var pos)) continue;
-                Place(b, pos);
-                todo.Enqueue(b);
-            }
-        }
-
-        // Physically detached islands: keep their mm arrangement at the primary's pitch,
-        // then snap into contact — Windows requires a connected desktop, and on KWin a
-        // gap makes the edge uncrossable without the engine.
-        var pitchPrimary = Pitch(primary);
-        foreach (var b in monitors
-                     .Where(m => !placed.ContainsKey(m.Id))
-                     .OrderBy(m => m.MmOutsideBounds.DistanceToTouch(placed.Values.Select(FromPixels(m))).DistanceHV())
-                     .ToList())
-        {
-            var estimate = new Rect(new Point(
-                Math.Round((b.MmBounds.X - primary.MmBounds.X) / pitchPrimary.X),
-                Math.Round((b.MmBounds.Y - primary.MmBounds.Y) / pitchPrimary.Y)), b.PixelSize);
-            Place(b, SnapToTouch(estimate, placed.Values.ToList()).Location);
-        }
-
-        // Rounding and inconsistent cycle constraints can leave small overlaps: push each
-        // monitor (placement order, never the primary) out of the ones placed before it.
-        for (var i = 1; i < order.Count; i++)
-        {
-            var others = order.Take(i).Select(m => placed[m.Id]).ToList();
-            placed[order[i].Id] = ResolveOverlap(placed[order[i].Id], others);
-        }
-
-        // Re-anchor: repairs only move non-primary monitors, but keep the invariant hard.
-        var origin = placed[primary.Id].Location;
-        return monitors.Where(m => placed.ContainsKey(m.Id)).ToDictionary(
-            m => m.Id,
-            m => new Point(placed[m.Id].X - origin.X, placed[m.Id].Y - origin.Y));
-    }
-
-    static Point Pitch(PixelPlacementMonitor m) => new(
-        m.MmBounds.Width / m.PixelSize.Width,
-        m.MmBounds.Height / m.PixelSize.Height);
-
-    /// <summary>
-    /// Island ordering needs mm-space distances to the already-placed group, but the
-    /// group is stored in pixels: scale each placed rect back to mm through the island's
-    /// own pitch — only the relative order matters, not the exact value.
-    /// </summary>
-    static Func<Rect, Rect> FromPixels(PixelPlacementMonitor m)
-    {
-        var pitch = Pitch(m);
-        return r => new Rect(r.X * pitch.X, r.Y * pitch.Y, r.Width * pitch.X, r.Height * pitch.Y);
-    }
-
-    static bool TryPlaceAdjacent(
-        PixelPlacementMonitor a, Rect aPx,
-        PixelPlacementMonitor b, double tolerance,
-        out Point pos)
-    {
-        var oa = a.MmOutsideBounds;
-        var ob = b.MmOutsideBounds;
-
-        var verticalOverlap = Math.Min(oa.Bottom, ob.Bottom) - Math.Max(oa.Y, ob.Y) > 0;
-        var horizontalOverlap = Math.Min(oa.Right, ob.Right) - Math.Max(oa.X, ob.X) > 0;
-
-        if (verticalOverlap && Math.Abs(ob.X - oa.Right) <= tolerance)
-        {
-            pos = new Point(aPx.Right, PerpendicularOffset(a, aPx.Y, b, vertical: true));
-            return true;
-        }
-        if (verticalOverlap && Math.Abs(oa.X - ob.Right) <= tolerance)
-        {
-            pos = new Point(aPx.X - b.PixelSize.Width, PerpendicularOffset(a, aPx.Y, b, vertical: true));
-            return true;
-        }
-        if (horizontalOverlap && Math.Abs(ob.Y - oa.Bottom) <= tolerance)
-        {
-            pos = new Point(PerpendicularOffset(a, aPx.X, b, vertical: false), aPx.Bottom);
-            return true;
-        }
-        if (horizontalOverlap && Math.Abs(oa.Y - ob.Bottom) <= tolerance)
-        {
-            pos = new Point(PerpendicularOffset(a, aPx.X, b, vertical: false), aPx.Y - b.PixelSize.Height);
-            return true;
-        }
-
-        pos = default;
-        return false;
-    }
-
-    /// <summary>
-    /// Perpendicular coordinate of b so that the physical midpoint of the shared span maps
-    /// to the same pixel on both monitors. Shared span is taken on the panels (pixels do
-    /// not cover bezels); when only the bezels overlap the midpoint between the two panel
-    /// spans is still the right anchor, so no special case is needed.
-    /// </summary>
-    static double PerpendicularOffset(PixelPlacementMonitor a, double aPxOrigin, PixelPlacementMonitor b, bool vertical)
-    {
-        double aLo, aSize, bLo, bSize, aPxSize, bPxSize;
-        if (vertical)
-        {
-            (aLo, aSize, aPxSize) = (a.MmBounds.Y, a.MmBounds.Height, a.PixelSize.Height);
-            (bLo, bSize, bPxSize) = (b.MmBounds.Y, b.MmBounds.Height, b.PixelSize.Height);
-        }
-        else
-        {
-            (aLo, aSize, aPxSize) = (a.MmBounds.X, a.MmBounds.Width, a.PixelSize.Width);
-            (bLo, bSize, bPxSize) = (b.MmBounds.X, b.MmBounds.Width, b.PixelSize.Width);
-        }
-
-        var mid = (Math.Max(aLo, bLo) + Math.Min(aLo + aSize, bLo + bSize)) / 2;
-
-        var pitchA = aSize / aPxSize;
-        var pitchB = bSize / bPxSize;
-
-        return Math.Round(aPxOrigin + (mid - aLo) / pitchA - (mid - bLo) / pitchB);
-    }
-
-    /// <summary>
-    /// Snap a detached island into contact: slide into the group band when no single
-    /// translation can touch, then translate by the smallest positive distance. Results stay
-    /// integer because inputs are integer.
-    /// </summary>
-    static Rect SnapToTouch(Rect rect, List<Rect> others)
-    {
-        var distance = rect.DistanceToTouch(others, true);
-
-        if (distance.IsPositiveInfinity())
-        {
-            var left = others.Min(r => r.X);
-            var top = others.Min(r => r.Y);
-            var right = others.Max(r => r.Right);
-            var bottom = others.Max(r => r.Bottom);
-
-            var toLeft = left - rect.Right;
-            var toTop = top - rect.Bottom;
-            var toRight = rect.X - right;
-            var toBottom = rect.Y - bottom;
-
-            // Slide along the axis with the smaller gap so the rect straddles the group
-            // band, then one translation on the other axis touches.
-            if (Math.Max(toLeft, toRight) <= Math.Max(toTop, toBottom))
-                rect.X = toLeft >= toRight ? left - Math.Round(rect.Width / 2) : right - Math.Round(rect.Width / 2);
-            else
-                rect.Y = toTop >= toBottom ? top - Math.Round(rect.Height / 2) : bottom - Math.Round(rect.Height / 2);
-
-            distance = rect.DistanceToTouch(others, true);
-        }
-
-        var min = distance.MinPositive();
-        if (min > 0 && !double.IsInfinity(min))
-        {
-            if (distance.Left > 0 && distance.Left <= min) rect.X -= distance.Left;
-            else if (distance.Top > 0 && distance.Top <= min) rect.Y -= distance.Top;
-            else if (distance.Right > 0 && distance.Right <= min) rect.X += distance.Right;
-            else if (distance.Bottom > 0 && distance.Bottom <= min) rect.Y += distance.Bottom;
-        }
-
-        return ResolveOverlap(rect, others);
-    }
-
-    static Rect ResolveOverlap(Rect rect, List<Rect> others)
-    {
-        // Each push is along one axis by the smallest amount; a few iterations settle
-        // rounding-sized overlaps, the bound only guards against pathological inputs.
-        for (var i = 0; i < 8; i++)
-        {
-            var conflict = others.FirstOrDefault(r =>
-                Math.Min(r.Right, rect.Right) - Math.Max(r.X, rect.X) > 0 &&
-                Math.Min(r.Bottom, rect.Bottom) - Math.Max(r.Y, rect.Y) > 0);
-            if (conflict.IsEmpty || conflict is { Width: 0, Height: 0 }) break;
-
-            var moves = new (double Amount, bool Horizontal)[]
-            {
-                (conflict.X - rect.Right, true),
-                (conflict.Right - rect.X, true),
-                (conflict.Y - rect.Bottom, false),
-                (conflict.Bottom - rect.Y, false),
-            };
-            var best = moves.OrderBy(m => Math.Abs(m.Amount)).First();
-            if (best.Horizontal) rect.X += best.Amount;
-            else rect.Y += best.Amount;
-        }
-        return rect;
-    }
-}
 
 public static class MonitorsLocationsToSystemExtensions
 {
@@ -257,6 +17,11 @@ public static class MonitorsLocationsToSystemExtensions
     /// logical pixel covers the same physical size everywhere (the primary's current logical
     /// pitch), quantized to 1/120 — the fractional-scale protocol unit KWin rounds to.
     /// Scale is null when unchanged; Windows callers ignore it entirely.
+    /// <para>
+    /// The geometry lives in <see cref="PixelLocationSolver"/>; this method snapshots the
+    /// reactive model, works out the pixel size each monitor will have after the change, solves,
+    /// and hands the result back keyed by source.
+    /// </para>
     /// </summary>
     public static Dictionary<DisplaySource, SystemPlacement> ComputePixelLocationsFromPhysical(
         this IMonitorsLayout layout, bool adjustScale = false)
@@ -271,7 +36,7 @@ public static class MonitorsLocationsToSystemExtensions
             .ToList();
         if (monitors.Count == 0) return result;
 
-        var inputs = new List<PixelPlacementMonitor>();
+        var inputs = new List<MonitorSnapshot>();
         var sizes = new Dictionary<string, (DisplaySource Source, Size PixelSize, double? Scale)>();
 
         // The primary's logical pitch (mm per logical pixel) is the homogeneity target:
@@ -302,12 +67,7 @@ public static class MonitorsLocationsToSystemExtensions
                 }
             }
 
-            inputs.Add(new PixelPlacementMonitor(
-                monitor.Id,
-                monitor.DepthProjection.Bounds,
-                monitor.DepthProjection.OutsideBounds,
-                pixelSize,
-                monitor == primary));
+            inputs.Add(monitor.Snapshot(ReferenceEquals(monitor, primary), pixelSize));
             sizes[monitor.Id] = (source, pixelSize, newScale);
         }
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/PixelLocationSolver.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/PixelLocationSolver.cs
@@ -1,0 +1,219 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HLab.Geo;
+
+namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+/// <summary>
+/// Inverse of <see cref="SystemLocationSolver"/>: derive integer system pixel positions from the
+/// physical (mm) layout. The system knows neither bezels nor exact scales, so physical adjacency
+/// becomes exact pixel edge contact, and on the perpendicular axis the shared-span invariant of
+/// <see cref="EdgeProjection"/> is solved the other way round — which is what makes a round trip
+/// through the two directions land where it started.
+///
+/// Reads the millimetre rects of each <see cref="MonitorSnapshot"/> and only the SIZE of its
+/// pixel rect: the pixel positions are the answer, not an input.
+/// </summary>
+public static class PixelLocationSolver
+{
+    /// <summary>
+    /// Physical gaps up to this count as adjacent: bezel measurements are hand-entered,
+    /// so touching monitors rarely land at exactly 0mm.
+    /// </summary>
+    public const double DefaultToleranceMm = 5.0;
+
+    public static IReadOnlyDictionary<string, Point> Solve(
+        IReadOnlyList<MonitorSnapshot> monitors,
+        double toleranceMm = DefaultToleranceMm)
+    {
+        var placed = new Dictionary<string, Rect>();
+        if (monitors.Count == 0) return new Dictionary<string, Point>();
+
+        var primary = monitors.FirstOrDefault(m => m.Primary) ?? monitors[0];
+        var order = new List<MonitorSnapshot>();
+
+        void Place(MonitorSnapshot m, Point pos)
+        {
+            placed[m.Id] = new Rect(new Point(Math.Round(pos.X), Math.Round(pos.Y)), m.PixelSize);
+            order.Add(m);
+        }
+
+        Place(primary, new Point(0, 0));
+
+        // Spanning tree over physical adjacency: first placement wins, grid cycles are
+        // reconciled by the overlap pass below.
+        var todo = new Queue<MonitorSnapshot>();
+        todo.Enqueue(primary);
+        while (todo.Count > 0)
+        {
+            var a = todo.Dequeue();
+            foreach (var b in monitors)
+            {
+                if (placed.ContainsKey(b.Id)) continue;
+                if (!TryPlaceAdjacent(a, placed[a.Id], b, toleranceMm, out var pos)) continue;
+                Place(b, pos);
+                todo.Enqueue(b);
+            }
+        }
+
+        // Physically detached islands: keep their mm arrangement at the primary's pitch,
+        // then snap into contact — Windows requires a connected desktop, and on KWin a
+        // gap makes the edge uncrossable without the engine.
+        var pitchPrimary = Pitch(primary);
+        foreach (var b in monitors
+                     .Where(m => !placed.ContainsKey(m.Id))
+                     .OrderBy(m => m.MmOutsideBounds.DistanceToTouch(placed.Values.Select(FromPixels(m))).DistanceHV())
+                     .ToList())
+        {
+            var estimate = new Rect(new Point(
+                Math.Round((b.MmBounds.X - primary.MmBounds.X) / pitchPrimary.X),
+                Math.Round((b.MmBounds.Y - primary.MmBounds.Y) / pitchPrimary.Y)), b.PixelSize);
+            Place(b, SnapToTouch(estimate, placed.Values.ToList()).Location);
+        }
+
+        // Rounding and inconsistent cycle constraints can leave small overlaps: push each
+        // monitor (placement order, never the primary) out of the ones placed before it.
+        for (var i = 1; i < order.Count; i++)
+        {
+            var others = order.Take(i).Select(m => placed[m.Id]).ToList();
+            placed[order[i].Id] = ResolveOverlap(placed[order[i].Id], others);
+        }
+
+        // Re-anchor: repairs only move non-primary monitors, but keep the invariant hard.
+        var origin = placed[primary.Id].Location;
+        return monitors.Where(m => placed.ContainsKey(m.Id)).ToDictionary(
+            m => m.Id,
+            m => new Point(placed[m.Id].X - origin.X, placed[m.Id].Y - origin.Y));
+    }
+
+    static Point Pitch(MonitorSnapshot m) => new(
+        m.Profile(Axis.Horizontal).Pitch,
+        m.Profile(Axis.Vertical).Pitch);
+
+    /// <summary>
+    /// Island ordering needs mm-space distances to the already-placed group, but the
+    /// group is stored in pixels: scale each placed rect back to mm through the island's
+    /// own pitch — only the relative order matters, not the exact value.
+    /// </summary>
+    static Func<Rect, Rect> FromPixels(MonitorSnapshot m)
+    {
+        var pitch = Pitch(m);
+        return r => new Rect(r.X * pitch.X, r.Y * pitch.Y, r.Width * pitch.X, r.Height * pitch.Y);
+    }
+
+    /// <summary>
+    /// Where <paramref name="b"/> goes if it is docked against <paramref name="a"/>: the bezels
+    /// meet within tolerance on one axis, the panels genuinely overlap on the other. The axis
+    /// carrying the contact fixes one coordinate exactly, the other comes from
+    /// <see cref="PerpendicularOffset"/>.
+    /// </summary>
+    static bool TryPlaceAdjacent(
+        MonitorSnapshot a, Rect aPx,
+        MonitorSnapshot b, double tolerance,
+        out Point pos)
+    {
+        foreach (var axis in Axes)
+        {
+            // A shared edge with no overlap across it is a corner meeting, which the cursor
+            // cannot cross.
+            if (LayoutGeometry.OverlapOn(a.MmOutsideBounds, b.MmOutsideBounds, axis.Perpendicular()) <= 0) continue;
+
+            var contact = LayoutGeometry.ContactBetween(a.MmOutsideBounds, b.MmOutsideBounds, axis, tolerance);
+            if (contact == EdgeContact.None) continue;
+
+            var anchorPx = aPx.On(axis);
+            var lo = contact == EdgeContact.After ? anchorPx.Hi : anchorPx.Lo - b.PixelBounds.On(axis).Size;
+
+            pos = Origin(axis, lo, PerpendicularOffset(a, aPx, b, axis.Perpendicular()));
+            return true;
+        }
+
+        pos = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Perpendicular coordinate of b so that the physical midpoint of the shared span maps
+    /// to the same pixel on both monitors. Shared span is taken on the panels (pixels do
+    /// not cover bezels); when only the bezels overlap the midpoint between the two panel
+    /// spans is still the right anchor, so no special case is needed.
+    /// </summary>
+    static double PerpendicularOffset(MonitorSnapshot a, Rect aPx, MonitorSnapshot b, Axis axis)
+        => Math.Round(EdgeProjection.PixelOrigin(
+            a.Profile(axis).AtPixel(aPx.On(axis).Lo),
+            b.Profile(axis)));
+
+    static Point Origin(Axis axis, double along, double across) => axis == Axis.Horizontal
+        ? new Point(along, across)
+        : new Point(across, along);
+
+    static readonly Axis[] Axes = [Axis.Horizontal, Axis.Vertical];
+
+    /// <summary>
+    /// Snap a detached island into contact: slide into the group band when no single
+    /// translation can touch, then translate by the smallest positive distance. Results stay
+    /// integer because inputs are integer.
+    /// </summary>
+    static Rect SnapToTouch(Rect rect, List<Rect> others)
+    {
+        var distance = rect.DistanceToTouch(others, true);
+
+        if (distance.IsPositiveInfinity())
+        {
+            var left = others.Min(r => r.X);
+            var top = others.Min(r => r.Y);
+            var right = others.Max(r => r.Right);
+            var bottom = others.Max(r => r.Bottom);
+
+            var toLeft = left - rect.Right;
+            var toTop = top - rect.Bottom;
+            var toRight = rect.X - right;
+            var toBottom = rect.Y - bottom;
+
+            // Slide along the axis with the smaller gap so the rect straddles the group
+            // band, then one translation on the other axis touches.
+            if (Math.Max(toLeft, toRight) <= Math.Max(toTop, toBottom))
+                rect.X = toLeft >= toRight ? left - Math.Round(rect.Width / 2) : right - Math.Round(rect.Width / 2);
+            else
+                rect.Y = toTop >= toBottom ? top - Math.Round(rect.Height / 2) : bottom - Math.Round(rect.Height / 2);
+
+            distance = rect.DistanceToTouch(others, true);
+        }
+
+        var min = distance.MinPositive();
+        if (min > 0 && !double.IsInfinity(min))
+        {
+            if (distance.Left > 0 && distance.Left <= min) rect.X -= distance.Left;
+            else if (distance.Top > 0 && distance.Top <= min) rect.Y -= distance.Top;
+            else if (distance.Right > 0 && distance.Right <= min) rect.X += distance.Right;
+            else if (distance.Bottom > 0 && distance.Bottom <= min) rect.Y += distance.Bottom;
+        }
+
+        return ResolveOverlap(rect, others);
+    }
+
+    static Rect ResolveOverlap(Rect rect, List<Rect> others)
+    {
+        // Each push is along one axis by the smallest amount; a few iterations settle
+        // rounding-sized overlaps, the bound only guards against pathological inputs.
+        for (var i = 0; i < 8; i++)
+        {
+            var conflict = others.FirstOrDefault(r => LayoutGeometry.Overlap(r, rect));
+            if (conflict.IsEmpty || conflict is { Width: 0, Height: 0 }) break;
+
+            var moves = new (double Amount, bool Horizontal)[]
+            {
+                (conflict.X - rect.Right, true),
+                (conflict.Right - rect.X, true),
+                (conflict.Y - rect.Bottom, false),
+                (conflict.Bottom - rect.Y, false),
+            };
+            var best = moves.OrderBy(m => Math.Abs(m.Amount)).First();
+            if (best.Horizontal) rect.X += best.Amount;
+            else rect.Y += best.Amount;
+        }
+        return rect;
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/SystemLocationSolver.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/SystemLocationSolver.cs
@@ -104,10 +104,12 @@ public static class SystemLocationSolver
     /// Everything one already-placed monitor says about where another one goes, and whether that
     /// amounts to claiming it.
     /// <para>
-    /// Only a real pixel-space edge adjacency PLACES a monitor. The alignment equalities are
-    /// hints: applying them must not consume the monitor, or a monitor whose only adjacency is
-    /// with a later-placed neighbour never gets its adjacency rule tested (e.g. P|S|H side by
-    /// side: H aligned on P by Y equality used to be swallowed before S could claim it).
+    /// Only a crossable pixel-space edge adjacency PLACES a monitor — one the two actually
+    /// straddle, a shared corner not counting. Everything else here is a hint: applying a hint
+    /// must not consume the monitor, or one whose only real adjacency is with a later-placed
+    /// neighbour never gets its adjacency rule tested (e.g. P|S|H side by side: H aligned on P by
+    /// Y equality used to be swallowed before S could claim it; and the diagonal of a 2x2 grid,
+    /// claimed by the primary on both axes at once, used to be dragged into the primary's bezels).
     /// </para>
     /// <para>
     /// Contact rule, then alignment hints, then edge projection — each stage overwriting the
@@ -137,8 +139,9 @@ public static class SystemLocationSolver
     }
 
     /// <summary>
-    /// The contact rule and the two alignment hints on one axis. Returns whether the contact
-    /// rule fired, which is the only thing that claims the monitor.
+    /// The contact rule and the two alignment hints on one axis. Returns whether a CROSSABLE
+    /// contact fired, which is the only thing that claims the monitor — every rule here suggests
+    /// a position, none of the others consumes the target.
     /// </summary>
     static bool Claim(MonitorSnapshot anchor, MonitorSnapshot target, Axis axis, ref Point position)
     {
@@ -150,6 +153,16 @@ public static class SystemLocationSolver
         // B  |__       transposes
         //  __|
         var contact = LayoutGeometry.ContactBetween(anchor.PixelBounds, target.PixelBounds, axis, PixelTolerance);
+
+        // A shared edge the two monitors do not straddle is a corner meeting, and the cursor has
+        // nowhere to cross it — the same rule <see cref="PixelLocationSolver.TryPlaceAdjacent"/>
+        // applies in the other direction. The contact still SUGGESTS a position, so a monitor
+        // whose only neighbour is diagonal keeps landing on that diagonal rather than staying
+        // stacked at the origin, but it no longer claims: claiming on both axes at once is what
+        // used to let the two perpendicular projections overwrite each other's coordinate and
+        // pull a diagonal neighbour panel-flush into its anchor's bezels.
+        var crossable = LayoutGeometry.OverlapOn(anchor.PixelBounds, target.PixelBounds, axis.Perpendicular()) > 0;
+
         var outside = anchor.MmOutsideBounds.On(axis);
 
         position = contact switch
@@ -175,7 +188,7 @@ public static class SystemLocationSolver
         if (targetPixel.Hi == anchorPixel.Hi)
             position = position.With(axis, anchorPanel.Hi - target.MmBounds.On(axis).Size);
 
-        return contact != EdgeContact.None;
+        return contact != EdgeContact.None && crossable;
     }
 
     /// <summary>Solve the shared-midpoint invariant along <paramref name="axis"/>.</summary>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/SystemLocationSolver.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/Extensions/SystemLocationSolver.cs
@@ -1,0 +1,195 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using HLab.Geo;
+
+namespace LittleBigMouse.DisplayLayout.Monitors.Extensions;
+
+/// <summary>
+/// Inverse of <see cref="PixelLocationSolver"/>: derive the physical (mm) layout from the pixel
+/// configuration the system reports. Walks out from the primary over pixel-space edge adjacency
+/// and turns each contact into a millimetre position, so monitors the user sees as touching in
+/// the system's display settings come out touching here too.
+///
+/// Works on immutable snapshots and returns positions, never mutating a model: every caller
+/// applies the result to a reactive <c>DepthProjection</c>, whose X/Y are the panel origin —
+/// the same point as <see cref="MonitorSnapshot.MmLocation"/>.
+///
+/// What it deliberately does NOT do is close the gaps it leaves. Monitors with no pixel
+/// adjacency to anything placed keep whatever their alignment hints gave them, and pulling
+/// those into the block is <see cref="CompactionSolver"/>'s job, which the caller runs after.
+/// </summary>
+public static class SystemLocationSolver
+{
+    /// <summary>
+    /// Pixel edges are integers the system reports verbatim: two monitors are adjacent when
+    /// their edges are equal, not merely close.
+    /// </summary>
+    public const double PixelTolerance = 0;
+
+    /// <summary>
+    /// Millimetre panel origins, keyed by monitor id, for the monitors that actually move.
+    /// Monitors that end where they started are absent — the caller writes to a reactive model,
+    /// and an unchanged write is still a write.
+    /// </summary>
+    /// <param name="monitors">Every monitor of the layout: any of them can serve as an anchor.</param>
+    /// <param name="toPlace">
+    /// Ids allowed to move, or null for all of them. The "place already placed monitors too"
+    /// switch: a monitor left out anchors nothing and moves nowhere, exactly as before.
+    /// </param>
+    public static IReadOnlyDictionary<string, Point> Solve(
+        IReadOnlyList<MonitorSnapshot> monitors,
+        IReadOnlySet<string>? toPlace = null)
+    {
+        var result = new Dictionary<string, Point>();
+
+        var primary = monitors.FirstOrDefault(m => m.Primary);
+        if (primary is null) return result;
+
+        // Where every monitor currently sits. A monitor no rule ever fires on keeps this
+        // position — which for a freshly built layout is the origin, where they are all stacked.
+        var positions = monitors.ToDictionary(m => m.Id, m => m.MmLocation);
+
+        var unplaced = monitors
+            .Where(m => toPlace is null || toPlace.Contains(m.Id))
+            .ToList();
+
+        if (unplaced.Count == 0) return result;
+
+        // Start with the primary display and walk outwards.
+        var todo = new Queue<MonitorSnapshot>();
+        todo.Enqueue(primary);
+
+        while (todo.Count > 0)
+        {
+            foreach (var monitor in todo) unplaced.RemoveAll(m => m.Id == monitor.Id);
+
+            var placed = todo.Dequeue();
+            var placedAt = positions[placed.Id];
+
+            foreach (var target in unplaced.ToList())
+            {
+                if (target.Id == placed.Id) continue;
+
+                var (position, adjacent) = Against(placed, placedAt, target, positions[target.Id]);
+
+                // Hints fire whether or not the monitor is claimed, so the position is kept
+                // either way.
+                positions[target.Id] = position;
+
+                if (!adjacent) continue;
+
+                unplaced.RemoveAll(m => m.Id == target.Id);
+
+                // No compacting here. Every monitor not yet reached is still stacked at the
+                // origin, so a compact run mid-walk resolves overlaps against screens that have
+                // no position yet — and shoves the ones just placed correctly out of the way. It
+                // is why running this twice used to give a better answer than running it once:
+                // the second pass started from a layout that was already spread out, so the same
+                // compacts found nothing to do.
+                todo.Enqueue(target);
+            }
+        }
+
+        foreach (var monitor in monitors)
+        {
+            var position = positions[monitor.Id];
+            if (position != monitor.MmLocation) result[monitor.Id] = position;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Everything one already-placed monitor says about where another one goes, and whether that
+    /// amounts to claiming it.
+    /// <para>
+    /// Only a real pixel-space edge adjacency PLACES a monitor. The alignment equalities are
+    /// hints: applying them must not consume the monitor, or a monitor whose only adjacency is
+    /// with a later-placed neighbour never gets its adjacency rule tested (e.g. P|S|H side by
+    /// side: H aligned on P by Y equality used to be swallowed before S could claim it).
+    /// </para>
+    /// <para>
+    /// Contact rule, then alignment hints, then edge projection — each stage overwriting the
+    /// coordinate the previous one set. That precedence is the behaviour, not an accident; see
+    /// each stage for what it exists to override.
+    /// </para>
+    /// </summary>
+    static (Point Position, bool Adjacent) Against(
+        MonitorSnapshot placed, Point placedAt, MonitorSnapshot target, Point current)
+    {
+        // The anchor at its solved position; the target's own position is the unknown, so only
+        // its sizes and bezels are ever read.
+        var anchor = placed.MovedTo(placedAt);
+
+        var position = current;
+        var horizontal = Claim(anchor, target, Axis.Horizontal, ref position);
+        var vertical = Claim(anchor, target, Axis.Vertical, ref position);
+
+        // The offset along the contact edge, on the axis the contact is NOT on. Last, so it
+        // overrides the alignment equalities in Claim: those only fire on an exact match, and a
+        // monitor sitting 219px higher than its neighbour matches none of them — it used to keep
+        // whatever it had and be shoved by the compact, landing a whole screen height away.
+        if (horizontal) Project(anchor, target, Axis.Vertical, ref position);
+        if (vertical) Project(anchor, target, Axis.Horizontal, ref position);
+
+        return (position, horizontal || vertical);
+    }
+
+    /// <summary>
+    /// The contact rule and the two alignment hints on one axis. Returns whether the contact
+    /// rule fired, which is the only thing that claims the monitor.
+    /// </summary>
+    static bool Claim(MonitorSnapshot anchor, MonitorSnapshot target, Axis axis, ref Point position)
+    {
+        // Contact: flush against the anchor's bezel edge, plus the target's own bezel, so the two
+        // panels end up as far apart as their frames make them.
+        //
+        //     __                    B |___|_
+        //  __| A       and its       A  |    |
+        // B  |__       transposes
+        //  __|
+        var contact = LayoutGeometry.ContactBetween(anchor.PixelBounds, target.PixelBounds, axis, PixelTolerance);
+        var outside = anchor.MmOutsideBounds.On(axis);
+
+        position = contact switch
+        {
+            EdgeContact.After => position.With(axis, outside.Hi + target.LowBorder(axis)),
+            EdgeContact.Before => position.With(axis,
+                outside.Lo - target.MmOutsideBounds.On(axis).Size + target.LowBorder(axis)),
+            _ => position
+        };
+
+        // Alignment hints, panel edge to panel edge. They come after the contact rule and
+        // override it: two monitors flush on one edge in pixels are meant to read as flush in
+        // millimetres, whichever other side they also happen to touch on.
+        //
+        //  __        ___   ___      __            |___||___|
+        // |     and |   | |   |       |    and
+        // |__                       __|
+        var anchorPixel = anchor.PixelBounds.On(axis);
+        var targetPixel = target.PixelBounds.On(axis);
+        var anchorPanel = anchor.MmBounds.On(axis);
+
+        if (targetPixel.Lo == anchorPixel.Lo) position = position.With(axis, anchorPanel.Lo);
+        if (targetPixel.Hi == anchorPixel.Hi)
+            position = position.With(axis, anchorPanel.Hi - target.MmBounds.On(axis).Size);
+
+        return contact != EdgeContact.None;
+    }
+
+    /// <summary>Solve the shared-midpoint invariant along <paramref name="axis"/>.</summary>
+    static void Project(MonitorSnapshot anchor, MonitorSnapshot target, Axis axis, ref Point position)
+    {
+        var anchorProfile = anchor.Profile(axis);
+        var targetProfile = target.Profile(axis);
+
+        // A monitor reporting no pixels has nothing to be proportional to.
+        if (!anchorProfile.HasPixels || !targetProfile.HasPixels) return;
+
+        position = position.With(axis, EdgeProjection.MillimetreOrigin(anchorProfile, targetProfile));
+    }
+
+    static Point With(this Point point, Axis axis, double value)
+        => axis == Axis.Horizontal ? new Point(value, point.Y) : new Point(point.X, value);
+}


### PR DESCRIPTION
Two commits, meant to be read separately.

## 1. `bfabe9a` — mutualise the geometry (no behaviour change)

"Place from system" (pixels → mm) and "apply to system" (mm → pixels) are inverses of each other, but were spelled out twice, each with its own axis handling and its own copy of the shared-span projection. Neither was reachable without a reactive model, so neither was ever tested against the other.

The neutral part moves to `LayoutGeometry.cs`: `Axis`, `Interval`, `EdgeContact`/`ContactBetween`, `AxisProfile`, and `EdgeProjection` — which now holds the one invariant both directions solve: *the physical midpoint of the span two panels share maps to the same coordinate on both*. Outbound solves it in closed form; inbound by a 4-pass fixed point seeded on the pixel midpoint, since there the overlap moves with the answer.

`MonitorSnapshot` replaces `PixelPlacementMonitor` and feeds both directions, which is what makes round-trip tests writable at all. The two solvers stay separate files and stay unmerged — the tolerances differ for good reason (0 on integer pixel edges, 5mm on hand-entered bezels), and so does island handling. `MonitorsLocations*Extensions.cs` are now only snapshot → solve → apply bridges.

Validated against a golden dump of 12 layouts, including degenerate ones (zero pixels, no primary, detached island, overlap), byte for byte, before a single new test was written.

## 2. `68d3c80` — refuse a corner-only contact (deliberate behaviour change)

A shared pixel edge the two monitors do not straddle is a corner, which the cursor cannot cross. The outbound direction has always known this — `PixelLocationSolver.TryPlaceAdjacent` skips an axis whose perpendicular overlap is zero — but the inbound walk did not, and the asymmetry had a visible cost.

In a 2x2 grid the diagonal neighbour shares an edge with the primary on **both** axes at once, so both contacts fired and both claimed it. Each then ran the perpendicular projection on the other axis, and the two projections overwrote the coordinate the other's contact rule had just set. The diagonal monitor landed panel-flush at mm (600,340) instead of bezel-flush at (620,360) — its frame one bezel width inside the primary's on each axis. Compaction had to pull them apart and skewed the grid doing it:

| | before | after |
|---|---|---|
| B | (620, **−20**) | (620, 0) |
| C | (**−20**, 360) | (0, 360) |
| D | (620, **340**) | (620, 360) |

A square grid came back out of square. Requiring a perpendicular overlap > 0 for a contact to claim — exactly what the other direction does — leaves the diagonal for the neighbour whose edge with it is real, and the 2x2 grid now round-trips exactly.

### The one subtlety worth reviewing

A refused contact still **suggests** a position; it only stops consuming the target. That is what a corner-only monitor with no other neighbour lives on — it keeps its diagonal instead of staying stacked at the origin to be shoved aside by compaction. With `MinimalEdgeOverlap = 0`, which `ForceCompactTests` documents as the way to accept bare corner contact, the user's corner now survives untouched; before, it was dragged into the primary's bezels and pushed back out. Pinned by `CornerToCornerContact_SurvivesWhenNoCorridorIsDemanded`.

Only the millimetre half survives there: the trip back out still cannot express a corner, since `PixelLocationSolver` refuses them whatever the options say and snaps the monitor in as a detached island. The corridor rule is layout editing; the pixel grid has to stay crossable regardless.

### Impact

Saved layouts are untouched. Users who re-run "place from system" on a grid will see it come out square rather than skewed — worth a line in the release notes. The characterization test is renamed from `DiagonalNeighbourInAGrid_IsClaimedOnBothAxes_AndSkewsTheGrid` to `DiagonalNeighbourInAGrid_IsRefused_AndTheGridRoundTrips` and moved to the invertible half of the file.

## Tests

`LittleBigMouse-Linux.slnf` builds with 0 errors. All four test projects green: DisplayLayout 197 passed / 16 pre-existing Windows-only skips, Ui.Avalonia 213, Plugin.Vcp 84, ColorTools 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)