### PR TITLE
Mutualise the mechanics the Tizen and VIDAA clients genuinely share

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/DeviceCommandGateTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/DeviceCommandGateTests.cs
@@ -1,0 +1,124 @@
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class DeviceCommandGateTests
+{
+    [Fact]
+    public async Task HoldsTheSecondCommandUntilTheFirstOneIsDone()
+    {
+        var gate = new DeviceCommandGate();
+        var release = new TaskCompletionSource();
+        var order = new List<string>();
+
+        var first = gate.RunExclusiveAsync(async _ =>
+        {
+            order.Add("first started");
+            await release.Task;
+            order.Add("first finished");
+        });
+        var second = gate.RunExclusiveAsync(_ =>
+        {
+            order.Add("second started");
+            return Task.CompletedTask;
+        });
+
+        Assert.False(second.IsCompleted);
+        Assert.Equal(["first started"], order);
+
+        release.SetResult();
+        await Task.WhenAll(first, second);
+
+        Assert.Equal(["first started", "first finished", "second started"], order);
+    }
+
+    [Fact]
+    public async Task ReturnsWhatTheCommandProduced()
+        => Assert.Equal("token", await new DeviceCommandGate().RunExclusiveAsync(_ => Task.FromResult("token")));
+
+    [Fact]
+    public async Task LetsTheNextCommandThroughWhenOneFails()
+    {
+        var gate = new DeviceCommandGate();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => gate.RunExclusiveAsync(async _ =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("the display closed the channel");
+        }));
+
+        Assert.True(await gate.RunExclusiveAsync(_ => Task.FromResult(true)));
+    }
+
+    [Fact]
+    public async Task GivesUpWaitingWhenTheCallerCancelsAndStaysUsable()
+    {
+        var gate = new DeviceCommandGate();
+        var release = new TaskCompletionSource();
+        var ran = false;
+
+        var blocking = gate.RunExclusiveAsync(_ => release.Task);
+        using var cancellation = new CancellationTokenSource();
+        var queued = gate.RunExclusiveAsync(_ =>
+        {
+            ran = true;
+            return Task.CompletedTask;
+        }, cancellation.Token);
+
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+        Assert.False(ran);
+
+        release.SetResult();
+        await blocking;
+        Assert.True(await gate.RunExclusiveAsync(_ => Task.FromResult(true)));
+    }
+
+    [Fact]
+    public async Task ClosingWaitsForTheCommandInFlightBeforeTearingDownTheConnection()
+    {
+        var gate = new DeviceCommandGate();
+        var release = new TaskCompletionSource();
+        var order = new List<string>();
+
+        var command = gate.RunExclusiveAsync(async _ =>
+        {
+            await release.Task;
+            order.Add("command finished");
+        });
+        var closing = gate.CloseAsync(() =>
+        {
+            order.Add("connection closed");
+            return Task.CompletedTask;
+        });
+
+        Assert.False(closing.IsCompleted);
+
+        release.SetResult();
+        await Task.WhenAll(command, closing);
+
+        Assert.Equal(["command finished", "connection closed"], order);
+    }
+
+    [Fact]
+    public async Task ClosedGateRefusesFurtherCommands()
+    {
+        var gate = new DeviceCommandGate();
+        await gate.CloseAsync(() => Task.CompletedTask);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => gate.RunExclusiveAsync(_ => Task.CompletedTask));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => gate.RunExclusiveAsync(_ => Task.FromResult(1)));
+    }
+
+    [Fact]
+    public async Task ClosingTwiceTearsTheConnectionDownOnce()
+    {
+        var gate = new DeviceCommandGate();
+        var closes = 0;
+
+        await gate.CloseAsync(() => { closes++; return Task.CompletedTask; });
+        await gate.CloseAsync(() => { closes++; return Task.CompletedTask; });
+
+        Assert.Equal(1, closes);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/ExclusiveOperationRunnerTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/ExclusiveOperationRunnerTests.cs
@@ -1,0 +1,132 @@
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class ExclusiveOperationRunnerTests
+{
+    const string TimeoutMessage = "The display did not answer in time.";
+
+    static ExclusiveOperationRunner Runner(
+        List<bool>? busy = null,
+        List<string>? status = null,
+        TimeSpan? defaultTimeout = null)
+        => new(
+            value => busy?.Add(value),
+            message => status?.Add(message),
+            TimeoutMessage,
+            defaultTimeout ?? TimeSpan.FromSeconds(30));
+
+    [Fact]
+    public async Task DropsACommandStartedWhileAnotherIsInFlight()
+    {
+        var runner = Runner();
+        var release = new TaskCompletionSource();
+        var started = 0;
+
+        var first = runner.RunAsync(async _ =>
+        {
+            started++;
+            await release.Task;
+        });
+        await runner.RunAsync(_ =>
+        {
+            started++;
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(1, started);
+        Assert.True(runner.Busy);
+
+        release.SetResult();
+        await first;
+
+        Assert.Equal(1, started);
+        Assert.False(runner.Busy);
+    }
+
+    [Fact]
+    public async Task AcceptsTheNextCommandOnceTheFirstOneIsDone()
+    {
+        var runner = Runner();
+        var started = 0;
+
+        await runner.RunAsync(_ => { started++; return Task.CompletedTask; });
+        await runner.RunAsync(_ => { started++; return Task.CompletedTask; });
+
+        Assert.Equal(2, started);
+    }
+
+    [Fact]
+    public async Task RaisesAndClearsBusyAroundTheCommand()
+    {
+        var busy = new List<bool>();
+        var runner = Runner(busy);
+
+        await runner.RunAsync(_ => Task.CompletedTask);
+
+        Assert.Equal([true, false], busy);
+    }
+
+    [Fact]
+    public async Task TurnsAFailureIntoAStatusLineRatherThanLettingItEscape()
+    {
+        var busy = new List<bool>();
+        var status = new List<string>();
+        var runner = Runner(busy, status);
+
+        await runner.RunAsync(_ => throw new InvalidOperationException("Associate a display first."));
+
+        Assert.Equal(["Associate a display first."], status);
+        Assert.Equal([true, false], busy);
+        Assert.False(runner.Busy);
+    }
+
+    [Fact]
+    public async Task ReportsTheTimeoutMessageWhenACommandOutlivesItsDeadline()
+    {
+        var status = new List<string>();
+        var runner = Runner(status: status);
+
+        await runner.RunAsync(
+            token => Task.Delay(Timeout.Infinite, token),
+            TimeSpan.FromMilliseconds(20));
+
+        Assert.Equal([TimeoutMessage], status);
+        Assert.False(runner.Busy);
+    }
+
+    [Fact]
+    public async Task FallsBackToItsOwnDeadlineWhenTheCommandDoesNotAskForOne()
+    {
+        var status = new List<string>();
+        var runner = Runner(status: status, defaultTimeout: TimeSpan.FromMilliseconds(20));
+
+        await runner.RunAsync(token => Task.Delay(Timeout.Infinite, token));
+
+        Assert.Equal([TimeoutMessage], status);
+    }
+
+    [Fact]
+    public async Task LeavesTheDeadlineToTheCommandThatAsksForItsOwn()
+    {
+        var status = new List<string>();
+        var runner = Runner(status: status, defaultTimeout: TimeSpan.FromMilliseconds(20));
+
+        await runner.RunAsync(
+            async _ => await Task.Delay(TimeSpan.FromMilliseconds(120)),
+            TimeSpan.FromSeconds(30));
+
+        Assert.Empty(status);
+    }
+
+    [Fact]
+    public async Task ReportsATimeoutRatherThanAnEmptyMessageWhenTheCommandCancelsItself()
+    {
+        var status = new List<string>();
+        var runner = Runner(status: status);
+
+        await runner.RunAsync(_ => Task.FromCanceled(new CancellationToken(canceled: true)));
+
+        Assert.Equal([TimeoutMessage], status);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/Ipv4AddressTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/Ipv4AddressTests.cs
@@ -1,0 +1,64 @@
+using LittleBigMouse.Plugin.Vcp.Networking;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class Ipv4AddressTests
+{
+    [Theory]
+    [InlineData("192.168.1.10")]
+    [InlineData("10.0.0.1")]
+    [InlineData("255.255.255.255")]
+    [InlineData(" 192.168.1.10 ")]          // pasted into a text box
+    [InlineData("\t192.168.1.10\n")]
+    public void AcceptsLiteralIpv4Addresses(string value) => Assert.True(Ipv4Address.IsValid(value));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("192.168.1.256")]
+    [InlineData("192.168.1.10.4")]
+    [InlineData("tv.local")]                // a name would move the failure to the first command
+    [InlineData("::1")]                     // IPv6: these devices are only reached over IPv4
+    [InlineData("2001:db8::1")]
+    [InlineData("192.168.1.10:8002")]       // a port is not part of the address
+    public void RejectsWhatCannotBeDialled(string? value) => Assert.False(Ipv4Address.IsValid(value));
+
+    [Fact]
+    public void TryParseReturnsTheAddressSoCallersCanReadItsOctets()
+    {
+        Assert.True(Ipv4Address.TryParse(" 192.168.7.42 ", out var address));
+        Assert.Equal(new byte[] { 192, 168, 7, 42 }, address.GetAddressBytes());
+    }
+
+    [Fact]
+    public void TryParseYieldsNoAddressWhenItFails()
+    {
+        Assert.False(Ipv4Address.TryParse("2001:db8::1", out var address));
+        Assert.Null(address);
+    }
+
+    [Fact]
+    public void RequireReturnsTheAddressWithoutItsBlanksSoTheStoredTextIsTheDialledText()
+        => Assert.Equal("192.168.1.10", Ipv4Address.Require(" 192.168.1.10 ", "ipAddress"));
+
+    [Fact]
+    public void RequireNamesTheRejectedArgument()
+    {
+        var error = Assert.Throws<ArgumentException>(() => Ipv4Address.Require("tv.local", "ipAddress"));
+
+        Assert.Equal("ipAddress", error.ParamName);
+        Assert.Contains(Ipv4Address.InvalidMessage, error.Message);
+    }
+
+    [Fact]
+    public void RequireKeepsTheCallerMessageWhenItHasOneOfItsOwn()
+    {
+        var error = Assert.Throws<ArgumentException>(
+            () => Ipv4Address.Require("", "ipAddress", "A valid IPv4 address is required."));
+
+        Assert.Contains("A valid IPv4 address is required.", error.Message);
+        Assert.DoesNotContain(Ipv4Address.InvalidMessage, error.Message);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/StaleConnectionRetryTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/StaleConnectionRetryTests.cs
@@ -1,0 +1,133 @@
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+public class StaleConnectionRetryTests
+{
+    static bool IsTransportFailure(Exception exception) => exception is IOException;
+
+    /// <summary>Counts the attempts and fails the first <c>failures</c> of them like a dead socket.</summary>
+    sealed class Transport(int failures)
+    {
+        public int Sends { get; private set; }
+        public int Reopens { get; private set; }
+
+        public Task SendAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Sends++;
+            return Sends <= failures
+                ? Task.FromException(new IOException($"write {Sends} found the connection closed"))
+                : Task.CompletedTask;
+        }
+
+        public Task ReopenAsync(CancellationToken cancellationToken)
+        {
+            Reopens++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SendsOnceAndLeavesTheSessionAloneWhenItIsAlive()
+    {
+        var transport = new Transport(failures: 0);
+
+        await StaleConnectionRetry.SendAsync(transport.SendAsync, transport.ReopenAsync, IsTransportFailure);
+
+        Assert.Equal(1, transport.Sends);
+        Assert.Equal(0, transport.Reopens);
+    }
+
+    [Fact]
+    public async Task ReopensAndSendsAgainWhenTheFirstWriteFindsTheSessionDead()
+    {
+        var transport = new Transport(failures: 1);
+
+        await StaleConnectionRetry.SendAsync(transport.SendAsync, transport.ReopenAsync, IsTransportFailure);
+
+        Assert.Equal(2, transport.Sends);
+        Assert.Equal(1, transport.Reopens);
+    }
+
+    [Fact]
+    public async Task GivesUpAfterOneRetryAndReportsTheSecondFailure()
+    {
+        var transport = new Transport(failures: 2);
+
+        var error = await Assert.ThrowsAsync<IOException>(() => StaleConnectionRetry.SendAsync(
+            transport.SendAsync, transport.ReopenAsync, IsTransportFailure));
+
+        Assert.Equal("write 2 found the connection closed", error.Message);
+        Assert.Equal(2, transport.Sends);
+        Assert.Equal(1, transport.Reopens);
+    }
+
+    [Fact]
+    public async Task DoesNotRepeatACommandTheDisplayRefused()
+    {
+        var sends = 0;
+        var reopens = 0;
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => StaleConnectionRetry.SendAsync(
+            _ =>
+            {
+                sends++;
+                return Task.FromException(new UnauthorizedAccessException("the display denied IP control"));
+            },
+            _ => { reopens++; return Task.CompletedTask; },
+            IsTransportFailure));
+
+        Assert.Equal(1, sends);
+        Assert.Equal(0, reopens);
+    }
+
+    [Fact]
+    public async Task DoesNotMistakeACancelledCommandForADeadSession()
+    {
+        var transport = new Transport(failures: 0);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => StaleConnectionRetry.SendAsync(
+            transport.SendAsync, transport.ReopenAsync, IsTransportFailure, cancellation.Token));
+
+        Assert.Equal(0, transport.Sends);
+        Assert.Equal(0, transport.Reopens);
+    }
+
+    [Fact]
+    public async Task ReportsAFailureToReopenRatherThanSendingIntoTheVoid()
+    {
+        var transport = new Transport(failures: 1);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => StaleConnectionRetry.SendAsync(
+            transport.SendAsync,
+            _ => Task.FromException(new InvalidOperationException("Pair this device first.")),
+            IsTransportFailure));
+
+        Assert.Equal("Pair this device first.", error.Message);
+        Assert.Equal(1, transport.Sends);
+    }
+
+    [Fact]
+    public async Task HandsTheCallerTokenToEveryAttemptAndToTheReopen()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var seen = new List<CancellationToken>();
+        var sends = 0;
+
+        await StaleConnectionRetry.SendAsync(
+            token =>
+            {
+                seen.Add(token);
+                return ++sends == 1 ? Task.FromException(new IOException("stale")) : Task.CompletedTask;
+            },
+            token => { seen.Add(token); return Task.CompletedTask; },
+            IsTransportFailure,
+            cancellation.Token);
+
+        Assert.Equal(3, seen.Count);
+        Assert.All(seen, token => Assert.Equal(cancellation.Token, token));
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/DeviceCommandGate.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/DeviceCommandGate.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia;
+
+/// <summary>
+/// Serializes the commands a client sends over its single connection to one display.
+///
+/// Every network remote here multiplexes pairing, key presses and setting changes onto one
+/// socket, and every one of those exchanges reads or replaces connection state — a token, a
+/// session, a pending answer. Two commands overlapping would interleave writes on that socket
+/// and let one command's reply satisfy the other's wait, so they are run one at a time rather
+/// than merely made thread-safe.
+///
+/// <see cref="CloseAsync"/> lets the last command finish before the connection is torn down,
+/// and turns every later command into <see cref="ObjectDisposedException"/> instead of a write
+/// to a disposed socket.
+/// </summary>
+public sealed class DeviceCommandGate
+{
+    readonly SemaphoreSlim _gate = new(1, 1);
+    bool _closed;
+
+    /// <summary>Runs <paramref name="command"/> once no other command is in flight.</summary>
+    /// <exception cref="ObjectDisposedException">The gate is closed.</exception>
+    public async Task<T> RunExclusiveAsync<T>(
+        Func<CancellationToken, Task<T>> command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_closed, this);
+            return await command(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc cref="RunExclusiveAsync{T}"/>
+    public async Task RunExclusiveAsync(
+        Func<CancellationToken, Task> command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await RunExclusiveAsync<object?>(async token =>
+        {
+            await command(token).ConfigureAwait(false);
+            return null;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Waits for the command in flight, runs <paramref name="lastCommand"/> — closing the
+    /// connection, as a rule — then refuses any further command. Calling it twice is harmless,
+    /// so an owner may close the gate explicitly and still be disposed.
+    /// </summary>
+    public async Task CloseAsync(Func<Task> lastCommand)
+    {
+        ArgumentNullException.ThrowIfNull(lastCommand);
+        if (Volatile.Read(ref _closed)) return;
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_closed) return;
+            Volatile.Write(ref _closed, true);
+            await lastCommand().ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+            _gate.Dispose();
+        }
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/ExclusiveOperationRunner.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/ExclusiveOperationRunner.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia;
+
+/// <summary>
+/// Runs one panel command at a time, under a deadline, and reports what happened as a single
+/// status line.
+///
+/// The three rules are the same for every network-attached display, and none of them is
+/// optional. A second command started while the first is in flight is dropped rather than
+/// queued: the buttons it comes from are disabled meanwhile, so a command that gets through is
+/// a double click or a key repeat, and the user wants it ignored, not replayed later. Every
+/// command gets a deadline because a display that is asleep, moved to another address or simply
+/// unplugged answers nothing at all — without one the panel would stay disabled for good. And a
+/// failure becomes text in the panel instead of an exception, because these commands run from
+/// <c>ReactiveCommand</c>, where an escaping exception takes the whole application down.
+///
+/// Expected to be used from the UI thread, as its callbacks write bound properties.
+/// </summary>
+/// <param name="reportBusy">Drives the flag the panel binds its buttons to.</param>
+/// <param name="reportStatus">Shows a timeout or a failure to the user.</param>
+/// <param name="timeoutMessage">
+/// What to show when the deadline expires. Names the device and what to check, since this is
+/// the failure users actually hit.
+/// </param>
+/// <param name="defaultTimeout">Deadline for the commands that do not ask for their own.</param>
+public sealed class ExclusiveOperationRunner(
+    Action<bool> reportBusy,
+    Action<string> reportStatus,
+    string timeoutMessage,
+    TimeSpan defaultTimeout)
+{
+    /// <summary>True while a command is in flight, i.e. while further commands are dropped.</summary>
+    public bool Busy { get; private set; }
+
+    public async Task RunAsync(Func<CancellationToken, Task> operation, TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        if (Busy) return;
+
+        Busy = true;
+        reportBusy(true);
+        using var deadline = new CancellationTokenSource(timeout ?? defaultTimeout);
+        try
+        {
+            await operation(deadline.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            reportStatus(timeoutMessage);
+        }
+        catch (Exception exception)
+        {
+            reportStatus(exception.Message);
+        }
+        finally
+        {
+            Busy = false;
+            reportBusy(false);
+        }
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseControlViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseControlViewModel.cs
@@ -9,6 +9,7 @@ namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
 {
     readonly IHisenseVidaaService? _service;
+    readonly ExclusiveOperationRunner _operations;
     readonly Queue<VidaaTrafficMessage> _trafficMessages = new();
     CancellationTokenSource? _trafficCancellation;
     CancellationTokenSource? _volumeSetCancellation;
@@ -206,6 +207,11 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
     public HisenseControlViewModel(IHisenseVidaaService? service)
     {
         _service = service;
+        _operations = new ExclusiveOperationRunner(
+            busy => Busy = busy,
+            status => Status = status,
+            "Timed out while contacting the projector. Check that it is awake and still reachable at the configured IP address.",
+            TimeSpan.FromSeconds(15));
         SaveCommand = ReactiveCommand.CreateFromTask(SaveAsync);
         PowerOnCommand = ReactiveCommand.CreateFromTask(WakeAsync);
         PowerOffCommand = ReactiveCommand.CreateFromTask(() => KeyAsync("KEY_POWER"));
@@ -284,7 +290,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             _service.SaveAddress(_monitor.Id, IpAddress, MacAddress, DeviceUuid, CertificatePath);
             var configuration = _service.GetConfiguration(_monitor.Id);
@@ -301,7 +307,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             Status = "Searching the configured /24 for the VIDAA projector…";
             var discoveredDevice = await _service.FindAsync(IpAddress, cancellationToken);
@@ -329,7 +335,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
         }
 
         var monitorId = _monitor.Id;
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.SendKeyAsync(monitorId, key, cancellationToken);
             Status = $"Sent {key}.";
@@ -351,7 +357,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.RequestPinAsync(_monitor.Id, cancellationToken);
             var configuration = _service.GetConfiguration(_monitor.Id);
@@ -369,7 +375,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
         }
 
         var monitorId = _monitor.Id;
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.PairAsync(monitorId, Pin, cancellationToken);
             var configuration = _service.GetConfiguration(monitorId);
@@ -392,7 +398,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             var keySequence = RemoteMacro.Parse(KeyMacro);
             _service.SaveKeyMacro(_monitor.Id, KeyMacro);
@@ -408,7 +414,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.SetPictureSettingAsync(
                 _monitor.Id,
@@ -427,7 +433,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
         }
 
         PictureSettingsCatalog = "Requesting the VIDAA picture-setting catalogue…";
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             var settings = await _service.GetPictureSettingsAsync(_monitor.Id, cancellationToken);
             PictureSettingsCatalog = string.Join("\n", settings
@@ -502,7 +508,7 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
         var monitorId = _monitor.Id;
         var action = LaserAction;
         var level = (int)LaserLevel;
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.SendPlatformActionAsync(monitorId, action, level, cancellationToken);
             Status = $"Sent {action.Trim()} = {level} (unconfirmed).";
@@ -760,39 +766,12 @@ public sealed class HisenseControlViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        await Run(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             _service.SaveAddress(_monitor.Id, IpAddress, MacAddress, DeviceUuid, CertificatePath);
             await _service.PowerOnAsync(_monitor.Id, cancellationToken);
             Status = "Wake-on-LAN sent.";
         });
-    }
-
-    async Task Run(Func<CancellationToken, Task> action, TimeSpan? timeout = null)
-    {
-        if (Busy)
-        {
-            return;
-        }
-
-        Busy = true;
-        using var cancellation = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(15));
-        try
-        {
-            await action(cancellation.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            Status = "Timed out while contacting the projector. Check that it is awake and still reachable at the configured IP address.";
-        }
-        catch (Exception exception)
-        {
-            Status = exception.Message;
-        }
-        finally
-        {
-            Busy = false;
-        }
     }
 
     public void Dispose()

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaClient.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaClient.cs
@@ -8,7 +8,7 @@ namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) : IAsyncDisposable
 {
     readonly HisenseVidaaConfiguration _configuration = configuration;
-    readonly SemaphoreSlim _gate = new(1, 1);
+    readonly DeviceCommandGate _commands = new();
     VidaaMqttConnection? _connection;
     TaskCompletionSource<bool>? _pinAccepted;
     TaskCompletionSource<bool>? _tokenIssued;
@@ -131,65 +131,33 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
         await _tokenIssued.Task.WaitAsync(TimeSpan.FromSeconds(12), cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task SendKeyAsync(string key, CancellationToken cancellationToken)
-    {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+    public Task SendKeyAsync(string key, CancellationToken cancellationToken)
+        => _commands.RunExclusiveAsync(async commandToken =>
         {
             var topic = HisenseVidaaProtocol.Topic("remote_service", _configuration.ClientId, "sendkey");
             var payload = HisenseVidaaProtocol.TranslateKey(key);
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e) when (IsConnectionFailure(e))
-            {
-                // TcpClient.Connected can remain true until the first failed write.
-                // Reopen the persistent MQTT session and retry this key once.
-                await ResetConnectionAsync().ConfigureAwait(false);
-                await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
+            await SendWithRetryAsync(
+                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
+        }, cancellationToken);
 
-    public async Task SetPictureSettingAsync(int menuId, int value, CancellationToken cancellationToken)
+    public Task SetPictureSettingAsync(int menuId, int value, CancellationToken cancellationToken)
     {
         var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, "picturesetting");
         var payload = HisenseVidaaProtocol.PictureSettingPayload(menuId, value);
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        return _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e) when (IsConnectionFailure(e))
-            {
-                await ResetConnectionAsync().ConfigureAwait(false);
-                await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _gate.Release();
-        }
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
+            await SendWithRetryAsync(
+                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
+        }, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<VidaaPictureSetting>> GetPictureSettingsAsync(
+    public Task<IReadOnlyList<VidaaPictureSetting>> GetPictureSettingsAsync(
         CancellationToken cancellationToken)
-    {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        => _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
             var signal = new TaskCompletionSource<IReadOnlyList<VidaaPictureSetting>>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             _pictureSettingsReceived = signal;
@@ -197,35 +165,18 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
                 "platform_service", _configuration.ClientId, "picturesetting");
             try
             {
-                try
-                {
-                    await _connection!.PublishAsync(
-                        topic,
-                        HisenseVidaaProtocol.PictureSettingsRequestPayload(),
-                        cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e) when (IsConnectionFailure(e))
-                {
-                    await ResetConnectionAsync().ConfigureAwait(false);
-                    await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-                    await _connection!.PublishAsync(
-                        topic,
-                        HisenseVidaaProtocol.PictureSettingsRequestPayload(),
-                        cancellationToken).ConfigureAwait(false);
-                }
-                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(6), cancellationToken)
+                await SendWithRetryAsync(
+                    token => _connection!.PublishAsync(
+                        topic, HisenseVidaaProtocol.PictureSettingsRequestPayload(), token),
+                    commandToken).ConfigureAwait(false);
+                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(6), commandToken)
                     .ConfigureAwait(false);
             }
             finally
             {
                 if (ReferenceEquals(_pictureSettingsReceived, signal)) _pictureSettingsReceived = null;
             }
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+        }, cancellationToken);
 
     public Task<int> GetVolumeAsync(CancellationToken cancellationToken)
         => SendVolumeActionAsync("getvolume", "0", cancellationToken);
@@ -233,67 +184,39 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
     public Task<int> SetVolumeAsync(int volume, CancellationToken cancellationToken)
         => SendVolumeActionAsync("changevolume", HisenseVidaaProtocol.VolumePayload(volume), cancellationToken);
 
-    public async Task SendPlatformActionAsync(string action, int value, CancellationToken cancellationToken)
+    public Task SendPlatformActionAsync(string action, int value, CancellationToken cancellationToken)
     {
         var topic = HisenseVidaaProtocol.Topic(
             "platform_service",
             _configuration.ClientId,
             HisenseVidaaProtocol.PlatformActionName(action));
         var payload = HisenseVidaaProtocol.ExperimentalLevelPayload(value);
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        return _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e) when (IsConnectionFailure(e))
-            {
-                await ResetConnectionAsync().ConfigureAwait(false);
-                await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-                await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _gate.Release();
-        }
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
+            await SendWithRetryAsync(
+                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
+        }, cancellationToken);
     }
 
-    async Task<int> SendVolumeActionAsync(string action, string payload, CancellationToken cancellationToken)
-    {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+    Task<int> SendVolumeActionAsync(string action, string payload, CancellationToken cancellationToken)
+        => _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
             var signal = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
             _volumeReceived = signal;
             var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, action);
             try
             {
-                try
-                {
-                    await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception e) when (IsConnectionFailure(e))
-                {
-                    await ResetConnectionAsync().ConfigureAwait(false);
-                    await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-                    await _connection!.PublishAsync(topic, payload, cancellationToken).ConfigureAwait(false);
-                }
-                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(4), cancellationToken).ConfigureAwait(false);
+                await SendWithRetryAsync(
+                    token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
+                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(4), commandToken).ConfigureAwait(false);
             }
             finally
             {
                 if (ReferenceEquals(_volumeReceived, signal)) _volumeReceived = null;
             }
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+        }, cancellationToken);
 
     public async Task<IReadOnlyList<VidaaTrafficMessage>> CaptureTrafficAsync(
         TimeSpan duration,
@@ -321,7 +244,6 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(onMessage);
-        VidaaMqttConnection connection;
         var recentMessages = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
 
         void Capture(string topic, byte[] bytes, bool retained)
@@ -346,26 +268,22 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
             onMessage(new VidaaTrafficMessage(now, topic, payload));
         }
 
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        var connection = await _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-            connection = _connection!;
-            connection.MessageReceived += Capture;
+            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
+            var opened = _connection!;
+            opened.MessageReceived += Capture;
             try
             {
-                await connection.SubscribeAsync(["#"], cancellationToken).ConfigureAwait(false);
+                await opened.SubscribeAsync(["#"], commandToken).ConfigureAwait(false);
             }
             catch
             {
-                connection.MessageReceived -= Capture;
+                opened.MessageReceived -= Capture;
                 throw;
             }
-        }
-        finally
-        {
-            _gate.Release();
-        }
+            return opened;
+        }, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -430,6 +348,20 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
         await _connection.SubscribeAsync(
             topics, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Binds <see cref="StaleConnectionRetry"/> to what a dead MQTT session means here: the
+    /// broker only accepts the persistent session once, so it has to be dropped before a new
+    /// one can be opened with the stored pairing.
+    /// </summary>
+    Task SendWithRetryAsync(Func<CancellationToken, Task> send, CancellationToken cancellationToken)
+        => StaleConnectionRetry.SendAsync(send, ReopenAsync, IsConnectionFailure, cancellationToken);
+
+    async Task ReopenAsync(CancellationToken cancellationToken)
+    {
+        await ResetConnectionAsync().ConfigureAwait(false);
+        await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
     }
 
     async Task ResetConnectionAsync()
@@ -529,16 +461,5 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
             : fallback;
 
     public async ValueTask DisposeAsync()
-    {
-        await _gate.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            await ResetConnectionAsync().ConfigureAwait(false);
-        }
-        finally
-        {
-            _gate.Release();
-            _gate.Dispose();
-        }
-    }
+        => await _commands.CloseAsync(ResetConnectionAsync).ConfigureAwait(false);
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDevice.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDevice.cs
@@ -3,10 +3,7 @@ using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
-public sealed record HisenseVidaaDevice(string IpAddress, string Name = "Hisense VIDAA", string ModelName = "", string MacAddress = "", int? ProtocolVersion = null, string Brand = "his")
-{
-    public static bool IsValidAddress(string value) => System.Net.IPAddress.TryParse(value?.Trim(), out var ip) && ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork;
-}
+public sealed record HisenseVidaaDevice(string IpAddress, string Name = "Hisense VIDAA", string ModelName = "", string MacAddress = "", int? ProtocolVersion = null, string Brand = "his");
 
 public sealed class HisenseVidaaConfiguration : IMonitorSetting
 {

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDiscovery.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaDiscovery.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
+using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
@@ -15,8 +16,7 @@ public sealed class HisenseVidaaDiscovery(HttpClient httpClient)
         string ipAddress,
         CancellationToken cancellationToken = default)
     {
-        if (!HisenseVidaaDevice.IsValidAddress(ipAddress))
-            throw new ArgumentException("Enter a valid IPv4 address.", nameof(ipAddress));
+        ipAddress = Ipv4Address.Require(ipAddress, nameof(ipAddress));
 
         Exception? lastError = null;
         foreach (var port in HisenseVidaaProtocol.DescriptorPorts)
@@ -49,8 +49,7 @@ public sealed class HisenseVidaaDiscovery(HttpClient httpClient)
         string lastKnownAddress,
         CancellationToken cancellationToken = default)
     {
-        if (!IPAddress.TryParse(lastKnownAddress, out var seed)
-            || seed.AddressFamily != AddressFamily.InterNetwork)
+        if (!Ipv4Address.TryParse(lastKnownAddress, out var seed))
             throw new ArgumentException("Enter a valid projector IPv4 address.", nameof(lastKnownAddress));
 
         try

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaProtocol.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaProtocol.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
+using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
@@ -80,8 +81,7 @@ public static class HisenseVidaaProtocol
 
     public static HisenseVidaaDevice ParseDescriptor(string ipAddress, string xml)
     {
-        if (!HisenseVidaaDevice.IsValidAddress(ipAddress))
-            throw new ArgumentException("Enter a valid IPv4 address.", nameof(ipAddress));
+        ipAddress = Ipv4Address.Require(ipAddress, nameof(ipAddress));
 
         var document = XDocument.Parse(xml);
         string Element(string name) => document.Descendants()

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaService.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System.Net;
 using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
@@ -36,9 +35,9 @@ public sealed class HisenseVidaaService : IHisenseVidaaService, IAsyncDisposable
         => _discovery.FindAsync(ipAddress.Trim(), cancellationToken);
     public void SaveAddress(string id, string ip, string mac, string uuid, string certificatePath)
     {
-        if (!IPAddress.TryParse(ip.Trim(), out var address) || address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) throw new ArgumentException("Enter a valid IPv4 address.");
+        var address = Ipv4Address.Require(ip, nameof(ip));
         var c=_store.Get(id) ?? new HisenseVidaaConfiguration { MonitorId=id };
-        c.IpAddress=ip.Trim(); c.MacAddress=mac.Trim(); c.DeviceUuid=uuid.Trim();
+        c.IpAddress=address; c.MacAddress=mac.Trim(); c.DeviceUuid=uuid.Trim();
         c.ClientCertificatePath = VidaaCertificate.Resolve(certificatePath);
         if (string.IsNullOrWhiteSpace(c.ClientCertificatePassword)) c.ClientCertificatePassword = VidaaCertificate.DefaultPassword;
         c.ControllerMacAddress = NetworkIdentity.ControllerMacFor(c.IpAddress);

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/NetworkIdentity.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/NetworkIdentity.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
@@ -9,7 +10,7 @@ static class NetworkIdentity
 {
     public static string ControllerMacFor(string remoteAddress)
     {
-        if (!IPAddress.TryParse(remoteAddress, out var remote) || remote.AddressFamily != AddressFamily.InterNetwork)
+        if (!Ipv4Address.TryParse(remoteAddress, out var remote))
             throw new ArgumentException("Enter a valid projector IPv4 address.", nameof(remoteAddress));
 
         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungControlViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungControlViewModel.cs
@@ -9,11 +9,17 @@ namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 public sealed class SamsungControlViewModel : ReactiveObject
 {
     readonly ISamsungTizenService? _service;
+    readonly ExclusiveOperationRunner _operations;
     PhysicalMonitor? _monitor;
 
     public SamsungControlViewModel(ISamsungTizenService? service)
     {
         _service = service;
+        _operations = new ExclusiveOperationRunner(
+            busy => Busy = busy,
+            status => Status = status,
+            "The Samsung display did not answer in time.",
+            TimeSpan.FromSeconds(15));
         DiscoverCommand = ReactiveCommand.CreateFromTask(DiscoverAsync);
         PairCommand = ReactiveCommand.CreateFromTask(PairAsync);
         PowerOnCommand = ReactiveCommand.CreateFromTask(PowerOnAsync);
@@ -158,7 +164,7 @@ public sealed class SamsungControlViewModel : ReactiveObject
     async Task DiscoverAsync()
     {
         if (_service is null) return;
-        await RunAsync(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             Status = "Searching the local network…";
             var devices = await _service.DiscoverAsync(cancellationToken);
@@ -178,7 +184,7 @@ public sealed class SamsungControlViewModel : ReactiveObject
     async Task PairAsync()
     {
         if (_service is null || _monitor is null) return;
-        await RunAsync(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             Status = "Allow LittleBigMouse on the Samsung display…";
             var configuration = await _service.PairAsync(
@@ -191,7 +197,7 @@ public sealed class SamsungControlViewModel : ReactiveObject
     async Task PowerOnAsync()
     {
         if (_service is null || _monitor is null) return;
-        await RunAsync(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             _service.SaveManualAddress(_monitor.Id, IpAddress, MacAddress);
             await _service.PowerOnAsync(_monitor.Id, cancellationToken);
@@ -202,7 +208,7 @@ public sealed class SamsungControlViewModel : ReactiveObject
     async Task SendKeyAsync(string key, string success)
     {
         if (_service is null || _monitor is null) return;
-        await RunAsync(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             await _service.SendKeyAsync(_monitor.Id, key, cancellationToken);
             Paired = true;
@@ -214,36 +220,13 @@ public sealed class SamsungControlViewModel : ReactiveObject
     async Task RunMacroAsync()
     {
         if (_service is null || _monitor is null) return;
-        await RunAsync(async cancellationToken =>
+        await _operations.RunAsync(async cancellationToken =>
         {
             var sequence = SamsungTizenProtocol.ParseSequence(PictureMacro);
             _service.SavePictureMacro(_monitor.Id, PictureMacro);
             await _service.SendSequenceAsync(_monitor.Id, sequence, cancellationToken);
             Status = $"Macro completed ({sequence.Count} keys).";
         }, TimeSpan.FromSeconds(45));
-    }
-
-    async Task RunAsync(Func<CancellationToken, Task> action, TimeSpan timeout)
-    {
-        if (Busy) return;
-        Busy = true;
-        using var cancellation = new CancellationTokenSource(timeout);
-        try
-        {
-            await action(cancellation.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            Status = "The Samsung display did not answer in time.";
-        }
-        catch (Exception e)
-        {
-            Status = e.Message;
-        }
-        finally
-        {
-            Busy = false;
-        }
     }
 
     void Apply(SamsungTizenConfiguration configuration)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenClient.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenClient.cs
@@ -7,50 +7,28 @@ namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 /// <summary>One serialized local remote-control channel to a Samsung Tizen display.</summary>
 public sealed class SamsungTizenClient(string ipAddress, string token = "") : IAsyncDisposable
 {
-    readonly SemaphoreSlim _gate = new(1, 1);
+    readonly DeviceCommandGate _commands = new();
     ClientWebSocket? _socket;
     string _token = token;
 
     public string Token => _token;
     public bool Connected => _socket?.State == WebSocketState.Open;
 
-    public async Task<string> ConnectAsync(CancellationToken cancellationToken = default)
-    {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+    public Task<string> ConnectAsync(CancellationToken cancellationToken = default)
+        => _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsureConnectedLockedAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureConnectedLockedAsync(commandToken).ConfigureAwait(false);
             return _token;
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+        }, cancellationToken);
 
-    public async Task SendKeyAsync(string key, CancellationToken cancellationToken = default)
-    {
-        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+    public Task SendKeyAsync(string key, CancellationToken cancellationToken = default)
+        => _commands.RunExclusiveAsync(async commandToken =>
         {
-            await EnsureConnectedLockedAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureConnectedLockedAsync(commandToken).ConfigureAwait(false);
             var payload = SamsungTizenProtocol.RemoteKeyPayload(key);
-            try
-            {
-                await SendTextLockedAsync(payload, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e) when (e is WebSocketException or IOException or ObjectDisposedException)
-            {
-                ResetSocketLocked();
-                await EnsureConnectedLockedAsync(cancellationToken).ConfigureAwait(false);
-                await SendTextLockedAsync(payload, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            _gate.Release();
-        }
-    }
+            await SendWithRetryAsync(token => SendTextLockedAsync(payload, token), commandToken)
+                .ConfigureAwait(false);
+        }, cancellationToken);
 
     async Task EnsureConnectedLockedAsync(CancellationToken cancellationToken)
     {
@@ -124,6 +102,23 @@ public sealed class SamsungTizenClient(string ipAddress, string token = "") : IA
         return exception.Message;
     }
 
+    /// <summary>
+    /// Binds <see cref="StaleConnectionRetry"/> to what a dead channel means here: the socket
+    /// has to be aborted and rebuilt, since a <see cref="ClientWebSocket"/> cannot be
+    /// reconnected once it has left the Open state.
+    /// </summary>
+    Task SendWithRetryAsync(Func<CancellationToken, Task> send, CancellationToken cancellationToken)
+        => StaleConnectionRetry.SendAsync(send, ReopenAsync, IsTransportFailure, cancellationToken);
+
+    async Task ReopenAsync(CancellationToken cancellationToken)
+    {
+        ResetSocketLocked();
+        await EnsureConnectedLockedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    static bool IsTransportFailure(Exception exception)
+        => exception is WebSocketException or IOException or ObjectDisposedException;
+
     async Task SendTextLockedAsync(string payload, CancellationToken cancellationToken)
     {
         var bytes = Encoding.UTF8.GetBytes(payload);
@@ -158,9 +153,7 @@ public sealed class SamsungTizenClient(string ipAddress, string token = "") : IA
     }
 
     public async ValueTask DisposeAsync()
-    {
-        await _gate.WaitAsync().ConfigureAwait(false);
-        try
+        => await _commands.CloseAsync(async () =>
         {
             if (_socket?.State == WebSocketState.Open)
             {
@@ -177,11 +170,5 @@ public sealed class SamsungTizenClient(string ipAddress, string token = "") : IA
             }
             _socket?.Dispose();
             _socket = null;
-        }
-        finally
-        {
-            _gate.Release();
-            _gate.Dispose();
-        }
-    }
+        }).ConfigureAwait(false);
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDevice.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDevice.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System.Net;
 using LittleBigMouse.Plugins;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
@@ -15,10 +14,6 @@ public sealed record SamsungTizenDevice(
     public string Label => string.IsNullOrWhiteSpace(ModelName)
         ? $"{Name} — {IpAddress}"
         : $"{Name} ({ModelName}) — {IpAddress}";
-
-    public static bool IsValidAddress(string? value)
-        => IPAddress.TryParse(value, out var address)
-           && address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork;
 }
 
 /// <summary>Persisted association between an EDID monitor and one Tizen network device.</summary>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDiscovery.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenDiscovery.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
+using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 
@@ -14,14 +15,13 @@ public sealed class SamsungTizenDiscovery(HttpClient httpClient)
         string ipAddress,
         CancellationToken cancellationToken = default)
     {
-        if (!SamsungTizenDevice.IsValidAddress(ipAddress))
-            throw new ArgumentException("Enter a valid IPv4 address.", nameof(ipAddress));
+        var address = Ipv4Address.Require(ipAddress, nameof(ipAddress));
 
         using var response = await httpClient.GetAsync(
-            $"http://{ipAddress}:8001/api/v2/", cancellationToken).ConfigureAwait(false);
+            $"http://{address}:8001/api/v2/", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        return SamsungTizenProtocol.ParseDevice(ipAddress, json);
+        return SamsungTizenProtocol.ParseDevice(address, json);
     }
 
     public async Task<IReadOnlyList<SamsungTizenDevice>> DiscoverAsync(

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenProtocol.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenProtocol.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Text.Json;
+using LittleBigMouse.Plugin.Vcp.Networking;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 
@@ -9,15 +10,14 @@ public static class SamsungTizenProtocol
 
     public static Uri RemoteUri(string ipAddress, string? token)
     {
-        if (!SamsungTizenDevice.IsValidAddress(ipAddress))
-            throw new ArgumentException("A valid IPv4 address is required.", nameof(ipAddress));
+        var address = Ipv4Address.Require(ipAddress, nameof(ipAddress), "A valid IPv4 address is required.");
 
         var name = Uri.EscapeDataString(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(AppName)));
         var tokenQuery = string.IsNullOrWhiteSpace(token)
             ? ""
             : $"&token={Uri.EscapeDataString(token)}";
 
-        return new Uri($"wss://{ipAddress}:8002/api/v2/channels/samsung.remote.control?name={name}{tokenQuery}");
+        return new Uri($"wss://{address}:8002/api/v2/channels/samsung.remote.control?name={name}{tokenQuery}");
     }
 
     public static string RemoteKeyPayload(string key, string command = "Click")

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenService.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/SamsungTizen/SamsungTizenService.cs
@@ -75,12 +75,11 @@ public sealed class SamsungTizenService : ISamsungTizenService, IAsyncDisposable
 
     public void SaveManualAddress(string monitorId, string ipAddress, string macAddress)
     {
-        if (!SamsungTizenDevice.IsValidAddress(ipAddress))
-            throw new ArgumentException("Enter a valid IPv4 address.", nameof(ipAddress));
+        var address = Ipv4Address.Require(ipAddress, nameof(ipAddress));
 
         var configuration = _store.Get(monitorId) ?? new SamsungTizenConfiguration { MonitorId = monitorId };
-        if (!configuration.IpAddress.Equals(ipAddress.Trim(), StringComparison.Ordinal)) configuration.Token = "";
-        configuration.IpAddress = ipAddress.Trim();
+        if (!configuration.IpAddress.Equals(address, StringComparison.Ordinal)) configuration.Token = "";
+        configuration.IpAddress = address;
         configuration.MacAddress = macAddress.Trim();
         _store.Save(configuration);
     }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/StaleConnectionRetry.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/StaleConnectionRetry.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia;
+
+/// <summary>
+/// Sends one command over a session that has been sitting idle, and gives it a second chance
+/// when the send is what reveals the session died meanwhile.
+///
+/// These displays keep one connection open between commands, and nothing tells the client when
+/// the other end drops it: the television goes to sleep, the projector moves to another
+/// network, a router forgets the flow. <c>TcpClient.Connected</c> and
+/// <c>WebSocketState.Open</c> both stay true until the first failed write, so that write is the
+/// probe — a transport failure on the first attempt means the session was stale, not that the
+/// display refused the command. Reporting it would show the user a network error for a key
+/// press that was never delivered anywhere.
+///
+/// Exactly one retry, and only after reopening. If the second attempt fails too, the display
+/// really is unreachable and that second failure is the one worth showing.
+/// </summary>
+public static class StaleConnectionRetry
+{
+    /// <param name="send">
+    /// Writes the command. Called once, or twice when the first call finds a dead session, so
+    /// it must be safe to repeat — which it is here, since a command lost with the session
+    /// never reached the display. It must also read the connection when it runs rather than
+    /// close over one, because <paramref name="reopen"/> replaces it between the two calls.
+    /// </param>
+    /// <param name="reopen">Drops the stale session and establishes a new one.</param>
+    /// <param name="isTransportFailure">
+    /// Tells a dead session from a refused command. Left to the caller because only it knows
+    /// what its transport raises, and because taking a protocol error for a dead socket would
+    /// send the command a second time for nothing.
+    /// </param>
+    public static async Task SendAsync(
+        Func<CancellationToken, Task> send,
+        Func<CancellationToken, Task> reopen,
+        Func<Exception, bool> isTransportFailure,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(send);
+        ArgumentNullException.ThrowIfNull(reopen);
+        ArgumentNullException.ThrowIfNull(isTransportFailure);
+
+        try
+        {
+            await send(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+        catch (Exception exception) when (isTransportFailure(exception))
+        {
+            // The session was stale. Reopen and send again below, outside the catch block, so
+            // a failure of the retry is reported on its own rather than while handling another.
+        }
+
+        await reopen(cancellationToken).ConfigureAwait(false);
+        await send(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Networking/Ipv4Address.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/Networking/Ipv4Address.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Sockets;
+
+namespace LittleBigMouse.Plugin.Vcp.Networking;
+
+/// <summary>
+/// The single rule every network-attached display in this plugin agrees on: it is reached at a
+/// literal IPv4 address. A host name is refused on purpose — the address is also what the
+/// discovery answers carry, what the pairing token is bound to and what a Wake-on-LAN burst is
+/// aimed at, so accepting something that needs resolving would move a failure from the setup
+/// panel to the middle of a command.
+///
+/// Surrounding blanks are accepted and stripped: every one of these addresses arrives from a
+/// text box.
+/// </summary>
+public static class Ipv4Address
+{
+    /// <summary>The message shown when an address entered by hand cannot be used.</summary>
+    public const string InvalidMessage = "Enter a valid IPv4 address.";
+
+    public static bool IsValid([NotNullWhen(true)] string? value) => TryParse(value, out _);
+
+    public static bool TryParse(string? value, [NotNullWhen(true)] out IPAddress? address)
+    {
+        address = null;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (!IPAddress.TryParse(value.Trim(), out var parsed)
+            || parsed.AddressFamily != AddressFamily.InterNetwork) return false;
+
+        address = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the address without its surrounding blanks, so callers store and send the same
+    /// text they validated.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value is not a literal IPv4 address.</exception>
+    public static string Require(string? value, string parameterName, string? message = null)
+        => IsValid(value)
+            ? value.Trim()
+            : throw new ArgumentException(message ?? InvalidMessage, parameterName);
+}


### PR DESCRIPTION
Follow-up to #568, which shared Wake-on-LAN between the two smart-display
clients. Four more mechanics were written twice, or in one case six times.
Each extraction is backed by real call sites on both sides; nothing about
the protocols, handshakes, remote-key models or reconnection strategies is
merged, and there is no common client interface.

## What is now shared

| Component | Replaces | Call sites |
|---|---|---|
| `Ipv4Address` (Plugin.Vcp/Networking) | 2 `IsValidAddress` helpers + 3 inline copies | 8, four per brand |
| `ExclusiveOperationRunner` | `SamsungControlViewModel.RunAsync` / `HisenseControlViewModel.Run` | 15 panel commands |
| `DeviceCommandGate` | 10 hand-written `SemaphoreSlim(1,1)` acquire/release pairs | 3 Tizen, 7 VIDAA |
| `StaleConnectionRetry` | 6 copies of send / catch / reopen / send once more | 1 Tizen, 5 VIDAA |

The per-brand parts stay injected at one point per client rather than
repeated at every call site: the timeout wording and default deadline for
the runner, and for the retry, how to reopen plus which exceptions mean a
dead transport.

Net effect on the existing files: 135 insertions, 275 deletions.

## Deliberately left separate

- **Protocols, handshakes and discovery** — WebSocket with `ms.channel.*`
  token issuance against MQTT with a PIN, a certificate and access/refresh
  tokens. Nothing under the surface is the same.
- **Per-client deadlines** — the 12 s / 6 s / 4 s waits for a VIDAA reply,
  the 6 s per credential variant, the 1 s WebSocket close: these are
  protocol reply deadlines, not the panel's command deadline.
- **The transport-failure predicates** — kept disjoint rather than merged
  into their union, which would be observably identical while hiding which
  transport is in play.
- **Per-monitor client caches in the services** — same skeleton, but VIDAA
  invalidates on eight configuration fields and swaps the client during
  pairing where Tizen does a plain get-or-create. Sharing that is a merge
  of service structure, not of an identical mechanic.
- **Wake-on-LAN bursts, `EncryptedJsonStore<T>`, `RemoteMacro`,
  `RemoteKeyboardProfile`** — already shared; only deliberate per-device
  tuning and disjoint field lists remain.
- **ViewModels and configuration classes** — neighbouring property names,
  disjoint contents. A base class here would be a universal TV client in
  disguise.

## Tests

34 new unit tests on the extracted components, covering exclusion under
concurrency, close-while-a-command-is-in-flight, retry-exactly-once, a
refused command not being replayed, and cancellation not being mistaken
for a dead session. The VCP suite goes from 104 to 145 tests, and each of
the three commits is green on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)