### PR TITLE
Separate the VIDAA transport, protocol and pairing from its façade

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/FakeVidaaTransport.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/FakeVidaaTransport.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// A VIDAA broker that never leaves the process: it records what a session publishes and
+/// subscribes, hands messages back to it, and can refuse a connection or drop one the way a real
+/// broker does — by failing the write that discovers it.
+/// </summary>
+sealed class FakeVidaaConnection : IVidaaConnection
+{
+    public List<(string Topic, string Payload)> Published { get; } = [];
+    public List<string> Subscribed { get; } = [];
+    public List<string> Unsubscribed { get; } = [];
+    public bool Connected { get; private set; } = true;
+    public bool Disposed { get; private set; }
+
+    /// <summary>Fails the next publish, as a broker that dropped the session does.</summary>
+    public Exception? PublishError { get; set; }
+
+    /// <summary>Answers a published request, the way the device would.</summary>
+    public Action<FakeVidaaConnection, string, string>? Answer { get; set; }
+
+    public event Action<string, byte[], bool>? MessageReceived;
+
+    /// <summary>Publishes a message to the session, as the device does.</summary>
+    public void Receive(string topic, string payload, bool retained = false)
+        => MessageReceived?.Invoke(topic, Encoding.UTF8.GetBytes(payload), retained);
+
+    public Task SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Subscribed.AddRange(topics);
+        return Task.CompletedTask;
+    }
+
+    public Task UnsubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Unsubscribed.AddRange(topics);
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAsync(string topic, string payload, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (PublishError is { } error)
+        {
+            PublishError = null;
+            Connected = false;
+            return Task.FromException(error);
+        }
+        Published.Add((topic, payload));
+        Answer?.Invoke(this, topic, payload);
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        Connected = false;
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Opens <see cref="FakeVidaaConnection"/>s, and records or refuses the attempts.</summary>
+sealed class FakeVidaaTransport
+{
+    readonly Queue<Exception> _refusals = new();
+
+    public List<VidaaConnectionRequest> Requests { get; } = [];
+    public List<FakeVidaaConnection> Connections { get; } = [];
+
+    /// <summary>The connection the session is using, once it has opened one.</summary>
+    public FakeVidaaConnection Current => Connections[^1];
+
+    /// <summary>Refuses the next attempt with <paramref name="error"/>.</summary>
+    public void Refuse(Exception error) => _refusals.Enqueue(error);
+
+    /// <summary>Prepares every connection this transport will open.</summary>
+    public Action<FakeVidaaConnection>? OnOpened { get; set; }
+
+    public Task<IVidaaConnection> OpenAsync(
+        VidaaConnectionRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Requests.Add(request);
+        if (_refusals.Count > 0) return Task.FromException<IVidaaConnection>(_refusals.Dequeue());
+
+        var connection = new FakeVidaaConnection();
+        OnOpened?.Invoke(connection);
+        Connections.Add(connection);
+        return Task.FromResult<IVidaaConnection>(connection);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaClientTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaClientTests.cs
@@ -1,0 +1,273 @@
+using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// The client as its callers see it — pairing, commands and answers — over
+/// <see cref="FakeVidaaTransport"/> rather than a device on the network.
+/// </summary>
+public class HisenseVidaaClientTests
+{
+    const string ControllerMac = "9c:69:b4:61:a9:78";
+    const string DeviceMac = "56:b8:88:4e:f7:19";
+    const string DeviceClientId = "56:b8:88:4e:f7:19$his$256DBF_vidaacommon_001";
+    const string RemoteNowTopic = "9C:69:B4:61:A9:78$normal";
+
+    static HisenseVidaaConfiguration Paired() => new()
+    {
+        MonitorId = "HEC002F",
+        IpAddress = "192.168.0.181",
+        ProtocolVersion = 3290,
+        ClientId = DeviceClientId,
+        MqttUsername = "his$6239759786168176024",
+        AccessToken = "access-token",
+    };
+
+    /// <summary>A device known but never paired, with the controller MAC already resolved.</summary>
+    static HisenseVidaaConfiguration Unpaired(int? protocolVersion) => new()
+    {
+        MonitorId = "HEC002F",
+        IpAddress = "192.168.0.181",
+        ProtocolVersion = protocolVersion,
+        ControllerMacAddress = ControllerMac,
+        DeviceUuid = DeviceMac,
+    };
+
+    [Fact]
+    public async Task SendsTheTranslatedKeyOnThePairedSession()
+    {
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(Paired(), transport.OpenAsync);
+
+        await client.SendKeyAsync("KEY_VOLUP", default);
+
+        Assert.True(client.Connected);
+        Assert.Equal(
+            ($"/remoteapp/tv/remote_service/{DeviceClientId}/actions/sendkey", "KEY_VOLUMEUP"),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task ReconnectsAndSendsAgainWhenTheDeviceDroppedTheSession()
+    {
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(Paired(), transport.OpenAsync);
+        await client.SendKeyAsync("KEY_OK", default);
+        transport.Current.PublishError = new IOException("write found the connection closed");
+
+        await client.SendKeyAsync("KEY_OK", default);
+
+        Assert.Equal(2, transport.Connections.Count);
+        Assert.True(transport.Connections[0].Disposed);
+        Assert.Equal("KEY_OK", Assert.Single(transport.Current.Published).Payload);
+    }
+
+    [Fact]
+    public async Task ReadsTheVolumeTheDeviceBroadcastsBack()
+    {
+        var transport = new FakeVidaaTransport
+        {
+            OnOpened = connection => connection.Answer = (device, topic, _) =>
+            {
+                if (topic.EndsWith("/actions/getvolume", StringComparison.Ordinal))
+                    device.Receive(
+                        "/remoteapp/mobile/broadcast/platform_service/actions/volumechange",
+                        "{\"volume_type\":0,\"volume_value\":37}");
+            },
+        };
+        await using var client = new HisenseVidaaClient(Paired(), transport.OpenAsync);
+
+        Assert.Equal(37, await client.GetVolumeAsync(default));
+        Assert.Equal(
+            ($"/remoteapp/tv/platform_service/{DeviceClientId}/actions/getvolume", "0"),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task ReadsThePictureSettingsTheDeviceLists()
+    {
+        var transport = new FakeVidaaTransport
+        {
+            OnOpened = connection => connection.Answer = (device, _, payload) =>
+            {
+                if (payload == HisenseVidaaProtocol.PictureSettingsRequestPayload())
+                    device.Receive(
+                        "/remoteapp/mobile/broadcast/platform_service/data/picturesetting",
+                        "{\"menu_info\":[{\"menu_id\":2,\"menu_name\":\"Laser Luminance\",\"menu_value\":5,\"menu_value_type\":\"int\",\"menu_flag\":1}]}");
+            },
+        };
+        await using var client = new HisenseVidaaClient(Paired(), transport.OpenAsync);
+
+        var settings = await client.GetPictureSettingsAsync(default);
+
+        Assert.Equal(new VidaaPictureSetting(2, "Laser Luminance", "5", "int", 1), Assert.Single(settings));
+    }
+
+    [Fact]
+    public async Task RefusesCommandsOnceTheClientIsDisposed()
+    {
+        var transport = new FakeVidaaTransport();
+        var client = new HisenseVidaaClient(Paired(), transport.OpenAsync);
+        await client.SendKeyAsync("KEY_OK", default);
+
+        await client.DisposeAsync();
+
+        Assert.True(transport.Current.Disposed);
+        Assert.False(client.Connected);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.SendKeyAsync("KEY_OK", default));
+    }
+
+    [Fact]
+    public async Task PairsARemoteNowDeviceOnItsOwnTopic()
+    {
+        var configuration = Unpaired(2160);
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+
+        await client.StartPairingAsync(default);
+
+        Assert.Equal(VidaaAuthMethod.Legacy, configuration.AuthMethod);
+        Assert.Equal(RemoteNowTopic, configuration.ClientId);
+        Assert.False(configuration.LegacyAuthorized);
+        Assert.Equal(
+            HisenseVidaaProtocol.LegacyResponseTopics(RemoteNowTopic),
+            transport.Current.Subscribed);
+        Assert.Equal(
+            ($"/remoteapp/tv/ui_service/{RemoteNowTopic}/actions/gettvstate", ""),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task AuthorisesARemoteNowDeviceWithTheDisplayedPin()
+    {
+        var configuration = Unpaired(2160);
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+        await client.StartPairingAsync(default, requestPin: false);
+        transport.Current.Answer = (device, topic, _) =>
+        {
+            if (topic.EndsWith("/actions/authenticationcode", StringComparison.Ordinal))
+                device.Receive($"/remoteapp/mobile/{RemoteNowTopic}/ui_service/data/authentication", "");
+        };
+
+        await client.AuthenticateAsync("1234", default);
+
+        Assert.True(configuration.LegacyAuthorized);
+        Assert.True(configuration.HasPairing);
+        Assert.Equal(
+            ($"/remoteapp/tv/ui_service/{RemoteNowTopic}/actions/authenticationcode", "{\"authNum\":\"1234\"}"),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task TriesTheKnownCredentialVariantsUntilTheDeviceLetsOneIn()
+    {
+        var configuration = Unpaired(protocolVersion: null);
+        var transport = new FakeVidaaTransport();
+        transport.Refuse(new UnauthorizedAccessException("VIDAA rejected the generated username or password."));
+        // A broker that goes silent after a rejection must not stop the sweep either.
+        transport.Refuse(new OperationCanceledException());
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+
+        await client.StartPairingAsync(default);
+
+        Assert.Equal(3, transport.Requests.Count);
+        Assert.Equal(DeviceClientId, configuration.ClientId);
+        Assert.Equal(DeviceMac, configuration.DeviceUuid);
+        Assert.Equal(VidaaAuthMethod.Middle, configuration.AuthMethod);
+        Assert.Equal(transport.Requests[2].Username, configuration.MqttUsername);
+        Assert.Equal(
+            ($"/remoteapp/tv/ui_service/{DeviceClientId}/actions/vidaa_app_connect",
+                HisenseVidaaProtocol.PairingRequestPayload()),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task ReportsThatTheDeviceRejectedEveryCredentialVariant()
+    {
+        var configuration = Unpaired(protocolVersion: null);
+        var transport = new FakeVidaaTransport();
+        var last = new UnauthorizedAccessException("VIDAA refused authorization.");
+        for (var attempt = 0; attempt < 5; attempt++)
+            transport.Refuse(new UnauthorizedAccessException("VIDAA rejected the generated username or password."));
+        transport.Refuse(last);
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+
+        var error = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => client.StartPairingAsync(default));
+
+        // Three authentication methods over the two spellings of the device identity.
+        Assert.Equal(6, transport.Requests.Count);
+        Assert.Contains("protocol unknown", error.Message);
+        Assert.Contains(DeviceMac, error.Message);
+        Assert.Same(last, error.InnerException);
+    }
+
+    [Fact]
+    public async Task TradesThePinForTheTokensLaterSessionsReuse()
+    {
+        var configuration = Unpaired(3290);
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+        await client.StartPairingAsync(default);
+        var clientId = configuration.ClientId;
+        transport.Current.Answer = (device, topic, _) =>
+        {
+            if (topic.EndsWith("/actions/authenticationcode", StringComparison.Ordinal))
+                device.Receive($"/remoteapp/mobile/{clientId}/ui_service/data/authentication", "{\"result\":1}");
+            if (topic == HisenseVidaaProtocol.TokenRequestTopic(clientId))
+                device.Receive(
+                    $"/remoteapp/mobile/{clientId}/platform_service/data/tokenissuance",
+                    "{\"accesstoken\":\"access\",\"refreshtoken\":\"refresh\",\"accesstoken_duration_day\":5}");
+        };
+
+        await client.AuthenticateAsync("1234", default);
+
+        Assert.Equal("access", configuration.AccessToken);
+        Assert.Equal("refresh", configuration.RefreshToken);
+        Assert.True(configuration.HasPairing);
+        Assert.Equal(
+            [
+                $"/remoteapp/tv/ui_service/{clientId}/actions/vidaa_app_connect",
+                $"/remoteapp/tv/ui_service/{clientId}/actions/authenticationcode",
+                HisenseVidaaProtocol.TokenRequestTopic(clientId),
+                $"/remoteapp/tv/ui_service/{clientId}/actions/authenticationcodeclose",
+            ],
+            transport.Current.Published.Select(message => message.Topic));
+    }
+
+    [Fact]
+    public async Task ReportsAPinTheDeviceRejected()
+    {
+        var configuration = Unpaired(3290);
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+        await client.StartPairingAsync(default);
+        var clientId = configuration.ClientId;
+        transport.Current.Answer = (device, topic, _) =>
+        {
+            if (topic.EndsWith("/actions/authenticationcode", StringComparison.Ordinal))
+                device.Receive($"/remoteapp/mobile/{clientId}/ui_service/data/authentication", "{\"result\":0}");
+        };
+
+        var error = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => client.AuthenticateAsync("1234", default));
+
+        Assert.Equal("The VIDAA PIN was rejected.", error.Message);
+        Assert.False(configuration.HasPairing);
+    }
+
+    [Fact]
+    public async Task RefusesToAuthenticateWithoutAnOpenSession()
+    {
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(Unpaired(3290), transport.OpenAsync);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.AuthenticateAsync("1234", default));
+
+        Assert.Equal("The VIDAA connection is not open.", error.Message);
+        Assert.Empty(transport.Requests);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaProtocolTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaProtocolTests.cs
@@ -128,6 +128,15 @@ public class HisenseVidaaProtocolTests
     }
 
     [Fact]
+    public void AsksForAFirstPairOfTokensOnTheDataTopic()
+    {
+        Assert.Equal(
+            "/remoteapp/tv/platform_service/56:b8:88:4e:f7:19$his$256DBF_vidaacommon_001/data/gettoken",
+            HisenseVidaaProtocol.TokenRequestTopic("56:b8:88:4e:f7:19$his$256DBF_vidaacommon_001"));
+        Assert.Equal("{\"refreshtoken\":\"\"}", HisenseVidaaProtocol.TokenRequestPayload());
+    }
+
+    [Fact]
     public void GeneratesAbsoluteVolumeCommand()
         => Assert.Equal("37", HisenseVidaaProtocol.VolumePayload(37));
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VidaaResponseRouterTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VidaaResponseRouterTests.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// What the device publishes, read as the answer a command is waiting for. The formats themselves
+/// are covered by <see cref="HisenseVidaaProtocolTests"/>; here it is the routing that matters.
+/// </summary>
+public class VidaaResponseRouterTests
+{
+    const string VolumeTopic = "/remoteapp/mobile/broadcast/platform_service/actions/volumechange";
+    const string PictureSettingTopic = "/remoteapp/mobile/broadcast/platform_service/data/picturesetting";
+    const string AuthenticationTopic = "/remoteapp/mobile/client/ui_service/data/authentication";
+    const string TokenTopic = "/remoteapp/mobile/client/ui_service/data/tokenissuance";
+
+    static void Deliver(VidaaResponseRouter router, string topic, string payload)
+        => router.Handle(topic, Encoding.UTF8.GetBytes(payload), retained: false);
+
+    [Fact]
+    public async Task AnswersTheVolumeCommandWaitingForIt()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+
+        var volume = await router.Volume.CollectAsync(
+            _ =>
+            {
+                Deliver(router, VolumeTopic, "{\"volume_type\":0,\"volume_value\":37}");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1), default);
+
+        Assert.Equal(37, volume);
+    }
+
+    [Fact]
+    public async Task AnswersThePictureSettingsCommandWaitingForIt()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+
+        var settings = await router.PictureSettings.CollectAsync(
+            _ =>
+            {
+                Deliver(router, PictureSettingTopic,
+                    "{\"menu_info\":[{\"menu_id\":2,\"menu_name\":\"Laser Luminance\",\"menu_value\":5,\"menu_value_type\":\"int\",\"menu_flag\":1}]}");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1), default);
+
+        Assert.Equal(new VidaaPictureSetting(2, "Laser Luminance", "5", "int", 1), Assert.Single(settings));
+    }
+
+    [Fact]
+    public async Task StoresTheTokensAPairingIssues()
+    {
+        var configuration = new HisenseVidaaConfiguration();
+        var router = new VidaaResponseRouter(configuration);
+        var issued = router.TokenIssued.Expect();
+
+        Deliver(router, TokenTopic,
+            """
+            {"accesstoken":"access","refreshtoken":"refresh",
+             "accesstoken_time":1766974704,"refreshtoken_time":1766974705,
+             "accesstoken_duration_day":5}
+            """);
+
+        Assert.True(await issued.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal("access", configuration.AccessToken);
+        Assert.Equal("refresh", configuration.RefreshToken);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1766974704), configuration.AccessTokenIssuedAt);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1766974705), configuration.RefreshTokenIssuedAt);
+        Assert.Equal(5, configuration.AccessTokenDurationDays);
+        // The device does not always state the refresh lifetime; the documented default holds.
+        Assert.Equal(30, configuration.RefreshTokenDurationDays);
+    }
+
+    [Fact]
+    public void KeepsTheStoredTokensWhenTheAnswerCarriesNone()
+    {
+        var configuration = new HisenseVidaaConfiguration { AccessToken = "access" };
+        var router = new VidaaResponseRouter(configuration);
+        var issued = router.TokenIssued.Expect();
+
+        Deliver(router, TokenTopic, "{\"result\":0}");
+
+        Assert.Equal("access", configuration.AccessToken);
+        Assert.False(issued.IsCompleted);
+    }
+
+    [Fact]
+    public async Task AcceptsTheEmptyRemoteNowAcknowledgement()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+        var accepted = router.PinAccepted.Expect();
+
+        router.Handle(AuthenticationTopic, [], retained: false);
+
+        Assert.True(await accepted.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public async Task ReportsARejectedPin()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+        var accepted = router.PinAccepted.Expect();
+
+        Deliver(router, AuthenticationTopic, "{\"result\":0}");
+
+        var error = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => accepted.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal("The VIDAA PIN was rejected.", error.Message);
+    }
+
+    [Fact]
+    public void LeavesACommandWaitingWhenTheAnswerIsMalformed()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+        var accepted = router.PinAccepted.Expect();
+
+        Deliver(router, AuthenticationTopic, "not json");
+
+        Assert.False(accepted.IsCompleted);
+    }
+
+    [Fact]
+    public void IgnoresAnAnswerNobodyIsWaitingFor()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+
+        Deliver(router, VolumeTopic, "{\"volume_value\":37}");
+        Deliver(router, "/remoteapp/mobile/broadcast/ui_service/state", "{\"statetype\":\"livetv\"}");
+    }
+
+    [Fact]
+    public async Task StopsWaitingForAnAnswerThatNeverCame()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+
+        await Assert.ThrowsAsync<TimeoutException>(() => router.Volume.CollectAsync(
+            _ => Task.CompletedTask, TimeSpan.FromMilliseconds(20), default));
+    }
+
+    [Fact]
+    public async Task DoesNotLetALaterNotificationAnswerACommandNobodyAsked()
+    {
+        var router = new VidaaResponseRouter(new HisenseVidaaConfiguration());
+        await router.Volume.CollectAsync(
+            _ =>
+            {
+                Deliver(router, VolumeTopic, "{\"volume_value\":37}");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1), default);
+
+        // The device keeps broadcasting volume changes between commands.
+        Deliver(router, VolumeTopic, "{\"volume_value\":11}");
+
+        var volume = await router.Volume.CollectAsync(
+            _ =>
+            {
+                Deliver(router, VolumeTopic, "{\"volume_value\":42}");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1), default);
+        Assert.Equal(42, volume);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VidaaSessionTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/VidaaSessionTests.cs
@@ -1,0 +1,205 @@
+using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// The connection a VIDAA device accepts, driven over <see cref="FakeVidaaTransport"/>: what
+/// opens it, what reopens it, and what it refuses to do without a pairing.
+/// </summary>
+public class VidaaSessionTests
+{
+    static HisenseVidaaConfiguration Paired() => new()
+    {
+        MonitorId = "HEC002F",
+        IpAddress = "192.168.0.181",
+        ProtocolVersion = 3290,
+        ClientId = "56:b8:88:4e:f7:19$his$256DBF_vidaacommon_001",
+        MqttUsername = "his$6239759786168176024",
+        AccessToken = "access-token",
+        ClientCertificatePath = "/home/user/.config/LittleBigMouse/vidaa-client.p12",
+        ClientCertificatePassword = "certificate-password",
+    };
+
+    static HisenseVidaaConfiguration PairedRemoteNow() => new()
+    {
+        MonitorId = "HEC002F",
+        IpAddress = "192.168.0.181",
+        ProtocolVersion = 2160,
+        ClientId = "9C:69:B4:61:A9:78$normal",
+        MqttUsername = HisenseVidaaProtocol.LegacyMqttUsername,
+        LegacyAuthorized = true,
+        ClientCertificatePath = "/home/user/.config/LittleBigMouse/vidaa-client.p12",
+        ClientCertificatePassword = "certificate-password",
+    };
+
+    [Fact]
+    public async Task OpensThePairedSessionAndSubscribesTheAnswerTopics()
+    {
+        var configuration = Paired();
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(configuration, transport.OpenAsync);
+
+        await session.SendAsync("/remoteapp/tv/remote_service/client/actions/sendkey", "KEY_OK", default);
+
+        var request = Assert.Single(transport.Requests);
+        Assert.Equal(configuration.IpAddress, request.Host);
+        Assert.Equal(configuration.ClientId, request.ClientId);
+        Assert.Equal(configuration.MqttUsername, request.Username);
+        Assert.Equal(configuration.AccessToken, request.Password);
+        Assert.Equal(configuration.ClientCertificatePath, request.CertificatePath);
+        Assert.Equal(configuration.ClientCertificatePassword, request.CertificatePassword);
+        Assert.Equal(HisenseVidaaProtocol.ResponseTopics(configuration.ClientId), transport.Current.Subscribed);
+        Assert.Equal(
+            ("/remoteapp/tv/remote_service/client/actions/sendkey", "KEY_OK"),
+            Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task KeepsOneSessionForConsecutiveCommands()
+    {
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+
+        await session.SendAsync("first", "1", default);
+        await session.SendAsync("second", "2", default);
+
+        Assert.Single(transport.Connections);
+        Assert.Equal(2, transport.Current.Published.Count);
+    }
+
+    [Fact]
+    public async Task RefusesToOpenASessionTheDeviceHasNotPaired()
+    {
+        var configuration = Paired();
+        configuration.AccessToken = "";
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(configuration, transport.OpenAsync);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => session.SendAsync("topic", "payload", default));
+
+        Assert.Equal("Pair this Hisense VIDAA device first.", error.Message);
+        Assert.Empty(transport.Requests);
+    }
+
+    [Fact]
+    public async Task ClosesTheDeadSessionThenSendsAgainWhenAWriteFindsItGone()
+    {
+        var transport = new FakeVidaaTransport();
+        // The broker accepts one persistent session at a time, so the dead one has to be closed
+        // before another is asked for.
+        transport.OnOpened = _ => Assert.All(transport.Connections, previous => Assert.True(previous.Disposed));
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+        await session.SendAsync("first", "1", default);
+        transport.Current.PublishError = new IOException("write found the connection closed");
+
+        await session.SendAsync("sendkey", "KEY_OK", default);
+
+        Assert.Equal(2, transport.Connections.Count);
+        Assert.True(transport.Connections[0].Disposed);
+        Assert.Equal(("sendkey", "KEY_OK"), Assert.Single(transport.Current.Published));
+    }
+
+    [Fact]
+    public async Task DoesNotReopenASessionForACommandTheDeviceRefused()
+    {
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+        await session.SendAsync("first", "1", default);
+        transport.Current.PublishError = new UnauthorizedAccessException("the device denied the command");
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => session.SendAsync("sendkey", "KEY_OK", default));
+
+        Assert.Single(transport.Connections);
+    }
+
+    [Fact]
+    public async Task ReportsTheSecondFailureWhenTheReopenedSessionDiesToo()
+    {
+        var transport = new FakeVidaaTransport
+        {
+            OnOpened = connection => connection.PublishError = new IOException("write 2 found the connection closed"),
+        };
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+        await session.EnsureOpenAsync(default);
+
+        var error = await Assert.ThrowsAsync<IOException>(
+            () => session.SendAsync("sendkey", "KEY_OK", default));
+
+        Assert.Equal("write 2 found the connection closed", error.Message);
+        Assert.Equal(2, transport.Connections.Count);
+    }
+
+    [Fact]
+    public async Task ForwardsWhatTheDevicePublishesUntilTheSessionIsClosed()
+    {
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+        var topics = new List<string>();
+        session.MessageReceived += (topic, _, _) => topics.Add(topic);
+        await session.EnsureOpenAsync(default);
+        var connection = transport.Current;
+
+        connection.Receive("/remoteapp/mobile/broadcast/ui_service/state", "{}");
+        await session.CloseAsync();
+        connection.Receive("/remoteapp/mobile/broadcast/ui_service/state", "{}");
+
+        Assert.Equal(["/remoteapp/mobile/broadcast/ui_service/state"], topics);
+        Assert.True(connection.Disposed);
+        Assert.False(session.Connected);
+    }
+
+    [Fact]
+    public async Task RemoteNowSessionsUseTheServiceAccountAndTheirOwnAnswerTopics()
+    {
+        var configuration = PairedRemoteNow();
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(configuration, transport.OpenAsync);
+
+        await session.EnsureOpenAsync(default);
+        var first = transport.Requests[0].ClientId;
+        await session.CloseAsync();
+        await session.EnsureOpenAsync(default);
+
+        Assert.All(transport.Requests, request =>
+        {
+            Assert.Equal(HisenseVidaaProtocol.LegacyMqttUsername, request.Username);
+            Assert.Equal(HisenseVidaaProtocol.LegacyMqttPassword, request.Password);
+            Assert.StartsWith("LittleBigMouse/", request.ClientId);
+        });
+        // The service account is shared, so each session takes an identifier of its own.
+        Assert.NotEqual(first, transport.Requests[1].ClientId);
+        Assert.Equal(
+            HisenseVidaaProtocol.LegacyResponseTopics(configuration.ClientId),
+            transport.Current.Subscribed);
+    }
+
+    [Fact]
+    public async Task DoesNotOpenASessionForACancelledCommand()
+    {
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => session.SendAsync("sendkey", "KEY_OK", cancellation.Token));
+
+        Assert.Empty(transport.Requests);
+        Assert.False(session.Connected);
+    }
+
+    [Fact]
+    public async Task RefusesToPublishOnASessionThatIsNotOpen()
+    {
+        var transport = new FakeVidaaTransport();
+        var session = new VidaaSession(Paired(), transport.OpenAsync);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => session.PublishAsync("topic", "payload", default));
+
+        Assert.Equal("The VIDAA connection is not open.", error.Message);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaClient.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaClient.cs
@@ -1,182 +1,94 @@
 #nullable enable
 using System.Collections.Concurrent;
-using System.Text;
-using System.Text.Json;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
-public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) : IAsyncDisposable
+/// <summary>
+/// What one Hisense VIDAA device can be asked to do, over the one session it accepts.
+///
+/// The façade owns the layers underneath and keeps them apart: <see cref="VidaaSession"/> holds
+/// the connection and reopens it, <see cref="VidaaResponseRouter"/> turns what the device
+/// publishes into the answers commands wait for, and <see cref="VidaaPairing"/> settles what a
+/// session needs to be accepted. What is left here is the shape of each command — its topic, its
+/// payload, and how long its answer is worth waiting for — and the guarantee that only one runs
+/// at a time on that shared session.
+/// </summary>
+public sealed class HisenseVidaaClient : IAsyncDisposable
 {
-    readonly HisenseVidaaConfiguration _configuration = configuration;
-    readonly DeviceCommandGate _commands = new();
-    VidaaMqttConnection? _connection;
-    TaskCompletionSource<bool>? _pinAccepted;
-    TaskCompletionSource<bool>? _tokenIssued;
-    TaskCompletionSource<int>? _volumeReceived;
-    TaskCompletionSource<IReadOnlyList<VidaaPictureSetting>>? _pictureSettingsReceived;
+    /// <summary>The device answers a settings request in one message, or not at all.</summary>
+    static readonly TimeSpan PictureSettingsTimeout = TimeSpan.FromSeconds(6);
 
-    public bool Connected => _connection?.Connected == true;
+    /// <summary>A volume change is echoed on the broadcast topic almost immediately.</summary>
+    static readonly TimeSpan VolumeTimeout = TimeSpan.FromSeconds(4);
+
+    /// <summary>Everything the broker holds, for the traffic listener only.</summary>
+    static readonly string[] AllTopics = ["#"];
+
+    readonly HisenseVidaaConfiguration _configuration;
+    readonly DeviceCommandGate _commands = new();
+    readonly VidaaSession _session;
+    readonly VidaaResponseRouter _responses;
+    readonly VidaaPairing _pairing;
+
+    public HisenseVidaaClient(HisenseVidaaConfiguration configuration)
+        : this(configuration, transport: null)
+    {
+    }
+
+    /// <param name="transport">
+    /// Opens the MQTT connections of this client. Defaults to the real TLS transport; tests pass
+    /// a simulated one to drive pairing and reconnection without a device on the network.
+    /// </param>
+    internal HisenseVidaaClient(
+        HisenseVidaaConfiguration configuration,
+        VidaaConnectionFactory? transport)
+    {
+        _configuration = configuration;
+        _responses = new VidaaResponseRouter(configuration);
+        _session = new VidaaSession(configuration, transport);
+        _session.MessageReceived += _responses.Handle;
+        _pairing = new VidaaPairing(configuration, _session, _responses);
+    }
+
+    public bool Connected => _session.Connected;
     public HisenseVidaaConfiguration Configuration => _configuration;
 
-    public async Task StartPairingAsync(
-        CancellationToken cancellationToken,
-        bool requestPin = true)
-    {
-        if (string.IsNullOrWhiteSpace(_configuration.ControllerMacAddress))
-            _configuration.ControllerMacAddress = NetworkIdentity.ControllerMacFor(_configuration.IpAddress);
+    public Task StartPairingAsync(CancellationToken cancellationToken, bool requestPin = true)
+        => _pairing.StartAsync(requestPin, cancellationToken);
 
-        if (HisenseVidaaProtocol.UsesStaticLegacyProtocol(_configuration.ProtocolVersion))
-        {
-            var legacyIdentity = HisenseVidaaProtocol.NormalizeMac(_configuration.ControllerMacAddress)
-                .ToUpperInvariant();
-            _configuration.DeviceUuid = legacyIdentity;
-            _configuration.AuthMethod = VidaaAuthMethod.Legacy;
-            _configuration.ClientId = HisenseVidaaProtocol.LegacyDeviceTopic(legacyIdentity);
-            _configuration.MqttUsername = HisenseVidaaProtocol.LegacyMqttUsername;
-            _configuration.AccessToken = "";
-            _configuration.RefreshToken = "";
-            _configuration.LegacyAuthorized = false;
-            await ConnectAsync(
-                HisenseVidaaProtocol.LegacyMqttPassword,
-                $"LittleBigMouse/{Guid.NewGuid():N}",
-                HisenseVidaaProtocol.LegacyMqttUsername,
-                cancellationToken).ConfigureAwait(false);
-            _pinAccepted = NewSignal();
-            if (requestPin)
-                await _connection!.PublishAsync(
-                    HisenseVidaaProtocol.Topic("ui_service", _configuration.ClientId, "gettvstate"),
-                    "", cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        var identity = PairingIdentity();
-        var identities = new[] { identity, identity.ToLowerInvariant(), identity.ToUpperInvariant() }
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-        var methods = _configuration.ProtocolVersion is null
-            ? new[] { VidaaAuthMethod.Modern, VidaaAuthMethod.Middle, VidaaAuthMethod.Legacy }
-            : new[] { HisenseVidaaProtocol.AuthMethodFor(_configuration.ProtocolVersion) };
-        UnauthorizedAccessException? lastAuthorizationError = null;
-
-        foreach (var method in methods)
-        foreach (var candidate in identities)
-        {
-            var credentials = HisenseVidaaProtocol.GenerateCredentials(
-                candidate, method, brand: NormalizedBrand());
-            try
-            {
-                using var attempt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                attempt.CancelAfter(TimeSpan.FromSeconds(6));
-                await ConnectAsync(credentials.Password, credentials.ClientId, credentials.Username, attempt.Token)
-                    .ConfigureAwait(false);
-                _configuration.DeviceUuid = candidate;
-                _configuration.AuthMethod = method;
-                _configuration.ClientId = credentials.ClientId;
-                _configuration.MqttUsername = credentials.Username;
-                _configuration.AccessToken = "";
-                _configuration.RefreshToken = "";
-                goto Connected;
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                lastAuthorizationError = e;
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                // Some brokers delay a reconnect after rejecting a credential
-                // variant. Continue with the next known representation.
-            }
-        }
-
-        var protocol = _configuration.ProtocolVersion?.ToString() ?? "unknown";
-        throw new UnauthorizedAccessException(
-            $"VIDAA rejected every authentication variant for protocol {protocol} and controller {identity}. " +
-            "Check the projector date, time and timezone.", lastAuthorizationError);
-
-        Connected:
-
-        _pinAccepted = NewSignal();
-        _tokenIssued = NewSignal();
-        if (requestPin)
-            await _connection!.PublishAsync(
-                HisenseVidaaProtocol.Topic("ui_service", _configuration.ClientId, "vidaa_app_connect"),
-                HisenseVidaaProtocol.PairingRequestPayload(), cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task AuthenticateAsync(string pin, CancellationToken cancellationToken)
-    {
-        if (_connection is null || !_connection.Connected)
-            throw new InvalidOperationException("The VIDAA connection is not open.");
-
-        _pinAccepted = NewSignal();
-        _tokenIssued = NewSignal();
-        await _connection.PublishAsync(
-            HisenseVidaaProtocol.Topic("ui_service", _configuration.ClientId, "authenticationcode"),
-            HisenseVidaaProtocol.UsesStaticLegacyProtocol(_configuration.ProtocolVersion)
-                ? HisenseVidaaProtocol.LegacyPinPayload(pin)
-                : HisenseVidaaProtocol.PinPayload(pin), cancellationToken).ConfigureAwait(false);
-
-        await _pinAccepted.Task.WaitAsync(TimeSpan.FromSeconds(12), cancellationToken).ConfigureAwait(false);
-        if (HisenseVidaaProtocol.UsesStaticLegacyProtocol(_configuration.ProtocolVersion))
-        {
-            _configuration.LegacyAuthorized = true;
-            return;
-        }
-        await _connection.PublishAsync(
-            $"/remoteapp/tv/platform_service/{_configuration.ClientId}/data/gettoken",
-            "{\"refreshtoken\":\"\"}", cancellationToken).ConfigureAwait(false);
-        await _connection.PublishAsync(
-            HisenseVidaaProtocol.Topic("ui_service", _configuration.ClientId, "authenticationcodeclose"),
-            "", cancellationToken).ConfigureAwait(false);
-        await _tokenIssued.Task.WaitAsync(TimeSpan.FromSeconds(12), cancellationToken).ConfigureAwait(false);
-    }
+    public Task AuthenticateAsync(string pin, CancellationToken cancellationToken)
+        => _pairing.AuthenticateAsync(pin, cancellationToken);
 
     public Task SendKeyAsync(string key, CancellationToken cancellationToken)
-        => _commands.RunExclusiveAsync(async commandToken =>
-        {
-            var topic = HisenseVidaaProtocol.Topic("remote_service", _configuration.ClientId, "sendkey");
-            var payload = HisenseVidaaProtocol.TranslateKey(key);
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            await SendWithRetryAsync(
-                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
-        }, cancellationToken);
+    {
+        var topic = HisenseVidaaProtocol.Topic("remote_service", _configuration.ClientId, "sendkey");
+        var payload = HisenseVidaaProtocol.TranslateKey(key);
+        return _commands.RunExclusiveAsync(
+            token => _session.SendAsync(topic, payload, token), cancellationToken);
+    }
 
     public Task SetPictureSettingAsync(int menuId, int value, CancellationToken cancellationToken)
     {
         var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, "picturesetting");
         var payload = HisenseVidaaProtocol.PictureSettingPayload(menuId, value);
-        return _commands.RunExclusiveAsync(async commandToken =>
-        {
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            await SendWithRetryAsync(
-                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
-        }, cancellationToken);
+        return _commands.RunExclusiveAsync(
+            token => _session.SendAsync(topic, payload, token), cancellationToken);
     }
 
     public Task<IReadOnlyList<VidaaPictureSetting>> GetPictureSettingsAsync(
         CancellationToken cancellationToken)
-        => _commands.RunExclusiveAsync(async commandToken =>
+    {
+        var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, "picturesetting");
+        var payload = HisenseVidaaProtocol.PictureSettingsRequestPayload();
+        return _commands.RunExclusiveAsync(async token =>
         {
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            var signal = new TaskCompletionSource<IReadOnlyList<VidaaPictureSetting>>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            _pictureSettingsReceived = signal;
-            var topic = HisenseVidaaProtocol.Topic(
-                "platform_service", _configuration.ClientId, "picturesetting");
-            try
-            {
-                await SendWithRetryAsync(
-                    token => _connection!.PublishAsync(
-                        topic, HisenseVidaaProtocol.PictureSettingsRequestPayload(), token),
-                    commandToken).ConfigureAwait(false);
-                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(6), commandToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                if (ReferenceEquals(_pictureSettingsReceived, signal)) _pictureSettingsReceived = null;
-            }
+            await _session.EnsureOpenAsync(token).ConfigureAwait(false);
+            return await _responses.PictureSettings.CollectAsync(
+                    requestToken => _session.SendAsync(topic, payload, requestToken),
+                    PictureSettingsTimeout, token)
+                .ConfigureAwait(false);
         }, cancellationToken);
+    }
 
     public Task<int> GetVolumeAsync(CancellationToken cancellationToken)
         => SendVolumeActionAsync("getvolume", "0", cancellationToken);
@@ -191,33 +103,24 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
             _configuration.ClientId,
             HisenseVidaaProtocol.PlatformActionName(action));
         var payload = HisenseVidaaProtocol.ExperimentalLevelPayload(value);
-        return _commands.RunExclusiveAsync(async commandToken =>
-        {
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            await SendWithRetryAsync(
-                token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
-        }, cancellationToken);
+        return _commands.RunExclusiveAsync(
+            token => _session.SendAsync(topic, payload, token), cancellationToken);
     }
 
     Task<int> SendVolumeActionAsync(string action, string payload, CancellationToken cancellationToken)
-        => _commands.RunExclusiveAsync(async commandToken =>
+    {
+        var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, action);
+        return _commands.RunExclusiveAsync(async token =>
         {
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            var signal = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _volumeReceived = signal;
-            var topic = HisenseVidaaProtocol.Topic("platform_service", _configuration.ClientId, action);
-            try
-            {
-                await SendWithRetryAsync(
-                    token => _connection!.PublishAsync(topic, payload, token), commandToken).ConfigureAwait(false);
-                return await signal.Task.WaitAsync(TimeSpan.FromSeconds(4), commandToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                if (ReferenceEquals(_volumeReceived, signal)) _volumeReceived = null;
-            }
+            await _session.EnsureOpenAsync(token).ConfigureAwait(false);
+            return await _responses.Volume.CollectAsync(
+                    requestToken => _session.SendAsync(topic, payload, requestToken),
+                    VolumeTimeout, token)
+                .ConfigureAwait(false);
         }, cancellationToken);
+    }
 
+    /// <summary>Listens for <paramref name="duration"/>, keeping the first 200 messages.</summary>
     public async Task<IReadOnlyList<VidaaTrafficMessage>> CaptureTrafficAsync(
         TimeSpan duration,
         CancellationToken cancellationToken)
@@ -239,50 +142,30 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
         return messages.ToArray();
     }
 
+    /// <summary>
+    /// Subscribes to everything the broker holds until <paramref name="cancellationToken"/> ends
+    /// the listen, then leaves the session as it found it.
+    /// </summary>
     public async Task ListenTrafficAsync(
         Action<VidaaTrafficMessage> onMessage,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(onMessage);
-        var recentMessages = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+        var filter = new VidaaTrafficFilter(onMessage);
 
-        void Capture(string topic, byte[] bytes, bool retained)
+        await _commands.RunExclusiveAsync(async token =>
         {
-            if (retained) return;
-            var payload = VidaaTrafficCapture.DecodePayload(bytes);
-            if (VidaaTrafficCapture.IsSensitive(topic, payload)) return;
-            var now = DateTimeOffset.Now;
-            var fingerprint = topic + "\n" + payload;
-            lock (recentMessages)
-            {
-                if (recentMessages.TryGetValue(fingerprint, out var previous)
-                    && now - previous < TimeSpan.FromMilliseconds(100)) return;
-                recentMessages[fingerprint] = now;
-                if (recentMessages.Count > 512)
-                    foreach (var stale in recentMessages
-                                 .Where(pair => now - pair.Value > TimeSpan.FromSeconds(5))
-                                 .Select(pair => pair.Key)
-                                 .ToArray())
-                        recentMessages.Remove(stale);
-            }
-            onMessage(new VidaaTrafficMessage(now, topic, payload));
-        }
-
-        var connection = await _commands.RunExclusiveAsync(async commandToken =>
-        {
-            await EnsurePairedConnectionAsync(commandToken).ConfigureAwait(false);
-            var opened = _connection!;
-            opened.MessageReceived += Capture;
+            await _session.EnsureOpenAsync(token).ConfigureAwait(false);
+            _session.MessageReceived += filter.Handle;
             try
             {
-                await opened.SubscribeAsync(["#"], commandToken).ConfigureAwait(false);
+                await _session.SubscribeAsync(AllTopics, token).ConfigureAwait(false);
             }
             catch
             {
-                opened.MessageReceived -= Capture;
+                _session.MessageReceived -= filter.Handle;
                 throw;
             }
-            return opened;
         }, cancellationToken).ConfigureAwait(false);
 
         try
@@ -291,175 +174,17 @@ public sealed class HisenseVidaaClient(HisenseVidaaConfiguration configuration) 
         }
         finally
         {
-            connection.MessageReceived -= Capture;
-            if (connection.Connected)
+            _session.MessageReceived -= filter.Handle;
+            if (_session.Connected)
             {
                 using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                try { await connection.UnsubscribeAsync(["#"], cleanup.Token).ConfigureAwait(false); }
-                catch (Exception e) when (IsConnectionFailure(e)) { }
+                try { await _session.UnsubscribeAsync(AllTopics, cleanup.Token).ConfigureAwait(false); }
+                catch (Exception e) when (VidaaSession.IsConnectionFailure(e)) { }
                 catch (OperationCanceledException) { }
             }
         }
-
     }
-
-    async Task EnsurePairedConnectionAsync(CancellationToken cancellationToken)
-    {
-        if (_connection?.Connected == true) return;
-        if (!_configuration.HasPairing)
-            throw new InvalidOperationException("Pair this Hisense VIDAA device first.");
-        if (HisenseVidaaProtocol.UsesStaticLegacyProtocol(_configuration.ProtocolVersion))
-        {
-            await ConnectAsync(
-                HisenseVidaaProtocol.LegacyMqttPassword,
-                $"LittleBigMouse/{Guid.NewGuid():N}",
-                HisenseVidaaProtocol.LegacyMqttUsername,
-                cancellationToken).ConfigureAwait(false);
-            return;
-        }
-        await ConnectAsync(
-            _configuration.AccessToken,
-            _configuration.ClientId,
-            _configuration.MqttUsername,
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    async Task ConnectAsync(
-        string password,
-        string clientId,
-        string username,
-        CancellationToken cancellationToken)
-    {
-        await ResetConnectionAsync().ConfigureAwait(false);
-        _connection = new VidaaMqttConnection();
-        _connection.MessageReceived += OnMessage;
-        await _connection.ConnectAsync(
-            _configuration.IpAddress,
-            HisenseVidaaProtocol.MqttPort,
-            clientId,
-            username,
-            password,
-            _configuration.ClientCertificatePath,
-            _configuration.ClientCertificatePassword,
-            cancellationToken).ConfigureAwait(false);
-        var topics = HisenseVidaaProtocol.UsesStaticLegacyProtocol(_configuration.ProtocolVersion)
-            ? HisenseVidaaProtocol.LegacyResponseTopics(_configuration.ClientId)
-            : HisenseVidaaProtocol.ResponseTopics(_configuration.ClientId);
-        await _connection.SubscribeAsync(
-            topics, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Binds <see cref="StaleConnectionRetry"/> to what a dead MQTT session means here: the
-    /// broker only accepts the persistent session once, so it has to be dropped before a new
-    /// one can be opened with the stored pairing.
-    /// </summary>
-    Task SendWithRetryAsync(Func<CancellationToken, Task> send, CancellationToken cancellationToken)
-        => StaleConnectionRetry.SendAsync(send, ReopenAsync, IsConnectionFailure, cancellationToken);
-
-    async Task ReopenAsync(CancellationToken cancellationToken)
-    {
-        await ResetConnectionAsync().ConfigureAwait(false);
-        await EnsurePairedConnectionAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    async Task ResetConnectionAsync()
-    {
-        if (_connection is null) return;
-        _connection.MessageReceived -= OnMessage;
-        await _connection.DisposeAsync().ConfigureAwait(false);
-        _connection = null;
-    }
-
-    static bool IsConnectionFailure(Exception exception)
-        => exception is IOException or System.Net.Sockets.SocketException or ObjectDisposedException;
-
-    void OnMessage(string topic, byte[] bytes, bool retained)
-    {
-        try
-        {
-            var payload = Encoding.UTF8.GetString(bytes);
-            if (HisenseVidaaProtocol.TryParsePictureSettings(topic, payload, out var settings))
-            {
-                _pictureSettingsReceived?.TrySetResult(settings);
-                return;
-            }
-            if (HisenseVidaaProtocol.TryParseVolume(topic, payload, out var volume))
-            {
-                _volumeReceived?.TrySetResult(volume);
-                return;
-            }
-            if (topic.Contains("tokenissuance", StringComparison.OrdinalIgnoreCase))
-            {
-                using var json = JsonDocument.Parse(bytes);
-                var root = json.RootElement;
-                if (!root.TryGetProperty("accesstoken", out var accessToken)) return;
-                _configuration.AccessToken = accessToken.GetString() ?? "";
-                _configuration.RefreshToken = root.TryGetProperty("refreshtoken", out var refreshToken)
-                    ? refreshToken.GetString() ?? ""
-                    : "";
-                var now = DateTimeOffset.UtcNow;
-                _configuration.AccessTokenIssuedAt = UnixTimeOrNow(root, "accesstoken_time", now);
-                _configuration.RefreshTokenIssuedAt = UnixTimeOrNow(root, "refreshtoken_time", now);
-                _configuration.AccessTokenDurationDays = IntegerOr(root, "accesstoken_duration_day", 7);
-                _configuration.RefreshTokenDurationDays = IntegerOr(root, "refreshtoken_duration_day", 30);
-                _tokenIssued?.TrySetResult(true);
-                return;
-            }
-
-            if (!topic.Contains("authentication", StringComparison.OrdinalIgnoreCase)) return;
-            if (bytes.Length == 0)
-            {
-                _pinAccepted?.TrySetResult(true);
-                return;
-            }
-            using var response = JsonDocument.Parse(bytes);
-            var result = response.RootElement;
-            if (result.ValueKind != JsonValueKind.Object) return;
-            if (result.TryGetProperty("result", out var accepted) && accepted.TryGetInt32(out var code))
-            {
-                if (code == 1) _pinAccepted?.TrySetResult(true);
-                else _pinAccepted?.TrySetException(new UnauthorizedAccessException("The VIDAA PIN was rejected."));
-            }
-            else if (result.TryGetProperty("statetype", out var state)
-                     && state.GetString() == "authenticationcode")
-            {
-                // The PIN dialog is visible; AuthenticateAsync will supply the code.
-            }
-        }
-        catch (Exception e)
-        {
-            Console.Error.WriteLine($"Invalid VIDAA response on {topic}: {e.Message}");
-        }
-    }
-
-    string NormalizedBrand()
-    {
-        var brand = _configuration.Brand.Trim().ToLowerInvariant();
-        return string.IsNullOrWhiteSpace(brand) || brand.Contains("hisense", StringComparison.Ordinal)
-            ? "his"
-            : brand;
-    }
-
-    string PairingIdentity()
-    {
-        var configured = HisenseVidaaProtocol.NormalizeMac(_configuration.DeviceUuid, preserveCase: true);
-        if (configured.Count(Uri.IsHexDigit) == 12) return configured;
-        return HisenseVidaaProtocol.NormalizeMac(_configuration.ControllerMacAddress, preserveCase: true);
-    }
-
-    static TaskCompletionSource<bool> NewSignal()
-        => new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-    static int IntegerOr(JsonElement root, string property, int fallback)
-        => root.TryGetProperty(property, out var value) && value.TryGetInt32(out var result) ? result : fallback;
-
-    static DateTimeOffset UnixTimeOrNow(JsonElement root, string property, DateTimeOffset fallback)
-        => root.TryGetProperty(property, out var value) && value.TryGetInt64(out var seconds)
-            ? DateTimeOffset.FromUnixTimeSeconds(seconds)
-            : fallback;
 
     public async ValueTask DisposeAsync()
-        => await _commands.CloseAsync(ResetConnectionAsync).ConfigureAwait(false);
+        => await _commands.CloseAsync(_session.CloseAsync).ConfigureAwait(false);
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaProtocol.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/HisenseVidaaProtocol.cs
@@ -124,6 +124,16 @@ public static class HisenseVidaaProtocol
     public static string Topic(string service, string clientId, string action)
         => $"/remoteapp/tv/{service}/{clientId}/actions/{action}";
 
+    /// <summary>
+    /// The token exchange is asked for on a <c>data</c> topic rather than through
+    /// <see cref="Topic"/>'s <c>actions</c> namespace.
+    /// </summary>
+    public static string TokenRequestTopic(string clientId)
+        => $"/remoteapp/tv/platform_service/{clientId}/data/gettoken";
+
+    /// <summary>An empty refresh token asks for a first pair of tokens.</summary>
+    public static string TokenRequestPayload() => "{\"refreshtoken\":\"\"}";
+
     public static string PictureSettingPayload(int menuId, int value)
     {
         if (menuId is < 1 or > 999)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/IVidaaConnection.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/IVidaaConnection.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+/// <summary>
+/// An open MQTT session with a VIDAA device, as its owner uses it.
+///
+/// Opening is left to <see cref="VidaaConnectionFactory"/> rather than being a method here, so an
+/// owner only ever holds a connection that is already established — and so the session, the
+/// pairing exchange and the command façade can be driven over a simulated transport in tests
+/// without a projector on the network.
+/// </summary>
+internal interface IVidaaConnection : IAsyncDisposable
+{
+    /// <summary>Topic, raw payload, and whether the broker replayed a retained message.</summary>
+    event Action<string, byte[], bool>? MessageReceived;
+
+    bool Connected { get; }
+
+    Task SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken);
+
+    Task UnsubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken);
+
+    Task PublishAsync(string topic, string payload, CancellationToken cancellationToken);
+}
+
+/// <summary>Everything the VIDAA broker needs to accept one session.</summary>
+internal sealed record VidaaConnectionRequest(
+    string Host,
+    string ClientId,
+    string Username,
+    string Password,
+    string CertificatePath,
+    string CertificatePassword);
+
+/// <summary>
+/// Opens one session, or throws the way the broker refused it —
+/// <see cref="UnauthorizedAccessException"/> for rejected credentials.
+/// </summary>
+internal delegate Task<IVidaaConnection> VidaaConnectionFactory(
+    VidaaConnectionRequest request,
+    CancellationToken cancellationToken);
+
+internal static class VidaaConnections
+{
+    /// <summary>Opens the real TLS MQTT connection on the VIDAA remote-control port.</summary>
+    public static async Task<IVidaaConnection> OpenMqttAsync(
+        VidaaConnectionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var connection = new VidaaMqttConnection();
+        try
+        {
+            await connection.ConnectAsync(
+                request.Host,
+                HisenseVidaaProtocol.MqttPort,
+                request.ClientId,
+                request.Username,
+                request.Password,
+                request.CertificatePath,
+                request.CertificatePassword,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // A refused handshake still leaves a socket and a TLS stream behind. The pairing
+            // sweep tries several credentials in a row, so each failure is cleaned up at once.
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+        return connection;
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaConnectionProfile.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaConnectionProfile.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+/// <summary>
+/// Reads a stored configuration as connection parameters: which credentials open the session, and
+/// which topics the answers arrive on. Both differ between protocol generations, and the pairing
+/// exchange and the automatic reconnection have to agree on them, so the rule lives in one place.
+/// </summary>
+internal static class VidaaConnectionProfile
+{
+    /// <summary>
+    /// Credentials of the RemoteNOW service account, which identifies the application rather than
+    /// the device: the MQTT client identifier is therefore unique per session, while
+    /// <see cref="HisenseVidaaConfiguration.ClientId"/> keeps the <c>$normal</c> device topic the
+    /// projector publishes on.
+    /// </summary>
+    public static VidaaMqttCredentials LegacyCredentials() => new(
+        $"LittleBigMouse/{Guid.NewGuid():N}",
+        HisenseVidaaProtocol.LegacyMqttUsername,
+        HisenseVidaaProtocol.LegacyMqttPassword);
+
+    /// <summary>Credentials that reopen the session an earlier pairing left in the configuration.</summary>
+    public static VidaaMqttCredentials StoredCredentials(HisenseVidaaConfiguration configuration)
+        => HisenseVidaaProtocol.UsesStaticLegacyProtocol(configuration.ProtocolVersion)
+            ? LegacyCredentials()
+            : new VidaaMqttCredentials(
+                configuration.ClientId,
+                configuration.MqttUsername,
+                configuration.AccessToken);
+
+    /// <summary>Topics carrying the answers to what this configuration is allowed to ask.</summary>
+    public static IReadOnlyList<string> ResponseTopics(HisenseVidaaConfiguration configuration)
+        => HisenseVidaaProtocol.UsesStaticLegacyProtocol(configuration.ProtocolVersion)
+            ? HisenseVidaaProtocol.LegacyResponseTopics(configuration.ClientId)
+            : HisenseVidaaProtocol.ResponseTopics(configuration.ClientId);
+
+    public static VidaaConnectionRequest Request(
+        HisenseVidaaConfiguration configuration,
+        VidaaMqttCredentials credentials)
+        => new(
+            configuration.IpAddress,
+            credentials.ClientId,
+            credentials.Username,
+            credentials.Password,
+            configuration.ClientCertificatePath,
+            configuration.ClientCertificatePassword);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaMqttConnection.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaMqttConnection.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 
 /// <summary>Small MQTT 3.1.1/QoS-0 transport for the VIDAA broker.</summary>
-internal sealed class VidaaMqttConnection : IAsyncDisposable
+internal sealed class VidaaMqttConnection : IVidaaConnection
 {
     readonly SemaphoreSlim _writeLock = new(1, 1);
     TcpClient? _tcpClient;

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaPairing.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaPairing.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+/// <summary>
+/// Associates LittleBigMouse with one device: opens a session it accepts, has it display a PIN,
+/// and trades that PIN for the tokens every later session reuses. What it settles is written to
+/// the configuration, which <see cref="VidaaConnectionProfile"/> then reads to reconnect.
+///
+/// Which credentials a device accepts is only partly known in advance. The UPnP descriptor gives
+/// a protocol generation when it answers, but not the exact spelling of the identity the broker
+/// hashes, so pairing sweeps the known variants and keeps the first the device lets in.
+/// </summary>
+internal sealed class VidaaPairing(
+    HisenseVidaaConfiguration configuration,
+    VidaaSession session,
+    VidaaResponseRouter responses)
+{
+    /// <summary>
+    /// A device rejecting a credential variant answers quickly. Some brokers instead go silent
+    /// for a while after a rejection, so an attempt that stops answering is abandoned rather than
+    /// left to hold up the remaining variants.
+    /// </summary>
+    static readonly TimeSpan AttemptTimeout = TimeSpan.FromSeconds(6);
+
+    /// <summary>The PIN is read off the screen and typed, and the tokens follow it.</summary>
+    static readonly TimeSpan AnswerTimeout = TimeSpan.FromSeconds(12);
+
+    /// <summary>
+    /// Opens a session the device accepts and, unless <paramref name="requestPin"/> says the user
+    /// already has a PIN from the device's own remote-control settings, asks it to display one.
+    /// </summary>
+    public async Task StartAsync(bool requestPin, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(configuration.ControllerMacAddress))
+            configuration.ControllerMacAddress = NetworkIdentity.ControllerMacFor(configuration.IpAddress);
+
+        if (HisenseVidaaProtocol.UsesStaticLegacyProtocol(configuration.ProtocolVersion))
+            await StartLegacyAsync(requestPin, cancellationToken).ConfigureAwait(false);
+        else
+            await StartDynamicAsync(requestPin, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends the PIN the device displays. On RemoteNOW that is the whole pairing; newer devices
+    /// answer it with an access token, which the router stores as it arrives.
+    /// </summary>
+    public async Task AuthenticateAsync(string pin, CancellationToken cancellationToken)
+    {
+        if (!session.Connected)
+            throw new InvalidOperationException("The VIDAA connection is not open.");
+
+        var legacy = HisenseVidaaProtocol.UsesStaticLegacyProtocol(configuration.ProtocolVersion);
+        var pinAccepted = responses.PinAccepted.Expect();
+        var tokenIssued = responses.TokenIssued.Expect();
+        await session.PublishAsync(
+            HisenseVidaaProtocol.Topic("ui_service", configuration.ClientId, "authenticationcode"),
+            legacy ? HisenseVidaaProtocol.LegacyPinPayload(pin) : HisenseVidaaProtocol.PinPayload(pin),
+            cancellationToken).ConfigureAwait(false);
+
+        await pinAccepted.WaitAsync(AnswerTimeout, cancellationToken).ConfigureAwait(false);
+        if (legacy)
+        {
+            configuration.LegacyAuthorized = true;
+            return;
+        }
+
+        await session.PublishAsync(
+            HisenseVidaaProtocol.TokenRequestTopic(configuration.ClientId),
+            HisenseVidaaProtocol.TokenRequestPayload(),
+            cancellationToken).ConfigureAwait(false);
+        await session.PublishAsync(
+            HisenseVidaaProtocol.Topic("ui_service", configuration.ClientId, "authenticationcodeclose"),
+            "", cancellationToken).ConfigureAwait(false);
+        await tokenIssued.WaitAsync(AnswerTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// RemoteNOW devices such as the C1 have no credentials to discover: the service account is
+    /// static and the device answers on a topic derived from the controller MAC.
+    /// </summary>
+    async Task StartLegacyAsync(bool requestPin, CancellationToken cancellationToken)
+    {
+        var identity = HisenseVidaaProtocol.NormalizeMac(configuration.ControllerMacAddress)
+            .ToUpperInvariant();
+        configuration.DeviceUuid = identity;
+        configuration.AuthMethod = VidaaAuthMethod.Legacy;
+        configuration.ClientId = HisenseVidaaProtocol.LegacyDeviceTopic(identity);
+        configuration.MqttUsername = HisenseVidaaProtocol.LegacyMqttUsername;
+        configuration.AccessToken = "";
+        configuration.RefreshToken = "";
+        configuration.LegacyAuthorized = false;
+
+        await session.OpenAsync(
+            VidaaConnectionProfile.LegacyCredentials(),
+            VidaaConnectionProfile.ResponseTopics(configuration),
+            cancellationToken).ConfigureAwait(false);
+
+        // Armed before the request, so an acknowledgement that arrives while the user is still
+        // reading the PIN off the screen is not lost. AuthenticateAsync arms its own wait.
+        _ = responses.PinAccepted.Expect();
+        if (requestPin)
+            await session.PublishAsync(
+                HisenseVidaaProtocol.Topic("ui_service", configuration.ClientId, "gettvstate"),
+                "", cancellationToken).ConfigureAwait(false);
+    }
+
+    async Task StartDynamicAsync(bool requestPin, CancellationToken cancellationToken)
+    {
+        var identity = PairingIdentity();
+        var identities = new[] { identity, identity.ToLowerInvariant(), identity.ToUpperInvariant() }
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var methods = configuration.ProtocolVersion is null
+            ? new[] { VidaaAuthMethod.Modern, VidaaAuthMethod.Middle, VidaaAuthMethod.Legacy }
+            : new[] { HisenseVidaaProtocol.AuthMethodFor(configuration.ProtocolVersion) };
+        UnauthorizedAccessException? lastAuthorizationError = null;
+
+        foreach (var method in methods)
+            foreach (var candidate in identities)
+            {
+                var credentials = HisenseVidaaProtocol.GenerateCredentials(
+                    candidate, method, brand: NormalizedBrand());
+                try
+                {
+                    using var attempt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    attempt.CancelAfter(AttemptTimeout);
+                    // The response topics still come from the configuration: a device keeps the same
+                    // client identifier across pairings, so this subscribes to the topics of the
+                    // pairing being replaced.
+                    await session.OpenAsync(
+                        credentials,
+                        VidaaConnectionProfile.ResponseTopics(configuration),
+                        attempt.Token).ConfigureAwait(false);
+                }
+                catch (UnauthorizedAccessException e)
+                {
+                    lastAuthorizationError = e;
+                    continue;
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // Some brokers delay a reconnect after rejecting a credential
+                    // variant. Continue with the next known representation.
+                    continue;
+                }
+
+                configuration.DeviceUuid = candidate;
+                configuration.AuthMethod = method;
+                configuration.ClientId = credentials.ClientId;
+                configuration.MqttUsername = credentials.Username;
+                configuration.AccessToken = "";
+                configuration.RefreshToken = "";
+
+                _ = responses.PinAccepted.Expect();
+                _ = responses.TokenIssued.Expect();
+                if (requestPin)
+                    await session.PublishAsync(
+                        HisenseVidaaProtocol.Topic("ui_service", configuration.ClientId, "vidaa_app_connect"),
+                        HisenseVidaaProtocol.PairingRequestPayload(), cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+        var protocol = configuration.ProtocolVersion?.ToString() ?? "unknown";
+        throw new UnauthorizedAccessException(
+            $"VIDAA rejected every authentication variant for protocol {protocol} and controller {identity}. " +
+            "Check the projector date, time and timezone.", lastAuthorizationError);
+    }
+
+    string NormalizedBrand()
+    {
+        var brand = configuration.Brand.Trim().ToLowerInvariant();
+        return string.IsNullOrWhiteSpace(brand) || brand.Contains("hisense", StringComparison.Ordinal)
+            ? "his"
+            : brand;
+    }
+
+    string PairingIdentity()
+    {
+        var configured = HisenseVidaaProtocol.NormalizeMac(configuration.DeviceUuid, preserveCase: true);
+        if (configured.Count(Uri.IsHexDigit) == 12) return configured;
+        return HisenseVidaaProtocol.NormalizeMac(configuration.ControllerMacAddress, preserveCase: true);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaResponseRouter.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaResponseRouter.cs
@@ -1,0 +1,166 @@
+#nullable enable
+using System.Text;
+using System.Text.Json;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+/// <summary>
+/// One answer a command is waiting for on the shared session.
+///
+/// A VIDAA device does not answer a request on a channel of its own: replies and unsolicited
+/// notifications arrive on the same subscribed topics. A command therefore arms the wait before
+/// publishing its request, and the first matching message completes it — which is also why the
+/// wait is disarmed afterwards, so a later notification does not resolve a command nobody asked.
+/// </summary>
+internal sealed class VidaaResponse<T>
+{
+    TaskCompletionSource<T>? _pending;
+
+    /// <summary>
+    /// Arms the wait and returns it, so the caller awaits the answer it armed rather than
+    /// whichever one is pending when it gets around to waiting.
+    /// </summary>
+    public Task<T> Expect()
+    {
+        var pending = NewPending();
+        _pending = pending;
+        return pending.Task;
+    }
+
+    /// <summary>
+    /// Arms the wait, publishes <paramref name="request"/>, and gives the device
+    /// <paramref name="timeout"/> to answer.
+    /// </summary>
+    public async Task<T> CollectAsync(
+        Func<CancellationToken, Task> request,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var pending = NewPending();
+        _pending = pending;
+        try
+        {
+            await request(cancellationToken).ConfigureAwait(false);
+            return await pending.Task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (ReferenceEquals(_pending, pending)) _pending = null;
+        }
+    }
+
+    /// <summary>Hands the answer to whoever is waiting, and ignores it when nobody is.</summary>
+    public void Complete(T value) => _pending?.TrySetResult(value);
+
+    /// <inheritdoc cref="Complete"/>
+    public void Fail(Exception error) => _pending?.TrySetException(error);
+
+    static TaskCompletionSource<T> NewPending() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+/// <summary>
+/// Reads what the projector publishes: completes the answer a command is waiting for, and stores
+/// the tokens the pairing hands out. Recognising and decoding the messages stays in
+/// <see cref="HisenseVidaaProtocol"/>; what is here is which waiting command each one belongs to.
+/// </summary>
+internal sealed class VidaaResponseRouter(HisenseVidaaConfiguration configuration)
+{
+    /// <summary>Completed by the projector accepting the PIN, failed by it rejecting it.</summary>
+    public VidaaResponse<bool> PinAccepted { get; } = new();
+
+    /// <summary>Completed once the access token of a fresh pairing has been stored.</summary>
+    public VidaaResponse<bool> TokenIssued { get; } = new();
+
+    public VidaaResponse<int> Volume { get; } = new();
+
+    public VidaaResponse<IReadOnlyList<VidaaPictureSetting>> PictureSettings { get; } = new();
+
+    /// <summary>
+    /// Routes one message from the broker, retained replays included. Never throws: a malformed
+    /// message is reported and dropped, because it arrives on the receive loop rather than on the
+    /// thread of the command it would otherwise fault.
+    /// </summary>
+    public void Handle(string topic, byte[] bytes, bool retained)
+    {
+        try
+        {
+            Route(topic, bytes);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"Invalid VIDAA response on {topic}: {e.Message}");
+        }
+    }
+
+    void Route(string topic, byte[] bytes)
+    {
+        var payload = Encoding.UTF8.GetString(bytes);
+        if (HisenseVidaaProtocol.TryParsePictureSettings(topic, payload, out var settings))
+        {
+            PictureSettings.Complete(settings);
+            return;
+        }
+        if (HisenseVidaaProtocol.TryParseVolume(topic, payload, out var volume))
+        {
+            Volume.Complete(volume);
+            return;
+        }
+        if (topic.Contains("tokenissuance", StringComparison.OrdinalIgnoreCase))
+        {
+            StoreIssuedTokens(bytes);
+            return;
+        }
+        if (topic.Contains("authentication", StringComparison.OrdinalIgnoreCase))
+            RouteAuthentication(bytes);
+    }
+
+    void StoreIssuedTokens(byte[] bytes)
+    {
+        using var json = JsonDocument.Parse(bytes);
+        var root = json.RootElement;
+        if (!root.TryGetProperty("accesstoken", out var accessToken)) return;
+
+        configuration.AccessToken = accessToken.GetString() ?? "";
+        configuration.RefreshToken = root.TryGetProperty("refreshtoken", out var refreshToken)
+            ? refreshToken.GetString() ?? ""
+            : "";
+        var now = DateTimeOffset.UtcNow;
+        configuration.AccessTokenIssuedAt = UnixTimeOr(root, "accesstoken_time", now);
+        configuration.RefreshTokenIssuedAt = UnixTimeOr(root, "refreshtoken_time", now);
+        configuration.AccessTokenDurationDays = IntegerOr(root, "accesstoken_duration_day", 7);
+        configuration.RefreshTokenDurationDays = IntegerOr(root, "refreshtoken_duration_day", 30);
+        TokenIssued.Complete(true);
+    }
+
+    void RouteAuthentication(byte[] bytes)
+    {
+        if (bytes.Length == 0)
+        {
+            // RemoteNOW acknowledges the PIN with an empty message on the authentication topic.
+            PinAccepted.Complete(true);
+            return;
+        }
+
+        using var response = JsonDocument.Parse(bytes);
+        var result = response.RootElement;
+        if (result.ValueKind != JsonValueKind.Object) return;
+        if (result.TryGetProperty("result", out var accepted) && accepted.TryGetInt32(out var code))
+        {
+            if (code == 1) PinAccepted.Complete(true);
+            else PinAccepted.Fail(new UnauthorizedAccessException("The VIDAA PIN was rejected."));
+        }
+        else if (result.TryGetProperty("statetype", out var state)
+                 && state.GetString() == "authenticationcode")
+        {
+            // The PIN dialog is visible; the pairing exchange supplies the code.
+        }
+    }
+
+    static int IntegerOr(JsonElement root, string property, int fallback)
+        => root.TryGetProperty(property, out var value) && value.TryGetInt32(out var result) ? result : fallback;
+
+    static DateTimeOffset UnixTimeOr(JsonElement root, string property, DateTimeOffset fallback)
+        => root.TryGetProperty(property, out var value) && value.TryGetInt64(out var seconds)
+            ? DateTimeOffset.FromUnixTimeSeconds(seconds)
+            : fallback;
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaSession.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaSession.cs
@@ -1,0 +1,115 @@
+#nullable enable
+using System.Net.Sockets;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
+
+/// <summary>
+/// Owns the single MQTT connection a VIDAA device accepts, and everything that keeps it usable:
+/// opening it with a set of credentials, subscribing the topics the answers arrive on, reopening
+/// it when a command discovers the broker dropped it, and closing it exactly once.
+///
+/// It knows nothing of pairing or of what the messages mean. Callers hand it credentials and
+/// topics — <see cref="VidaaConnectionProfile"/> derives both from the configuration — and read
+/// the traffic through <see cref="MessageReceived"/>, which survives a reconnection because it
+/// belongs to the session rather than to the connection of the moment.
+/// </summary>
+internal sealed class VidaaSession(
+    HisenseVidaaConfiguration configuration,
+    VidaaConnectionFactory? transport = null)
+{
+    readonly VidaaConnectionFactory _transport = transport ?? VidaaConnections.OpenMqttAsync;
+    IVidaaConnection? _connection;
+
+    /// <summary>Every message of the open connection, retained ones included.</summary>
+    public event Action<string, byte[], bool>? MessageReceived;
+
+    public bool Connected => _connection?.Connected == true;
+
+    /// <summary>
+    /// Drops whatever session is open and establishes a new one. The broker accepts one
+    /// persistent session at a time, so the old one goes before the new one is asked for.
+    /// </summary>
+    public async Task OpenAsync(
+        VidaaMqttCredentials credentials,
+        IReadOnlyList<string> topics,
+        CancellationToken cancellationToken)
+    {
+        await CloseAsync().ConfigureAwait(false);
+        var connection = await _transport(
+                VidaaConnectionProfile.Request(configuration, credentials), cancellationToken)
+            .ConfigureAwait(false);
+        connection.MessageReceived += Dispatch;
+        _connection = connection;
+        await connection.SubscribeAsync(topics, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Opens the session the stored pairing describes, unless one is already open.</summary>
+    /// <exception cref="InvalidOperationException">The device has never been paired.</exception>
+    public async Task EnsureOpenAsync(CancellationToken cancellationToken)
+    {
+        if (Connected) return;
+        if (!configuration.HasPairing)
+            throw new InvalidOperationException("Pair this Hisense VIDAA device first.");
+
+        await OpenAsync(
+            VidaaConnectionProfile.StoredCredentials(configuration),
+            VidaaConnectionProfile.ResponseTopics(configuration),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Publishes on the paired session, opening it if needed and giving the command a second
+    /// chance when the write is what reveals the broker dropped the previous one. See
+    /// <see cref="StaleConnectionRetry"/>; here a dead session has to be closed before the
+    /// stored pairing can open another.
+    /// </summary>
+    public async Task SendAsync(string topic, string payload, CancellationToken cancellationToken)
+    {
+        await EnsureOpenAsync(cancellationToken).ConfigureAwait(false);
+        await StaleConnectionRetry.SendAsync(
+            token => PublishAsync(topic, payload, token),
+            ReopenAsync,
+            IsConnectionFailure,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Publishes on the open session, without reopening it.</summary>
+    /// <exception cref="InvalidOperationException">No session is open.</exception>
+    public Task PublishAsync(string topic, string payload, CancellationToken cancellationToken)
+        => Open().PublishAsync(topic, payload, cancellationToken);
+
+    /// <inheritdoc cref="PublishAsync"/>
+    public Task SubscribeAsync(IReadOnlyList<string> topics, CancellationToken cancellationToken)
+        => Open().SubscribeAsync(topics, cancellationToken);
+
+    /// <inheritdoc cref="PublishAsync"/>
+    public Task UnsubscribeAsync(IReadOnlyList<string> topics, CancellationToken cancellationToken)
+        => Open().UnsubscribeAsync(topics, cancellationToken);
+
+    public async Task CloseAsync()
+    {
+        if (_connection is not { } connection) return;
+        _connection = null;
+        connection.MessageReceived -= Dispatch;
+        await connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tells a session the broker dropped from a command the device refused, so that only the
+    /// former is worth sending again.
+    /// </summary>
+    public static bool IsConnectionFailure(Exception exception)
+        => exception is IOException or SocketException or ObjectDisposedException;
+
+    async Task ReopenAsync(CancellationToken cancellationToken)
+    {
+        await CloseAsync().ConfigureAwait(false);
+        await EnsureOpenAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    IVidaaConnection Open()
+        => _connection ?? throw new InvalidOperationException("The VIDAA connection is not open.");
+
+    void Dispatch(string topic, byte[] payload, bool retained)
+        => MessageReceived?.Invoke(topic, payload, retained);
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaTrafficCapture.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaTrafficCapture.cs
@@ -32,3 +32,39 @@ public static class VidaaTrafficCapture
         => string.Join("\n\n", messages.Select(message =>
             $"[{message.Timestamp:HH:mm:ss.fff}] {message.Topic}\n{message.Payload}"));
 }
+
+/// <summary>
+/// Keeps a traffic listener readable: retained replays, credentials, and the copies a device
+/// publishes on several topics within the same instant never reach it.
+/// </summary>
+internal sealed class VidaaTrafficFilter(Action<VidaaTrafficMessage> onMessage)
+{
+    static readonly TimeSpan RepeatWindow = TimeSpan.FromMilliseconds(100);
+    static readonly TimeSpan Staleness = TimeSpan.FromSeconds(5);
+
+    readonly Dictionary<string, DateTimeOffset> _recentMessages = new(StringComparer.Ordinal);
+
+    /// <summary>Called from the receive loop, hence the lock on the deduplication table.</summary>
+    public void Handle(string topic, byte[] bytes, bool retained)
+    {
+        if (retained) return;
+        var payload = VidaaTrafficCapture.DecodePayload(bytes);
+        if (VidaaTrafficCapture.IsSensitive(topic, payload)) return;
+
+        var now = DateTimeOffset.Now;
+        var fingerprint = topic + "\n" + payload;
+        lock (_recentMessages)
+        {
+            if (_recentMessages.TryGetValue(fingerprint, out var previous)
+                && now - previous < RepeatWindow) return;
+            _recentMessages[fingerprint] = now;
+            if (_recentMessages.Count > 512)
+                foreach (var stale in _recentMessages
+                             .Where(pair => now - pair.Value > Staleness)
+                             .Select(pair => pair.Key)
+                             .ToArray())
+                    _recentMessages.Remove(stale);
+        }
+        onMessage(new VidaaTrafficMessage(now, topic, payload));
+    }
+}


### PR DESCRIPTION
`HisenseVidaaClient` ran the MQTT connection, decoded what the projector published, drove the pairing handshake and shaped every command, all interleaved in the same method bodies. This splits it along those responsibilities, reusing `HisenseVidaaProtocol` and `VidaaMqttConnection` rather than duplicating them.

| Layer | Owns |
|---|---|
| `IVidaaConnection` / `VidaaConnections` | The transport seam: an already-open connection, and the factory that opens the real TLS MQTT one |
| `VidaaConnectionProfile` | Configuration → credentials and response topics, so pairing and reconnection cannot disagree |
| `VidaaSession` | The single connection: open, subscribe, reopen through `StaleConnectionRetry`, close once, fan out messages |
| `VidaaResponseRouter` | The answers commands wait for, and the tokens a pairing issues (decoding stays in `HisenseVidaaProtocol`) |
| `VidaaPairing` | The RemoteNOW path, the credential sweep, the PIN traded for tokens |
| `HisenseVidaaClient` | Façade: topic, payload and deadline per command, plus the `DeviceCommandGate` |

The public API is unchanged; `HisenseVidaaService` is untouched. The client goes from **465 to 190 lines** (416 → 145 excluding blanks and comments). Dependencies now run one way — protocol → profile → session → pairing → façade — the router only reads the protocol, and `VidaaMqttConnection` is reachable only through the factory.

Delays, retries, error messages and payload formats are preserved. Three deliberate differences: a traffic listen survives a reconnection (the handler belongs to the session now), `SendKeyAsync` validates its key before taking the command gate as the other commands already did, and a refused connection is disposed at once.

**Tests:** 33 new tests over a simulated broker (`FakeVidaaTransport`) covering session open/reopen/refusal, both pairing paths, the credential sweep, a rejected PIN and the awaited answers. `dotnet test LittleBigMouse.Plugin.Vcp.Avalonia.Tests` → 178 passed, 0 failed (145 before). Neutralising `IsConnectionFailure` fails 3 of the 4 reconnection tests, so they bite. `dotnet format --verify-no-changes` is clean on every file touched.

One oddity is preserved rather than fixed and noted in the commit message: the credential sweep subscribes to the response topics of the already-stored `ClientId`, which is empty on a first pairing of a recent device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)