### PR TITLE
Listen on the topics of the VIDAA pairing being attempted

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/FakeVidaaTransport.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/FakeVidaaTransport.cs
@@ -24,9 +24,32 @@ sealed class FakeVidaaConnection : IVidaaConnection
 
     public event Action<string, byte[], bool>? MessageReceived;
 
-    /// <summary>Publishes a message to the session, as the device does.</summary>
+    /// <summary>
+    /// Publishes a message to the session, as the device does — and, as a broker does, only to a
+    /// session that subscribed a filter matching it. A session listening on the wrong topic
+    /// therefore hears nothing, which is the failure this fake exists to reproduce.
+    /// </summary>
     public void Receive(string topic, string payload, bool retained = false)
-        => MessageReceived?.Invoke(topic, Encoding.UTF8.GetBytes(payload), retained);
+    {
+        if (!Subscribed.Any(filter => Matches(filter, topic))) return;
+        MessageReceived?.Invoke(topic, Encoding.UTF8.GetBytes(payload), retained);
+    }
+
+    /// <summary>Matches an MQTT 3.1.1 topic filter, wildcards included, against a topic name.</summary>
+    internal static bool Matches(string filter, string topic)
+    {
+        var filterLevels = filter.Split('/');
+        var topicLevels = topic.Split('/');
+        for (var level = 0; level < filterLevels.Length; level++)
+        {
+            if (filterLevels[level] == "#") return true;
+            if (level >= topicLevels.Length) return false;
+            if (filterLevels[level] == "+") continue;
+            if (!string.Equals(filterLevels[level], topicLevels[level], StringComparison.Ordinal))
+                return false;
+        }
+        return filterLevels.Length == topicLevels.Length;
+    }
 
     public Task SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken)
     {

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaClientTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/HisenseVidaaClientTests.cs
@@ -183,6 +183,24 @@ public class HisenseVidaaClientTests
             Assert.Single(transport.Current.Published));
     }
 
+    /// <summary>
+    /// A device answers the pairing exchange on the topics of the identity the session was opened
+    /// with. A first pairing has none in its configuration yet, so taking them from there would
+    /// leave the session listening on an empty client identifier and lose every answer.
+    /// </summary>
+    [Fact]
+    public async Task ListensOnTheTopicsOfTheCredentialsThePairingIsTrying()
+    {
+        var configuration = Unpaired(3290);
+        var transport = new FakeVidaaTransport();
+        await using var client = new HisenseVidaaClient(configuration, transport.OpenAsync);
+
+        await client.StartPairingAsync(default);
+
+        Assert.Equal(DeviceClientId, Assert.Single(transport.Requests).ClientId);
+        Assert.Equal(HisenseVidaaProtocol.ResponseTopics(DeviceClientId), transport.Current.Subscribed);
+    }
+
     [Fact]
     public async Task ReportsThatTheDeviceRejectedEveryCredentialVariant()
     {

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaPairing.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/HisenseVidaa/VidaaPairing.cs
@@ -125,12 +125,12 @@ internal sealed class VidaaPairing(
                 {
                     using var attempt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                     attempt.CancelAfter(AttemptTimeout);
-                    // The response topics still come from the configuration: a device keeps the same
-                    // client identifier across pairings, so this subscribes to the topics of the
-                    // pairing being replaced.
+                    // The answers come back addressed to the candidate being tried, not to whatever
+                    // an earlier pairing left in the configuration: a first pairing has no client
+                    // identifier there at all, and would otherwise listen on an empty one.
                     await session.OpenAsync(
                         credentials,
-                        VidaaConnectionProfile.ResponseTopics(configuration),
+                        HisenseVidaaProtocol.ResponseTopics(credentials.ClientId),
                         attempt.Token).ConfigureAwait(false);
                 }
                 catch (UnauthorizedAccessException e)


### PR DESCRIPTION
## What

`VidaaPairing.StartDynamicAsync` opened the session with a candidate's credentials but subscribed to `VidaaConnectionProfile.ResponseTopics(configuration)` — i.e. to the topics of `configuration.ClientId`, which is only assigned *after* a successful open. On a first pairing that field is still empty, so the session listened on `/remoteapp/mobile//ui_service/data/authentication` and never received the PIN acknowledgement or the tokens; `AuthenticateAsync` timed out after 12 s.

The subscription now uses the identifier the session actually connected with.

## Why the identifiers cannot differ here

On the dynamic-auth generation the MQTT client id is cryptographically bound to the credentials (the device recomputes the `race` MD5 from it), so the device's replies are addressed to that exact identifier. The RemoteNOW branch is the opposite case and is left alone: those sessions deliberately connect under a per-session id while the device publishes on the `<MAC>$normal` topic, so it keeps taking its topic from the configuration.

## Scope of the bug

Only the very first pairing attempt. `RequestPinAsync` saves the configuration right after `StartPairingAsync`, so a retry subscribed correctly — the observable symptom was "pairing fails once, then works", which is likely why it was never reported.

This behaviour predates the layering refactor (#570): the former `HisenseVidaaClient.ConnectAsync` subscribed from `_configuration.ClientId` in the same order. The refactor preserved it faithfully.

## Tests

`FakeVidaaConnection.Receive` now delivers a message only to a session that subscribed a matching filter (MQTT 3.1.1 matching, wildcards included), as a broker does. Without that, no test could observe a subscription on the wrong topic — and indeed, against the unfixed code, `TradesThePinForTheTokensLaterSessionsReuse` and `ReportsAPinTheDeviceRejected` now fail with the predicted 12 s `TimeoutException`, while the RemoteNOW tests keep passing. Adds `ListensOnTheTopicsOfTheCredentialsThePairingIsTrying`.

179 tests pass.

## Caveat

No modern VIDAA hardware (protocol >= 3000) was available to verify this end to end, and there is no MQTT capture of one in the repo. The official APK is packed with baiduprotect and yields no topic strings, so the protocol behaviour above rests on third-party implementations (`vidaa-control`/`pyvidaa`, `ha_vidaatv`, `hisensetv`) plus the in-repo reproduction, not on a trace from a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)