### PR TITLE
Let a border gesture be cancelled, and decide its own guide

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderBandShape.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderBandShape.cs
@@ -1,0 +1,46 @@
+using Avalonia;
+
+namespace LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
+
+/// <summary>
+/// The outline of a band along one monitor edge, mitred at both ends.
+/// <para>
+/// A band spans its edge end to end, so the four bands of a monitor overlap in the
+/// corner squares. Each one keeps the triangle on its own side of the square's
+/// diagonal, so the corners meet like a picture frame and a click there reaches
+/// exactly one band.
+/// </para>
+/// <para>
+/// Nothing here but arithmetic on a rectangle: the band's own size in, its corner
+/// points out. <see cref="Point"/> is a plain value, so this needs no display.
+/// </para>
+/// </summary>
+public static class BorderBandShape
+{
+    /// <param name="thickness">
+    /// The thickness of the bands meeting this one at right angles. They are all the
+    /// same width, so the corner square is <paramref name="thickness"/> square.
+    /// </param>
+    public static Point[] For(BorderSideKind kind, double width, double height, double thickness)
+    {
+        var w = width;
+        var h = height;
+        var t = thickness;
+
+        return kind switch
+        {
+            // Outer edge on the left: keep the lower-left half of each corner square.
+            BorderSideKind.Left =>
+                [new Point(0, 0), new Point(t, t), new Point(t, h - t), new Point(0, h)],
+
+            BorderSideKind.Right =>
+                [new Point(w, 0), new Point(w, h), new Point(0, h - t), new Point(0, t)],
+
+            BorderSideKind.Top =>
+                [new Point(0, 0), new Point(w, 0), new Point(w - t, t), new Point(t, t)],
+
+            _ =>
+                [new Point(0, h), new Point(t, 0), new Point(w - t, 0), new Point(w, h)]
+        };
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderSectionGesture.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderSectionGesture.cs
@@ -2,22 +2,26 @@ using LittleBigMouse.DisplayLayout.Dimensions;
 
 namespace LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
 
-/// <summary>What a gesture asks its band to draw after a pointer position.</summary>
-/// <param name="PreviewFromMm">Start of the section being drawn, if one is.</param>
-/// <param name="PreviewToMm">Its moving end.</param>
-/// <param name="GuideMm">Boundary to mark, if it landed on a snap target.</param>
-/// <param name="SecondGuideMm">
-/// The other end of a section being moved: it keeps its length, so only one of its
-/// two ends can have caught a target, and which one is not known here.
-/// </param>
-public readonly record struct BorderGestureFeedback(
-    double? PreviewFromMm = null,
-    double? PreviewToMm = null,
-    double? GuideMm = null,
-    double? SecondGuideMm = null);
+/// <summary>A boundary that landed exactly on a snap target, and what it caught.</summary>
+public readonly record struct BorderGuideMark(double Mm, SnapKind Kind);
 
 /// <summary>
-/// One pointer gesture on a band, from press to release.
+/// What a gesture asks its band to draw after a pointer position.
+/// <para>
+/// Both members are answers, not candidates: which of a moved section's two ends
+/// won the guide is decided here, where the targets are known, rather than by the
+/// band that draws it.
+/// </para>
+/// </summary>
+/// <param name="Preview">The section being swept out, while one is.</param>
+/// <param name="Guide">The boundary to mark, when one landed on a target.</param>
+public readonly record struct BorderGestureFeedback(
+    BorderSpan? Preview = null,
+    BorderGuideMark? Guide = null);
+
+/// <summary>
+/// One pointer gesture on a band, from press to release — or to the cancellation
+/// that takes its place.
 /// <para>
 /// Kept apart from the band itself so it can be exercised without a display. That
 /// is not a preference: both defects found while testing this feature lived in
@@ -50,6 +54,12 @@ public class BorderSectionGesture(BorderSideViewModel side)
 
     /// <summary>Where a moved section would start with no snapping — see <see cref="Move"/>.</summary>
     double _movedFromMm;
+
+    /// <summary>
+    /// Where the target sat when it was taken hold of, to put it back on
+    /// <see cref="Cancel"/>.
+    /// </summary>
+    BorderSpan _grabbedSpan;
 
     /// <summary>
     /// How far the press landed from the boundary it grabbed.
@@ -91,6 +101,7 @@ public class BorderSectionGesture(BorderSideViewModel side)
         _anchorMm = side.Snap(mm, snap, target);
         _lastMm = mm;
         _movedFromMm = target?.From ?? 0;
+        _grabbedSpan = target == null ? default : new BorderSpan(target.From, target.To);
 
         return target;
     }
@@ -105,15 +116,17 @@ public class BorderSectionGesture(BorderSideViewModel side)
         switch (Mode)
         {
             case Kind.Draw:
-                return new BorderGestureFeedback(PreviewFromMm: _anchorMm, PreviewToMm: mm);
+                // A section is swept out from a fixed anchor, so only the moving end
+                // can catch anything.
+                return new BorderGestureFeedback(new BorderSpan(_anchorMm, mm), Mark(snap, mm));
 
             case Kind.ResizeFrom when Target != null:
                 side.Resize(Target, mm, Target.To);
-                return new BorderGestureFeedback(GuideMm: mm);
+                return new BorderGestureFeedback(Guide: Mark(snap, mm));
 
             case Kind.ResizeTo when Target != null:
                 side.Resize(Target, Target.From, mm);
-                return new BorderGestureFeedback(GuideMm: mm);
+                return new BorderGestureFeedback(Guide: Mark(snap, mm));
 
             case Kind.Move when Target != null:
                 // The wanted position follows the pointer exactly and is kept apart
@@ -128,11 +141,30 @@ public class BorderSectionGesture(BorderSideViewModel side)
                     ? side.SnapMovedStart(_movedFromMm, length, Target)
                     : _movedFromMm);
 
-                return new BorderGestureFeedback(GuideMm: Target.From, SecondGuideMm: Target.To);
+                // A moved section keeps its length, so at most one of its ends can
+                // have caught a target; the far one is tried when the near one found
+                // nothing.
+                return new BorderGestureFeedback(Guide: Mark(snap, Target.From, Target.To));
 
             default:
                 return new BorderGestureFeedback();
         }
+    }
+
+    /// <summary>
+    /// The first of these boundaries that landed on a snap target, if any. The
+    /// section being dragged is left out, or it would keep catching itself.
+    /// </summary>
+    BorderGuideMark? Mark(bool snap, params double[] candidates)
+    {
+        if (!snap) return null;
+
+        foreach (var mm in candidates)
+        {
+            if (side.MatchedTarget(mm, Target) is { } target) return new BorderGuideMark(mm, target.Kind);
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -149,10 +181,46 @@ public class BorderSectionGesture(BorderSideViewModel side)
             created = side.Create(_anchorMm, side.Snap(raw, snap, Target));
         }
 
+        Idle();
+
+        return created;
+    }
+
+    /// <summary>
+    /// Give up on the gesture and leave the edge as it was found.
+    /// <para>
+    /// A drawn section only exists once released, so there is nothing to undo there;
+    /// a resize or a move has been applied at every pointer position since the press,
+    /// and is put back where it was taken from. Directly, not through
+    /// <see cref="BorderSideViewModel.Resize"/>: the span being restored held that
+    /// place a moment ago, so there is nothing left to clamp it against.
+    /// </para>
+    /// <para>
+    /// This is where a lost capture ends up too. Losing the pointer mid-drag is not a
+    /// decision to keep whatever the section happened to be under at that instant.
+    /// </para>
+    /// </summary>
+    /// <returns>The section put back, if the gesture had edited one.</returns>
+    public BorderSection? Cancel()
+    {
+        var restored = Mode is Kind.ResizeFrom or Kind.ResizeTo or Kind.Move ? Target : null;
+
+        if (restored != null)
+        {
+            restored.From = _grabbedSpan.From;
+            restored.To = _grabbedSpan.To;
+        }
+
+        Idle();
+
+        return restored;
+    }
+
+    void Idle()
+    {
         Mode = Kind.None;
         Target = null;
         _grabOffsetMm = 0;
-
-        return created;
+        _grabbedSpan = default;
     }
 }

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderSideStrip.axaml.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/BorderResistancePlugin/BorderSideStrip.axaml.cs
@@ -117,6 +117,17 @@ public partial class BorderSideStrip : UserControl
 
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        if (e.Key == Key.Escape)
+        {
+            // Only while something is going on: otherwise Escape belongs to whatever
+            // is above, which may want to close the overlay it is shown in.
+            if (_gesture is not { Active: true }) return;
+
+            CancelGesture();
+            e.Handled = true;
+            return;
+        }
+
         var vm = ViewModel;
         if (e.Key != Key.Delete || vm == null) return;
 
@@ -141,9 +152,8 @@ public partial class BorderSideStrip : UserControl
     /// <para>
     /// The band spans its edge end to end, so its length IS the edge length — which
     /// is why the millimetre scale is taken from here rather than from the parent
-    /// overlay. The four bands therefore overlap in the corner squares; each one
-    /// keeps the triangle on its own side of the square's diagonal, so the corners
-    /// meet like a picture frame and a click there reaches exactly one band.
+    /// overlay. The corner squares the four bands share out are cut by
+    /// <see cref="BorderBandShape"/>.
     /// </para>
     /// </summary>
     void UpdateGeometry()
@@ -158,13 +168,7 @@ public partial class BorderSideStrip : UserControl
         vm.PixelLength = vm.IsVertical ? h : w;
         vm.PixelThickness = vm.IsVertical ? w : h;
 
-        // Thickness of the bands meeting this one at right angles; they are all the
-        // same width, so the corner square is t by t.
-        var t = vm.PixelThickness;
-
-        var points = vm.IsVertical
-            ? Corners(vm, w, h, t)
-            : Horizontal(vm, w, h, t);
+        var points = BorderBandShape.For(vm.Kind, w, h, vm.PixelThickness);
 
         // Backdrop.Data drives hit testing; Clip additionally trims a section drawn
         // right up to a corner so it follows the mitre instead of squaring it off.
@@ -180,18 +184,6 @@ public partial class BorderSideStrip : UserControl
 
         foreach (var section in vm.Sections) section.Refresh();
     }
-
-    static Points Corners(BorderSideViewModel vm, double w, double h, double t) =>
-        vm.Kind == BorderSideKind.Left
-            // Outer edge on the left: keep the lower-left half of each corner square.
-            ? [new Point(0, 0), new Point(t, t), new Point(t, h - t), new Point(0, h)]
-            // Outer edge on the right.
-            : [new Point(w, 0), new Point(w, h), new Point(0, h - t), new Point(0, t)];
-
-    static Points Horizontal(BorderSideViewModel vm, double w, double h, double t) =>
-        vm.Kind == BorderSideKind.Top
-            ? [new Point(0, 0), new Point(w, 0), new Point(w - t, t), new Point(t, t)]
-            : [new Point(0, h), new Point(t, 0), new Point(w - t, 0), new Point(w, h)];
 
     /// <summary>Position along the edge, in millimetres from its starting corner.</summary>
     double AlongMm(PointerEventArgs e) => AlongMm(e.GetPosition(this));
@@ -230,19 +222,46 @@ public partial class BorderSideStrip : UserControl
         if (vm == null || _gesture is not { Active: true } gesture) return;
         if (e.Pointer.Captured != this) return;
 
-        var snap = SnapEnabled(e.KeyModifiers);
-
-        Render(vm, gesture.Move(AlongMm(e), snap), snap);
+        Render(vm, gesture.Move(AlongMm(e), SnapEnabled(e.KeyModifiers)));
 
         e.Handled = true;
+    }
+
+    /// <summary>
+    /// The pointer was taken away mid-gesture — another window came up, or the device
+    /// went. The section goes back where it was found: losing the pointer is not a
+    /// decision to keep it wherever it happened to be at that instant.
+    /// <para>
+    /// Every ordinary release comes through here too, since letting go of the button
+    /// drops the capture — but only after the release itself: Avalonia raises
+    /// PointerReleased and clears the capture in that call's finally, in that order.
+    /// So the gesture has already ended by then, and cancelling an ended gesture does
+    /// nothing. Were it the other way round, this would undo every drag ever made.
+    /// </para>
+    /// </summary>
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        CancelGesture();
+        base.OnPointerCaptureLost(e);
+    }
+
+    /// <summary>
+    /// Drop the gesture and take back what it was showing. The edge is left exactly
+    /// as the press found it, so there is nothing to compact or push.
+    /// </summary>
+    void CancelGesture()
+    {
+        if (_gesture is not { Active: true } gesture) return;
+
+        gesture.Cancel();
+        ClearFeedback();
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         var vm = ViewModel;
 
-        Overlay.Children.Clear();
-        BorderSectionGuide.Clear();
+        ClearFeedback();
 
         var created = _gesture?.Release(AlongMm(e), SnapEnabled(e.KeyModifiers));
 
@@ -276,44 +295,33 @@ public partial class BorderSideStrip : UserControl
 
     /// <summary>
     /// Turn what the gesture reports into the outline, and publish the guide. The
-    /// gesture has already applied its edit; this only says so on screen.
+    /// gesture has already applied its edit and already decided which boundary — if
+    /// any — caught a target; this only says so on screen.
+    /// <para>
+    /// The guide is published rather than drawn here: every band showing this edge
+    /// draws it from that notification, this one included.
+    /// </para>
     /// </summary>
-    void Render(BorderSideViewModel vm, BorderGestureFeedback feedback, bool snap)
+    void Render(BorderSideViewModel vm, BorderGestureFeedback feedback)
     {
-        if (feedback is { PreviewFromMm: { } from, PreviewToMm: { } to })
+        if (feedback.Preview is { } preview) DrawPreview(vm, preview);
+
+        if (feedback.Guide is not { } guide)
         {
-            DrawPreview(vm, from, to);
-            // A section is swept out from a fixed anchor, so only the moving end
-            // can catch anything.
-            PublishGuide(vm, snap, to);
+            BorderSectionGuide.Clear();
             return;
         }
 
-        // A moved section keeps its length, so at most one of its ends can have
-        // caught a target; the far one is tried when the near one found nothing.
-        PublishGuide(vm, snap, feedback.GuideMm, feedback.SecondGuideMm);
+        // Also in layout coordinates: the bands match this guide by their own edge,
+        // the screens by where it falls across them.
+        BorderSectionGuide.Show(
+            vm.Side, guide.Mm, guide.Kind, vm.OriginMm + guide.Mm, vm.IsVertical);
     }
 
-    /// <summary>
-    /// Say where the boundary caught something, for every band showing this edge —
-    /// this one included, which draws it from the same notification as the others.
-    /// </summary>
-    void PublishGuide(BorderSideViewModel vm, bool snap, params double?[] candidates)
+    /// <summary>Take back everything a gesture in progress was showing.</summary>
+    void ClearFeedback()
     {
-        if (snap)
-        {
-            foreach (var candidate in candidates)
-            {
-                if (candidate is not { } mm) continue;
-                if (vm.MatchedTarget(mm, _gesture?.Target) is not { } target) continue;
-
-                // Also in layout coordinates: the bands match this guide by their
-                // own edge, the screens by where it falls across them.
-                BorderSectionGuide.Show(vm.Side, mm, target.Kind, vm.OriginMm + mm, vm.IsVertical);
-                return;
-            }
-        }
-
+        Overlay.Children.Clear();
         BorderSectionGuide.Clear();
     }
 
@@ -329,12 +337,14 @@ public partial class BorderSideStrip : UserControl
         DrawGuide(vm, g.Mm, g.Kind);
     }
 
-    void DrawPreview(BorderSideViewModel vm, double fromMm, double toMm)
+    void DrawPreview(BorderSideViewModel vm, BorderSpan span)
     {
         Overlay.Children.Clear();
 
-        var from = vm.ToPixels(System.Math.Min(fromMm, toMm));
-        var length = vm.ToPixels(System.Math.Abs(toMm - fromMm));
+        // The span runs from the anchor towards the pointer, so it may well be
+        // backwards.
+        var from = vm.ToPixels(System.Math.Min(span.From, span.To));
+        var length = vm.ToPixels(System.Math.Abs(span.Length));
 
         var preview = new Rectangle
         {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderGestureSequenceTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderGestureSequenceTests.cs
@@ -1,0 +1,467 @@
+using DynamicData;
+using LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
+using Xunit;
+
+using static LittleBigMouse.Ui.Avalonia.Tests.BorderTestLayouts;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// Whole pointer gestures on a band, played out event by event without a display:
+/// press, the positions that follow, and whichever of release or cancellation ends
+/// them.
+/// <para>
+/// The band itself only turns Avalonia events into millimetres and the feedback
+/// into shapes. Everything a gesture decides — what a press takes hold of, what
+/// each position edits, which boundary the guide marks, what a cancellation puts
+/// back — is <see cref="BorderSectionGesture"/>, and is all exercised here.
+/// </para>
+/// </summary>
+public sealed class BorderGestureSequenceTests
+{
+    //==================//
+    // Drawing          //
+    //==================//
+
+    [Fact]
+    public void DrawingCreatesOnlyOnRelease()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        Assert.Null(gesture.Press(50, snap: false));
+        Assert.Equal(BorderSectionGesture.Kind.Draw, gesture.Mode);
+
+        // The sweep only outlines: nothing exists until the button comes up.
+        var feedback = gesture.Move(150, snap: false);
+        Assert.Equal(new BorderSpan(50, 150), feedback.Preview);
+        Assert.Empty(side.Side.Sections.Items);
+
+        var created = gesture.Release(150, snap: false);
+
+        Assert.NotNull(created);
+        Assert.Equal(50, created!.From);
+        Assert.Equal(150, created.To);
+        Assert.False(gesture.Active);
+    }
+
+    [Fact]
+    public void AClickThatDrawsNothingCreatesNothing()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(50, snap: false);
+
+        Assert.Null(gesture.Release(50, snap: false));
+        Assert.Empty(side.Side.Sections.Items);
+    }
+
+    //==================//
+    // Resizing         //
+    //==================//
+
+    [Fact]
+    public void ResizingHoldsTheBoundaryWhereItWasGrabbed()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // Pressed 3 mm inside the handle rather than on the line, which is the usual
+        // case: the handle is 4 mm deep here. The boundary must not move yet.
+        gesture.Press(53, snap: false);
+        Assert.Equal(50, section.From);
+
+        // A pointer position arrives with the press itself. Before the grab offset
+        // was kept, this alone slid the boundary from 50 to 53.
+        gesture.Move(53, snap: false);
+        Assert.Equal(50, section.From);
+
+        // From there the boundary follows the movement, not the position.
+        gesture.Move(63, snap: false);
+        Assert.Equal(60, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void ResizingTheFarEndHoldsItsGripToo()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(147, snap: false);
+        gesture.Move(147, snap: false);
+        Assert.Equal(150, section.To);
+
+        gesture.Move(137, snap: false);
+        Assert.Equal(140, section.To);
+        Assert.Equal(50, section.From);
+    }
+
+    [Fact]
+    public void EachEndIsResizedInTurnAndStopsWhereItRunsOut()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // The near end, out to the edge's own start and no further: the position is
+        // clamped to the edge before anything else looks at it.
+        gesture.Press(51, snap: false);
+        gesture.Move(1, snap: false);
+        Assert.Equal(0, section.From);
+
+        gesture.Move(-40, snap: false);
+        Assert.Equal(0, section.From);
+        gesture.Release(-40, snap: false);
+
+        // The far end, up against a neighbour rather than against the edge.
+        var neighbour = side.Create(200, 260)!;
+
+        gesture.Press(149, snap: false);
+        gesture.Move(199, snap: false);
+        Assert.Equal(200, section.To);
+
+        // Pushed into the neighbour, it comes to rest on it and does not swallow it.
+        gesture.Move(260, snap: false);
+        Assert.Equal(200, section.To);
+        Assert.Equal(200, neighbour.From);
+        Assert.Equal(260, neighbour.To);
+    }
+
+    [Fact]
+    public void AGestureOnATouchingBoundaryTakesTheSectionItStartsFrom()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        side.Create(50, 150);
+        var lower = side.Create(150, 250)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // The whole point of the handle rule, end to end: pressing the shared
+        // boundary resizes the lower section rather than the one above it.
+        Assert.Same(lower, gesture.Press(150, snap: false));
+
+        gesture.Move(150, snap: false);
+        gesture.Move(170, snap: false);
+
+        Assert.Equal(170, lower.From);
+        Assert.Equal(250, lower.To);
+    }
+
+    //==================//
+    // Moving           //
+    //==================//
+
+    [Fact]
+    public void MovingCarriesTheWholeSection()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        Assert.Same(section, gesture.Press(100, snap: false));
+        Assert.Equal(BorderSectionGesture.Kind.Move, gesture.Mode);
+
+        gesture.Move(120, snap: false);
+
+        Assert.Equal(70, section.From);
+        Assert.Equal(170, section.To);
+    }
+
+    //==================//
+    // Release, undrawn //
+    //==================//
+
+    [Fact]
+    public void ReleasingWithoutMovingLeavesASectionExactlyWhereItWas()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // A plain click in the middle of a section only selects it.
+        Assert.Same(section, gesture.Press(100, snap: true));
+        Assert.Null(gesture.Release(100, snap: true));
+
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+        Assert.False(gesture.Active);
+        Assert.Single(side.Side.Sections.Items);
+    }
+
+    [Fact]
+    public void ReleasingWithoutMovingLeavesAGrabbedBoundaryAlone()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // Clicked on the handle, so the gesture is a resize — but no position ever
+        // followed, and a resize that never ran must not snap the boundary on its
+        // way out.
+        gesture.Press(53, snap: true);
+        Assert.Equal(BorderSectionGesture.Kind.ResizeFrom, gesture.Mode);
+
+        Assert.Null(gesture.Release(53, snap: true));
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    //==================//
+    // Cancelling       //
+    //==================//
+
+    [Fact]
+    public void CancellingAResizePutsBothEndsBack()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(53, snap: false);
+        gesture.Move(63, snap: false);
+        Assert.Equal(60, section.From);
+
+        Assert.Same(section, gesture.Cancel());
+
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+        Assert.False(gesture.Active);
+    }
+
+    [Fact]
+    public void CancellingAResizeOfTheFarEndPutsItBackToo()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(147, snap: false);
+        gesture.Move(220, snap: false);
+        Assert.Equal(223, section.To);
+
+        Assert.Same(section, gesture.Cancel());
+
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void CancellingAMovePutsTheSectionBack()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(100, snap: false);
+        gesture.Move(120, snap: false);
+        Assert.Equal(70, section.From);
+
+        Assert.Same(section, gesture.Cancel());
+
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void CancellingADrawingLeavesNothingBehind()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(50, snap: false);
+        gesture.Move(150, snap: false);
+
+        // Nothing was ever created, so there is nothing to put back.
+        Assert.Null(gesture.Cancel());
+        Assert.Empty(side.Side.Sections.Items);
+
+        // The button still has to come up, and must not create the section then.
+        Assert.Null(gesture.Release(150, snap: false));
+        Assert.Empty(side.Side.Sections.Items);
+    }
+
+    [Fact]
+    public void PositionsArrivingAfterACancellationAreIgnored()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(100, snap: false);
+        gesture.Move(120, snap: false);
+        gesture.Cancel();
+
+        // Escape does not take the capture away, so the pointer keeps reporting until
+        // the button comes up. The gesture is over and none of it may land.
+        var feedback = gesture.Move(200, snap: false);
+
+        Assert.Null(feedback.Preview);
+        Assert.Null(feedback.Guide);
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void CancellingTwiceChangesNothingFurther()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(100, snap: false);
+        gesture.Move(120, snap: false);
+        gesture.Cancel();
+
+        Assert.Null(gesture.Cancel());
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void CancellingAGestureThatNeverStartedDoesNothing()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+
+        Assert.Null(new BorderSectionGesture(side).Cancel());
+        Assert.Equal(50, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    //==================//
+    // Lost capture     //
+    //==================//
+
+    // A lost capture cancels, so what matters is exactly when it does NOT: the
+    // release itself drops the capture, and the loss that follows must not undo the
+    // edit the release just settled.
+
+    [Fact]
+    public void TheCaptureLostOnReleaseDoesNotUndoAResize()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 150)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(53, snap: false);
+        gesture.Move(63, snap: false);
+        gesture.Release(63, snap: false);
+
+        Assert.Null(gesture.Cancel());
+
+        Assert.Equal(60, section.From);
+        Assert.Equal(150, section.To);
+    }
+
+    [Fact]
+    public void TheCaptureLostOnReleaseDoesNotUndoADrawing()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(50, snap: false);
+        gesture.Move(150, snap: false);
+        var created = gesture.Release(150, snap: false);
+
+        Assert.Null(gesture.Cancel());
+
+        Assert.NotNull(created);
+        Assert.Equal(50, created!.From);
+        Assert.Equal(150, created.To);
+        Assert.Single(side.Side.Sections.Items);
+    }
+
+    //==================//
+    // The guide        //
+    //==================//
+
+    [Fact]
+    public void DrawingMarksTheMovingEndWhenItLandsOnATarget()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        // 50 is near nothing; the edge's middle at 135 is a target, and 133 is within
+        // the 4 mm tolerance of it.
+        gesture.Press(50, snap: true);
+        var feedback = gesture.Move(133, snap: true);
+
+        Assert.Equal(new BorderSpan(50, 135), feedback.Preview);
+        Assert.Equal(new BorderGuideMark(135, SnapKind.Middle), feedback.Guide);
+    }
+
+    [Fact]
+    public void NothingIsMarkedWhileSnappingIsSuspended()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(50, snap: false);
+        var feedback = gesture.Move(133, snap: false);
+
+        // Ctrl held: the sweep goes where the pointer is and catches nothing.
+        Assert.Equal(new BorderSpan(50, 133), feedback.Preview);
+        Assert.Null(feedback.Guide);
+    }
+
+    [Fact]
+    public void ABoundaryBetweenTargetsIsNotMarked()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(50, snap: true);
+
+        Assert.Null(gesture.Move(100, snap: true).Guide);
+    }
+
+    [Fact]
+    public void ResizingMarksTheBoundaryItMoved()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(50, 200)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(53, snap: true);
+        var feedback = gesture.Move(136, snap: true);
+
+        Assert.Equal(135, section.From);
+        Assert.Equal(new BorderGuideMark(135, SnapKind.Middle), feedback.Guide);
+    }
+
+    [Fact]
+    public void AMovedSectionMarksWhicheverEndCaughtSomething()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(10, 40)!;
+        var gesture = new BorderSectionGesture(side);
+
+        // A moved section keeps its length, so only one of its two ends can land on a
+        // target — and which one is not known in advance. Here the far end catches
+        // the middle of the edge and the start is left over nothing.
+        gesture.Press(25, snap: true);
+        var feedback = gesture.Move(118, snap: true);
+
+        Assert.Equal(105, section.From);
+        Assert.Equal(135, section.To);
+        Assert.Equal(new BorderGuideMark(135, SnapKind.Middle), feedback.Guide);
+    }
+
+    [Fact]
+    public void AMovedSectionMarksItsStartWhenThatIsTheEndThatCaught()
+    {
+        var side = RightEdgeOf(TwoMonitorsLeft());
+        var section = side.Create(10, 40)!;
+        var gesture = new BorderSectionGesture(side);
+
+        gesture.Press(25, snap: true);
+        var feedback = gesture.Move(152, snap: true);
+
+        Assert.Equal(135, section.From);
+        Assert.Equal(165, section.To);
+        Assert.Equal(new BorderGuideMark(135, SnapKind.Middle), feedback.Guide);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderSectionEditorTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderSectionEditorTests.cs
@@ -1,11 +1,12 @@
 using System.Globalization;
 using DynamicData;
-using HLab.Geo;
 using LittleBigMouse.DisplayLayout;
 using LittleBigMouse.DisplayLayout.Dimensions;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
 using Xunit;
+
+using static LittleBigMouse.Ui.Avalonia.Tests.BorderTestLayouts;
 
 // Both geometry namespaces are in play here: the layout model speaks HLab.Geo,
 // the converter under test is fed by Avalonia's layout pass.
@@ -21,50 +22,11 @@ namespace LittleBigMouse.Ui.Avalonia.Tests;
 /// </summary>
 public sealed class BorderSectionEditorTests
 {
-    // Two 1920x1080 monitors, 480x270 mm each, side by side and vertically aligned.
-    static MonitorsLayout TwoMonitors(out PhysicalMonitor left, out PhysicalMonitor right)
-    {
-        var layout = new MonitorsLayout(new ILayoutOptions.Design()) { Id = "TEST" };
-
-        left = AddMonitor(layout, "LEFT", -480, 0);
-        right = AddMonitor(layout, "RIGHT", 0, 0);
-
-        return layout;
-    }
-
-    static PhysicalMonitor AddMonitor(
-        MonitorsLayout layout, string id, double xMm, double yMm,
-        double widthMm = 480, double heightMm = 270)
-    {
-        var model = new PhysicalMonitorModel($"PNP-{id}");
-        model.PhysicalSize.Width = widthMm;
-        model.PhysicalSize.Height = heightMm;
-
-        var monitor = new PhysicalMonitor(id, layout, model);
-        var source = new DisplaySource($"SRC-{id}") { AttachedToDesktop = true };
-        source.InPixel.Set(new Rect(new Point(0, 0), new Size(1920, 1080)));
-
-        var physicalSource = new PhysicalSource($"DEV-{id}", monitor, source);
-        monitor.ActiveSource = physicalSource;
-        monitor.Sources.Add(physicalSource);
-
-        layout.AddOrUpdatePhysicalMonitor(monitor);
-        layout.AddOrUpdatePhysicalSource(physicalSource);
-
-        monitor.DepthProjection.X = xMm;
-        monitor.DepthProjection.Y = yMm;
-
-        return monitor;
-    }
-
     static void AssertTarget(IReadOnlyList<SnapTarget> targets, double mm, SnapKind kind)
         => Assert.Contains(targets, t => System.Math.Abs(t.Mm - mm) < 0.001 && t.Kind == kind);
 
     static void AssertNoTarget(IReadOnlyList<SnapTarget> targets, double mm)
         => Assert.DoesNotContain(targets, t => System.Math.Abs(t.Mm - mm) < 0.001);
-
-    static BorderSideViewModel RightEdgeOf(PhysicalMonitor monitor, double pixelLength = 540)
-        => new(monitor, BorderSideKind.Right, monitor.BorderResistance.Right) { PixelLength = pixelLength };
 
     [Fact]
     public void PixelsAndMillimetresRoundTrip()
@@ -210,8 +172,6 @@ public sealed class BorderSectionEditorTests
         Assert.Equal(200, second.To);
     }
 
-    // 540 UI px over a 270 mm edge: 2 px per mm. The band is 16 px thick by default,
-    // so the handle is 8 px — 4 mm — and the mitre 8 mm.
     [Fact]
     public void TouchingSectionsEachKeepTheirOwnHandle()
     {
@@ -338,117 +298,10 @@ public sealed class BorderSectionEditorTests
     }
 
     //==================//
-    // The gesture      //
+    // Editing          //
     //==================//
 
-    [Fact]
-    public void ResizingHoldsTheBoundaryWhereItWasGrabbed()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        var section = side.Create(50, 150)!;
-        var gesture = new BorderSectionGesture(side);
-
-        // Pressed 3 mm inside the handle rather than on the line, which is the usual
-        // case: the handle is 4 mm deep here. The boundary must not move yet.
-        gesture.Press(53, snap: false);
-        Assert.Equal(50, section.From);
-
-        // A pointer position arrives with the press itself. Before the grab offset
-        // was kept, this alone slid the boundary from 50 to 53.
-        gesture.Move(53, snap: false);
-        Assert.Equal(50, section.From);
-
-        // From there the boundary follows the movement, not the position.
-        gesture.Move(63, snap: false);
-        Assert.Equal(60, section.From);
-        Assert.Equal(150, section.To);
-    }
-
-    [Fact]
-    public void ResizingTheFarEndHoldsItsGripToo()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        var section = side.Create(50, 150)!;
-        var gesture = new BorderSectionGesture(side);
-
-        gesture.Press(147, snap: false);
-        gesture.Move(147, snap: false);
-        Assert.Equal(150, section.To);
-
-        gesture.Move(137, snap: false);
-        Assert.Equal(140, section.To);
-        Assert.Equal(50, section.From);
-    }
-
-    [Fact]
-    public void MovingCarriesTheWholeSection()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        var section = side.Create(50, 150)!;
-        var gesture = new BorderSectionGesture(side);
-
-        Assert.Same(section, gesture.Press(100, snap: false));
-        Assert.Equal(BorderSectionGesture.Kind.Move, gesture.Mode);
-
-        gesture.Move(120, snap: false);
-
-        Assert.Equal(70, section.From);
-        Assert.Equal(170, section.To);
-    }
-
-    [Fact]
-    public void DrawingCreatesOnlyOnRelease()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        var gesture = new BorderSectionGesture(side);
-
-        Assert.Null(gesture.Press(50, snap: false));
-        Assert.Equal(BorderSectionGesture.Kind.Draw, gesture.Mode);
-
-        // The sweep only outlines: nothing exists until the button comes up.
-        var feedback = gesture.Move(150, snap: false);
-        Assert.Equal(50, feedback.PreviewFromMm);
-        Assert.Equal(150, feedback.PreviewToMm);
-        Assert.Empty(side.Side.Sections.Items);
-
-        var created = gesture.Release(150, snap: false);
-
-        Assert.NotNull(created);
-        Assert.Equal(50, created!.From);
-        Assert.Equal(150, created.To);
-        Assert.False(gesture.Active);
-    }
-
-    [Fact]
-    public void AClickThatDrawsNothingCreatesNothing()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        var gesture = new BorderSectionGesture(side);
-
-        gesture.Press(50, snap: false);
-
-        Assert.Null(gesture.Release(50, snap: false));
-        Assert.Empty(side.Side.Sections.Items);
-    }
-
-    [Fact]
-    public void AGestureOnATouchingBoundaryTakesTheSectionItStartsFrom()
-    {
-        var side = RightEdgeOf(TwoMonitorsLeft());
-        side.Create(50, 150);
-        var lower = side.Create(150, 250)!;
-        var gesture = new BorderSectionGesture(side);
-
-        // The whole point of the handle rule, end to end: pressing the shared
-        // boundary resizes the lower section rather than the one above it.
-        Assert.Same(lower, gesture.Press(150, snap: false));
-
-        gesture.Move(150, snap: false);
-        gesture.Move(170, snap: false);
-
-        Assert.Equal(170, lower.From);
-        Assert.Equal(250, lower.To);
-    }
+    // The gestures that drive these edits are in BorderGestureSequenceTests.
 
     [Fact]
     public void ASectionTooShortToBeIntentionalIsRejected()
@@ -744,11 +597,5 @@ public sealed class BorderSectionEditorTests
         // Opening drags anywhere rescues it.
         rest.DragBlock = false;
         Assert.False(side.IsFullyBlocked);
-    }
-
-    static PhysicalMonitor TwoMonitorsLeft()
-    {
-        TwoMonitors(out var left, out _);
-        return left;
     }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderSectionGeometryTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderSectionGeometryTests.cs
@@ -1,6 +1,9 @@
 using LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
 using Xunit;
 
+// The band's outline is in the UI's coordinates, so it speaks Avalonia's Point.
+using Point = global::Avalonia.Point;
+
 namespace LittleBigMouse.Ui.Avalonia.Tests;
 
 public sealed class BorderSectionGeometryTests
@@ -298,5 +301,60 @@ public sealed class FacingEdgeResolverTests
 
         Assert.Null(FacingEdgeResolver.FindNearest(
             BorderSideKind.Right, Source, 20, candidates));
+    }
+
+    //==================//
+    // The band's shape //
+    //==================//
+
+    // A 200 px edge with 16 px bands: each corner square is 16 by 16, and the two
+    // bands meeting there take half of it each.
+
+    [Fact]
+    public void AVerticalBandKeepsHalfOfEachCornerSquare()
+    {
+        Assert.Equal(
+            new[] { new Point(0, 0), new Point(16, 16), new Point(16, 184), new Point(0, 200) },
+            BorderBandShape.For(BorderSideKind.Left, 16, 200, 16));
+
+        // The mirror of it: the outer edge is on the right, so the mitre leans the
+        // other way.
+        Assert.Equal(
+            new[] { new Point(16, 0), new Point(16, 200), new Point(0, 184), new Point(0, 16) },
+            BorderBandShape.For(BorderSideKind.Right, 16, 200, 16));
+    }
+
+    [Fact]
+    public void AHorizontalBandKeepsTheOtherHalf()
+    {
+        Assert.Equal(
+            new[] { new Point(0, 0), new Point(200, 0), new Point(184, 16), new Point(16, 16) },
+            BorderBandShape.For(BorderSideKind.Top, 200, 16, 16));
+
+        Assert.Equal(
+            new[] { new Point(0, 16), new Point(16, 0), new Point(184, 0), new Point(200, 16) },
+            BorderBandShape.For(BorderSideKind.Bottom, 200, 16, 16));
+    }
+
+    [Fact]
+    public void TheTwoBandsOfACornerMeetOnItsDiagonal()
+    {
+        // The top-left square of a 300x200 monitor with 16 px bands. Both bands
+        // reaching into it end on the square's diagonal — (0,0) to (16,16) — so each
+        // keeps the triangle on its own side of it and a click there lands on exactly
+        // one of them.
+        var left = BorderBandShape.For(BorderSideKind.Left, 16, 200, 16);
+        var top = BorderBandShape.For(BorderSideKind.Top, 300, 16, 16);
+
+        foreach (var end in new[] { new Point(0, 0), new Point(16, 16) })
+        {
+            Assert.Contains(end, left);
+            Assert.Contains(end, top);
+        }
+
+        // And neither turns the corner the band on the other side of the diagonal
+        // has, which is what squaring one of them off would look like.
+        Assert.DoesNotContain(new Point(16, 0), left);
+        Assert.DoesNotContain(new Point(0, 16), top);
     }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderTestLayouts.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BorderTestLayouts.cs
@@ -1,0 +1,64 @@
+using DynamicData;
+using HLab.Geo;
+using LittleBigMouse.DisplayLayout;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugin.Layout.Avalonia.BorderResistancePlugin;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The monitor layouts the border section tests are written against, shared by the
+/// editor's arithmetic and by the gesture sequences.
+/// </summary>
+static class BorderTestLayouts
+{
+    // Two 1920x1080 monitors, 480x270 mm each, side by side and vertically aligned.
+    public static MonitorsLayout TwoMonitors(out PhysicalMonitor left, out PhysicalMonitor right)
+    {
+        var layout = new MonitorsLayout(new ILayoutOptions.Design()) { Id = "TEST" };
+
+        left = AddMonitor(layout, "LEFT", -480, 0);
+        right = AddMonitor(layout, "RIGHT", 0, 0);
+
+        return layout;
+    }
+
+    public static PhysicalMonitor AddMonitor(
+        MonitorsLayout layout, string id, double xMm, double yMm,
+        double widthMm = 480, double heightMm = 270)
+    {
+        var model = new PhysicalMonitorModel($"PNP-{id}");
+        model.PhysicalSize.Width = widthMm;
+        model.PhysicalSize.Height = heightMm;
+
+        var monitor = new PhysicalMonitor(id, layout, model);
+        var source = new DisplaySource($"SRC-{id}") { AttachedToDesktop = true };
+        source.InPixel.Set(new Rect(new Point(0, 0), new Size(1920, 1080)));
+
+        var physicalSource = new PhysicalSource($"DEV-{id}", monitor, source);
+        monitor.ActiveSource = physicalSource;
+        monitor.Sources.Add(physicalSource);
+
+        layout.AddOrUpdatePhysicalMonitor(monitor);
+        layout.AddOrUpdatePhysicalSource(physicalSource);
+
+        monitor.DepthProjection.X = xMm;
+        monitor.DepthProjection.Y = yMm;
+
+        return monitor;
+    }
+
+    /// <summary>
+    /// 540 UI px over a 270 mm edge: 2 px per mm. The band is 16 px thick by default,
+    /// so the handle is 8 px — 4 mm — and the mitre 8 mm.
+    /// </summary>
+    public static BorderSideViewModel RightEdgeOf(PhysicalMonitor monitor, double pixelLength = 540)
+        => new(monitor, BorderSideKind.Right, monitor.BorderResistance.Right) { PixelLength = pixelLength };
+
+    public static PhysicalMonitor TwoMonitorsLeft()
+    {
+        TwoMonitors(out var left, out _);
+        return left;
+    }
+}


### PR DESCRIPTION
`BorderSectionGesture` already owned press, drag, resize and release, and was already exercised without a display. Three things were missing from it, and all three lived in `BorderSideStrip`.

### A gesture had no end other than its release

Nothing handled Escape, and nothing handled a lost pointer — so a capture stolen mid-drag by another window left the gesture `Active` for good, with the outline and the snap guide still drawn over an edge nobody was editing any more. `Cancel()` ends a gesture the way `Release()` does and puts back the span the press took hold of. A drawn section only exists once released, so there is nothing to undo there.

The order those two arrive in is what makes this safe rather than destructive: letting go of the button drops the capture, so `PointerCaptureLost` runs on every ordinary release too. Avalonia raises `PointerReleased` inside `MouseDevice.MouseUp` and clears the capture in that call's `finally`, in that order — verified against Avalonia 12.1.0 rather than assumed — so the gesture has already ended by the time the loss arrives, and cancelling an ended gesture does nothing. Were it the other way round this would undo every drag ever made, which is why two tests pin it.

### The guide decided where it could not see

Which boundary the guide marks was decided in the band, from candidates the gesture handed it — one for a sweep, two for a moved section, since a moved section keeps its length and only one of its ends can have caught anything. That is a decision about snap targets rather than about drawing, and it needs the targets to make it. `BorderGestureFeedback` carries answers now: a `Preview` span, and the one `BorderGuideMark` that won if any did.

### The mitre arithmetic

Moved to `BorderBandShape`, where the way four bands share a monitor's corner squares can be read in one place and checked without a window.

### What this does not do

The band is **not shorter** for it — 440 lines to 450, the cancellation paths costing about what the decisions freed. What changed is what is left in it: it turns Avalonia events into millimetres and feedback into shapes, and decides nothing else. The snap and placement arithmetic is untouched.

### Tests

Twenty-four gesture sequences, played event by event: a release that never dragged, on a section and on a handle; cancelling each of the three edits and cancelling a drawing; positions still arriving afterwards, since Escape does not take the capture away; and the two lost-capture cases that must undo nothing. Resizing runs to both ends of a section in one sequence, stopping on the edge at one end and on a neighbour at the other. Plus the band's shape for the four sides and the corner they share.

234 tests pass in `LittleBigMouse.Ui.Avalonia.Tests`. Both halves were checked by mutation: a `Release` that forgets to go idle fails 3, a `Cancel` that does not restore fails 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
