### PR TITLE
Extract testable collaborators from three files, and fix the 5 cm ruler label

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/MonitorBorderPolicyTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/MonitorBorderPolicyTests.cs
@@ -1,0 +1,250 @@
+using System.Reactive;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using LittleBigMouse.DisplayLayout.Monitors;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// The "Border values" rules on their own: which size a monitor's geometry roots at, and how a
+/// monitor comes to own its bezel borders. No monitor, layout or display source is built here —
+/// that is what pulling these rules out of <see cref="PhysicalMonitor"/> bought.
+/// <para>
+/// <see cref="DimensionReactiveContractTests.MonitorGeometryRewiresWhenTheEffectiveDimensionInstanceChanges"/>
+/// remains the end-to-end guard that a real monitor's geometry follows what this policy publishes.
+/// </para>
+/// </summary>
+public class MonitorBorderPolicyTests
+{
+    sealed class ReactiveLayoutOptions : ILayoutOptions.Design
+    {
+        public void SetBorderValues(string value)
+        {
+            BorderValues = value;
+            OnPropertyChanged(nameof(BorderValues));
+        }
+    }
+
+    static DisplaySizeInMm ModelSize() => new()
+    {
+        Width = 600,
+        Height = 340,
+        LeftBorder = 10,
+        TopBorder = 11,
+        RightBorder = 12,
+        BottomBorder = 13,
+    };
+
+    static (MonitorBorderPolicy Policy, DisplaySizeInMm Model, ReactiveLayoutOptions Options) Build(
+        string mode = MonitorBorderPolicy.PerModel)
+    {
+        var model = ModelSize();
+        var options = new ReactiveLayoutOptions { BorderValues = mode };
+        return (new MonitorBorderPolicy(model, options), model, options);
+    }
+
+    [Fact]
+    public void BordersAreSeededFromTheModelSoPerMonitorStartsMatchingPerModel()
+    {
+        var (policy, model, _) = Build();
+
+        Assert.Equal(model.LeftBorder, policy.Borders.Left);
+        Assert.Equal(model.TopBorder, policy.Borders.Top);
+        Assert.Equal(model.RightBorder, policy.Borders.Right);
+        Assert.Equal(model.BottomBorder, policy.Borders.Bottom);
+        Assert.False(policy.Customized);
+    }
+
+    [Fact]
+    public void EffectiveSizeIsTheModelSizeUntilTheModeSwitchesToPerMonitor()
+    {
+        var (policy, model, options) = Build();
+
+        var sizes = new List<IMutableDisplaySize>();
+        using var subscription = policy.EffectiveSize.Subscribe(sizes.Add);
+
+        Assert.Same(model, Assert.Single(sizes));
+
+        options.SetBorderValues(MonitorBorderPolicy.PerMonitor);
+        Assert.Equal(2, sizes.Count);
+        Assert.NotSame(model, sizes[1]);
+
+        options.SetBorderValues(MonitorBorderPolicy.PerModel);
+        Assert.Same(model, sizes[2]);
+
+        // Back to PerMonitor must reuse the very same override instance: the geometry chain
+        // carries layout-computed positions on it.
+        options.SetBorderValues(MonitorBorderPolicy.PerMonitor);
+        Assert.Same(sizes[1], sizes[3]);
+    }
+
+    [Fact]
+    public void RepeatedModeWritesOfTheSameValueDoNotRepublishTheSize()
+    {
+        var (policy, _, options) = Build();
+
+        var sizes = new List<IMutableDisplaySize>();
+        using var subscription = policy.EffectiveSize.Subscribe(sizes.Add);
+
+        options.SetBorderValues(MonitorBorderPolicy.PerModel);
+        options.SetBorderValues(MonitorBorderPolicy.PerModel);
+
+        Assert.Single(sizes);
+    }
+
+    [Fact]
+    public void LateSubscribersReceiveTheCurrentSizeRatherThanWaitingForTheNextSwitch()
+    {
+        var (policy, _, options) = Build();
+
+        // The first subscriber is what connects the replayed stream; the geometry chains that
+        // subscribe afterwards must not miss the emission that connection already produced.
+        using var first = policy.EffectiveSize.Subscribe(_ => { });
+        options.SetBorderValues(MonitorBorderPolicy.PerMonitor);
+
+        var late = new List<IMutableDisplaySize>();
+        using var second = policy.EffectiveSize.Subscribe(late.Add);
+
+        Assert.Same(policy.Borders, Assert.IsType<DisplayBorderOverride>(Assert.Single(late)).BorderSource);
+    }
+
+    [Fact]
+    public void ThePerMonitorSizeKeepsTheModelDimensionsButSubstitutesTheMonitorBorders()
+    {
+        var (policy, model, options) = Build(MonitorBorderPolicy.PerMonitor);
+
+        var sizes = new List<IMutableDisplaySize>();
+        using var subscription = policy.EffectiveSize.Subscribe(sizes.Add);
+
+        policy.Borders.Left = 40;
+
+        var effective = Assert.Single(sizes);
+        Assert.Equal(model.Width, effective.Width);
+        Assert.Equal(model.Height, effective.Height);
+        Assert.Equal(40, effective.LeftBorder);
+        Assert.Equal(model.TopBorder, effective.TopBorder);
+    }
+
+    [Fact]
+    public void BordersMirrorTheModelWhileTheMonitorDoesNotOwnThem()
+    {
+        var (policy, model, _) = Build();
+
+        model.LeftBorder = 25;
+
+        Assert.Equal(25, policy.Borders.Left);
+        Assert.False(policy.Customized);
+    }
+
+    [Fact]
+    public void TheMirrorStopsOnceTheMonitorOwnsItsBorders()
+    {
+        var (policy, model, _) = Build();
+
+        policy.Customized = true;
+        model.LeftBorder = 25;
+
+        Assert.Equal(10, policy.Borders.Left);
+    }
+
+    [Fact]
+    public void AMirrorWriteIsNeverAUserEditEvenWhileAlreadyInPerMonitorMode()
+    {
+        // The Load path applies model borders with the mode already on PerMonitor. Without the
+        // mirror flag that copy would mark the monitor customized and cut the mirror mid-write,
+        // freezing the remaining sides at their seeded values.
+        var (policy, model, _) = Build(MonitorBorderPolicy.PerMonitor);
+
+        model.LeftBorder = 25;
+        model.BottomBorder = 26;
+
+        Assert.False(policy.Customized);
+        Assert.Equal(25, policy.Borders.Left);
+        Assert.Equal(26, policy.Borders.Bottom);
+    }
+
+    [Fact]
+    public void EditingABorderInPerMonitorModeMakesTheMonitorOwnThem()
+    {
+        var (policy, model, _) = Build(MonitorBorderPolicy.PerMonitor);
+
+        policy.Borders.Left = 40;
+        Assert.True(policy.Customized);
+
+        // Ownership taken: the model no longer drives this monitor.
+        model.LeftBorder = 25;
+        Assert.Equal(40, policy.Borders.Left);
+    }
+
+    [Fact]
+    public void EditingABorderInPerModelModeDoesNotMakeTheMonitorOwnThem()
+    {
+        // PerModel edits land on the shared model, not here; a write reaching Borders in that
+        // mode is the store or a stray caller, and must not silently take ownership.
+        var (policy, _, _) = Build();
+
+        policy.Borders.Left = 40;
+
+        Assert.False(policy.Customized);
+    }
+
+    [Fact]
+    public void CustomizedRaisesAChangeNotificationWhenTheEditIsDetected()
+    {
+        var (policy, _, _) = Build(MonitorBorderPolicy.PerMonitor);
+
+        var changed = new List<string?>();
+        policy.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        policy.Borders.Left = 40;
+
+        Assert.Contains(nameof(MonitorBorderPolicy.Customized), changed);
+    }
+
+    [Fact]
+    public void BordersChangedReportsEveryEditPastTheSeedingIncludingMirrorWrites()
+    {
+        var (policy, model, options) = Build();
+
+        var edits = new List<Unit>();
+        using var subscription = policy.BordersChanged.Subscribe(edits.Add);
+
+        // Seeding already happened in the constructor and must not be reported.
+        Assert.Empty(edits);
+
+        // A mirror write is not a user edit, but it does change what a save would write out.
+        model.LeftBorder = 25;
+        Assert.Single(edits);
+
+        options.SetBorderValues(MonitorBorderPolicy.PerMonitor);
+        policy.Borders.Top = 30;
+        Assert.Equal(2, edits.Count);
+    }
+
+    [Fact]
+    public void WritingTheSameBorderValueReportsNothing()
+    {
+        var (policy, _, _) = Build();
+
+        var edits = new List<Unit>();
+        using var subscription = policy.BordersChanged.Subscribe(edits.Add);
+
+        policy.Borders.Left = policy.Borders.Left;
+
+        Assert.Empty(edits);
+    }
+
+    [Fact]
+    public void DisposingStopsTheMirrorAndTheEditReports()
+    {
+        var (policy, model, _) = Build();
+
+        var edits = new List<Unit>();
+        using var subscription = policy.BordersChanged.Subscribe(edits.Add);
+
+        policy.Dispose();
+        model.LeftBorder = 25;
+
+        Assert.Equal(10, policy.Borders.Left);
+        Assert.Empty(edits);
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorBorderPolicy.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/MonitorBorderPolicy.cs
@@ -1,0 +1,173 @@
+using System;
+using System.ComponentModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using LittleBigMouse.DisplayLayout.Dimensions;
+using ReactiveUI;
+
+namespace LittleBigMouse.DisplayLayout.Monitors;
+
+/// <summary>
+/// Decides which bezel borders one monitor's geometry is built from, and keeps that decision
+/// consistent while the "Border values" option, the shared model and the user all move.
+/// <para>
+/// Three rules live here, and nothing else does:
+/// <list type="number">
+/// <item>which size the geometry roots at — the shared per-model one, or the same size with this
+/// monitor's own borders substituted (<see cref="EffectiveSize"/>);</item>
+/// <item>the mirror that keeps <see cref="Borders"/> following the model until the monitor owns
+/// its values, so the first switch to "PerMonitor" starts from what the user currently sees;</item>
+/// <item>the detection of that ownership (<see cref="Customized"/>) — a user edit in "PerMonitor"
+/// mode, as opposed to a mirror write, which is never one.</item>
+/// </list>
+/// </para>
+/// <para>
+/// It owns no persistence and no dirty flag: it reports edits through <see cref="BordersChanged"/>
+/// and lets the monitor decide what "unsaved" means. That is the whole point of the split — these
+/// rules are testable against a bare size and an options object, with no monitor, layout or source
+/// in sight.
+/// </para>
+/// </summary>
+public sealed class MonitorBorderPolicy : ReactiveObject, IDisposable
+{
+    /// <summary>Bezel borders are shared by every monitor of the same make/model.</summary>
+    public const string PerModel = "PerModel";
+
+    /// <summary>Each physical monitor keeps its own bezel borders.</summary>
+    public const string PerMonitor = "PerMonitor";
+
+    readonly CompositeDisposable _disposables = new();
+    readonly Subject<Unit> _bordersChanged = new();
+
+    // True while the mirror below copies model borders into Borders, so the
+    // customization detector can tell mirror writes from user edits.
+    bool _mirroringModelBorders;
+
+    public MonitorBorderPolicy(DisplaySizeInMm modelSize, ILayoutOptions options)
+    {
+        // Per-monitor border source, seeded from the model so "PerMonitor" starts matching "PerModel".
+        Borders = new DisplayBorders
+        {
+            Left = modelSize.LeftBorder,
+            Top = modelSize.TopBorder,
+            Right = modelSize.RightBorder,
+            Bottom = modelSize.BottomBorder,
+        };
+
+        var borderOverride = new DisplayBorderOverride(modelSize, Borders);
+
+        // Observe BorderValues directly via ILayoutOptions.PropertyChanged — WhenAnyValue through
+        // IMonitorsLayout (which declares no INotifyPropertyChanged) loses the innermost subscription.
+        var borderValuesObs = Observable
+            .FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                h => options.PropertyChanged += h,
+                h => options.PropertyChanged -= h)
+            .Where(e => e.EventArgs.PropertyName == nameof(ILayoutOptions.BorderValues))
+            .Select(_ => options.BorderValues)
+            .StartWith(options.BorderValues)
+            .DistinctUntilChanged();
+
+        IMutableDisplaySize EffectiveSizeFor(string mode) =>
+            mode == PerMonitor ? borderOverride : modelSize;
+
+        // Shared, replayed stream — Replay(1) ensures every geometry chain receives the current
+        // value when it subscribes, without missing the StartWith emission that already fired for
+        // the first subscriber. Consumers subscribe directly rather than through a
+        // WhenAnyValue(e => e.EffectivePhysicalSize) OAPH-PropertyChanged round-trip, which breaks
+        // in Avalonia's synchronous reentrancy model (mode-change event → OAPH fires → inner
+        // PropertyChanged → WhenAnyValue chain stops).
+        EffectiveSize = borderValuesObs
+            .Select(EffectiveSizeFor)
+            .Replay(1)
+            .RefCount();
+
+        // Keep the per-monitor borders following the shared model values until this
+        // monitor owns some (loaded from the store, or edited in PerMonitor mode):
+        // the first switch to PerMonitor must start from the monitor's CURRENT model
+        // borders, not from a seed frozen at an earlier launch. Once customized the
+        // mirror stops for good and the stored values win.
+        _disposables.Add(modelSize.WhenAnyValue(
+                e => e.LeftBorder,
+                e => e.TopBorder,
+                e => e.RightBorder,
+                e => e.BottomBorder)
+            .Where(_ => !Customized)
+            .Subscribe(_ =>
+            {
+                // Flag the copy so the customization detector below ignores it: a
+                // mirror write is never a user edit. Without this, the first model
+                // border applied while the mode is already PerMonitor (e.g. during
+                // Load) marks the monitor customized and cuts the mirror mid-copy.
+                _mirroringModelBorders = true;
+                try
+                {
+                    Borders.Left = modelSize.LeftBorder;
+                    Borders.Top = modelSize.TopBorder;
+                    Borders.Right = modelSize.RightBorder;
+                    Borders.Bottom = modelSize.BottomBorder;
+                }
+                finally
+                {
+                    _mirroringModelBorders = false;
+                }
+            }));
+
+        // Skip(1) drops the initial combined emission at subscription time.
+        // A change landing while in PerMonitor mode is a user edit of this monitor's
+        // own borders: from then on the monitor keeps them (mirror above stops).
+        _disposables.Add(Borders.WhenAnyValue(
+                e => e.Left,
+                e => e.Top,
+                e => e.Right,
+                e => e.Bottom,
+                (l, t, r, b) => (l, t, r, b))
+            .Skip(1)
+            .Subscribe(_ =>
+            {
+                if (!_mirroringModelBorders && options.BorderValues == PerMonitor)
+                    Customized = true;
+
+                _bordersChanged.OnNext(Unit.Default);
+            }));
+    }
+
+    /// <summary>
+    /// This monitor's own bezel borders, used to build the geometry only when "Border values" is
+    /// "PerMonitor". Seeded from the model at construction; loaded from / saved to the monitor's
+    /// own store entry. In "PerModel" mode the geometry ignores these and uses the shared model
+    /// borders — but the mirror keeps them up to date all the same.
+    /// </summary>
+    public DisplayBorders Borders { get; }
+
+    /// <summary>
+    /// The size the geometry must be built from, re-emitted whenever the "Border values" option
+    /// switches the monitor between the shared per-model size and its own border override.
+    /// </summary>
+    public IObservable<IMutableDisplaySize> EffectiveSize { get; }
+
+    /// <summary>
+    /// Fires on every change to <see cref="Borders"/> past the seeding, mirror writes included:
+    /// <see cref="DisplayBorders"/> is not <c>ISavable</c>, so the owner cannot track it with
+    /// <c>UnsavedOn</c> and needs this to mark itself dirty.
+    /// </summary>
+    public IObservable<Unit> BordersChanged => _bordersChanged;
+
+    /// <summary>
+    /// True once this monitor owns its bezel borders (persisted values were loaded, or a border
+    /// was edited in "PerMonitor" mode). Until then <see cref="Borders"/> mirrors the shared model
+    /// values, and nothing per-monitor is persisted.
+    /// </summary>
+    public bool Customized
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+        _bordersChanged.Dispose();
+    }
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/PhysicalMonitor.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Reactive.Concurrency;
 using System.Linq;
 using System.Reactive.Linq;
@@ -88,43 +87,31 @@ public class PhysicalMonitor : SavableReactiveModel
             .Do(ParseDisplaySources)
             .Subscribe().DisposeWith(this);
 
-        // Per-monitor border source, seeded from the model so "PerMonitor" starts matching "PerModel".
-        Borders = new DisplayBorders
-        {
-            Left = model.PhysicalSize.LeftBorder,
-            Top = model.PhysicalSize.TopBorder,
-            Right = model.PhysicalSize.RightBorder,
-            Bottom = model.PhysicalSize.BottomBorder,
-        };
-        _borderOverride = new DisplayBorderOverride(model.PhysicalSize, Borders);
+        // Which borders the geometry is built from, and how this monitor comes to own them:
+        // see MonitorBorderPolicy. The whole rotation / projection / zones chain below just
+        // follows the size it publishes, and never asks which mode produced it.
+        _borderPolicy = new MonitorBorderPolicy(model.PhysicalSize, layout.Options).DisposeWith(this);
+        Borders = _borderPolicy.Borders;
 
-        // Observe BorderValues directly via ILayoutOptions.PropertyChanged — WhenAnyValue through
-        // IMonitorsLayout (which declares no INotifyPropertyChanged) loses the innermost subscription.
-        var borderValuesObs = Observable
-            .FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
-                h => Layout.Options.PropertyChanged += h,
-                h => Layout.Options.PropertyChanged -= h)
-            .Where(e => e.EventArgs.PropertyName == nameof(ILayoutOptions.BorderValues))
-            .Select(_ => Layout.Options.BorderValues)
-            .StartWith(Layout.Options.BorderValues)
-            .DistinctUntilChanged();
+        // Republish the policy's ownership flag as this monitor's own property change:
+        // persistence and the UI watch PhysicalMonitor, not the policy behind it.
+        _borderPolicy.Changing
+            .Where(e => e.PropertyName == nameof(MonitorBorderPolicy.Customized))
+            .Subscribe(_ => this.RaisePropertyChanging(nameof(BordersCustomized)))
+            .DisposeWith(this);
 
-        // The size the geometry is built from: the shared per-model size, or — when "Border values"
-        // is "PerMonitor" — the same size with this monitor's own borders substituted. Reactive so a
-        // mode switch rewires rotation / projection / zones live.
-        // Shared, replayed stream — Replay(1) ensures _physicalRotated and _depthProjectionUnrotated
-        // receive the current value when they subscribe, without missing the StartWith emission that
-        // already fired for _effectivePhysicalSize. Direct subscription also avoids the
-        // WhenAnyValue(e => e.EffectivePhysicalSize) OAPH-PropertyChanged round-trip that breaks
-        // in Avalonia's synchronous reentrancy model (mode-change event → OAPH fires → inner
-        // PropertyChanged → WhenAnyValue chain stops).
-        IMutableDisplaySize EffectiveSizeFor(string mode) =>
-            mode == "PerMonitor" ? _borderOverride : Model.PhysicalSize;
+        _borderPolicy.Changed
+            .Where(e => e.PropertyName == nameof(MonitorBorderPolicy.Customized))
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(BordersCustomized)))
+            .DisposeWith(this);
 
-        var effectiveSizeObs = borderValuesObs
-            .Select(EffectiveSizeFor)
-            .Replay(1)
-            .RefCount();
+        // DisplayBorders is not ISavable so UnsavedOn cannot track it.
+        // Load() resets Saved=true at its end, so loading does not leave a dirty flag.
+        _borderPolicy.BordersChanged
+            .Subscribe(_ => Saved = false)
+            .DisposeWith(this);
+
+        var effectiveSizeObs = _borderPolicy.EffectiveSize;
 
         _effectivePhysicalSize = effectiveSizeObs
             .ToProperty(this, e => e.EffectivePhysicalSize, initialValue: model.PhysicalSize, scheduler: Scheduler.Immediate)
@@ -174,63 +161,9 @@ public class PhysicalMonitor : SavableReactiveModel
             e => e.DepthRatio,
             e => e.BorderResistance
         );
-
-        // Keep the per-monitor borders following the shared model values until this
-        // monitor owns some (loaded from the store, or edited in PerMonitor mode):
-        // the first switch to PerMonitor must start from the monitor's CURRENT model
-        // borders, not from a seed frozen at an earlier launch. Once customized the
-        // mirror stops for good and the stored values win.
-        this.WhenAnyValue(
-                e => e.Model.PhysicalSize.LeftBorder,
-                e => e.Model.PhysicalSize.TopBorder,
-                e => e.Model.PhysicalSize.RightBorder,
-                e => e.Model.PhysicalSize.BottomBorder)
-            .Where(_ => !BordersCustomized)
-            .Subscribe(_ =>
-            {
-                // Flag the copy so the customization detector below ignores it: a
-                // mirror write is never a user edit. Without this, the first model
-                // border applied while the mode is already PerMonitor (e.g. during
-                // Load) marks the monitor customized and cuts the mirror mid-copy.
-                _mirroringModelBorders = true;
-                try
-                {
-                    Borders.Left = Model.PhysicalSize.LeftBorder;
-                    Borders.Top = Model.PhysicalSize.TopBorder;
-                    Borders.Right = Model.PhysicalSize.RightBorder;
-                    Borders.Bottom = Model.PhysicalSize.BottomBorder;
-                }
-                finally
-                {
-                    _mirroringModelBorders = false;
-                }
-            })
-            .DisposeWith(this);
-
-        // DisplayBorders is not ISavable so UnsavedOn cannot track it.
-        // Skip(1) drops the initial combined emission at subscription time.
-        // Load() resets Saved=true at its end, so loading does not leave a dirty flag.
-        // A change landing while in PerMonitor mode is a user edit of this monitor's
-        // own borders: from then on the monitor keeps them (mirror above stops).
-        this.WhenAnyValue(
-                e => e.Borders.Left,
-                e => e.Borders.Top,
-                e => e.Borders.Right,
-                e => e.Borders.Bottom,
-                (l, t, r, b) => (l, t, r, b))
-            .Skip(1)
-            .Subscribe(_ =>
-            {
-                if (!_mirroringModelBorders && Layout.Options.BorderValues == "PerMonitor")
-                    BordersCustomized = true;
-                Saved = false;
-            })
-            .DisposeWith(this);
     }
 
-    // True while the mirror above copies model borders into Borders, so the
-    // customization detector can tell mirror writes from user edits.
-    bool _mirroringModelBorders;
+    readonly MonitorBorderPolicy _borderPolicy;
 
     void ParseDisplaySources(IReadOnlyCollection<PhysicalSource> obj)
     {
@@ -301,10 +234,10 @@ public class PhysicalMonitor : SavableReactiveModel
 
     /// <summary>
     /// The physical size (with bezel borders) this monitor's geometry is built from — the whole
-    /// rotation / depth-projection / zones chain reads through here. Today it always returns the
-    /// shared per-model <see cref="PhysicalMonitorModel.PhysicalSize"/>, so behaviour is unchanged.
-    /// It exists as the single seam where a future "Border values: per monitor" option can substitute
-    /// a per-monitor border source, without touching any geometry consumer. See the border-values plan.
+    /// rotation / depth-projection / zones chain reads through here. Either the shared per-model
+    /// <see cref="PhysicalMonitorModel.PhysicalSize"/> or, when "Border values" is "PerMonitor",
+    /// the same size with this monitor's own borders substituted; <see cref="MonitorBorderPolicy"/>
+    /// decides which and re-publishes on a mode switch, so no geometry consumer sees the option.
     /// </summary>
     public IMutableDisplaySize EffectivePhysicalSize => _effectivePhysicalSize.Value;
     readonly ObservableAsPropertyHelper<IMutableDisplaySize> _effectivePhysicalSize;
@@ -314,18 +247,21 @@ public class PhysicalMonitor : SavableReactiveModel
     /// "PerMonitor". Seeded from the model at construction; loaded from / saved to the monitor's own
     /// registry key. In "PerModel" mode the geometry ignores these and uses the shared model borders.
     /// </summary>
+    /// <remarks>Held by <see cref="MonitorBorderPolicy"/>; kept in a field here so consumers still
+    /// observe it through a plain get-only property on the monitor.</remarks>
     public DisplayBorders Borders { get; }
-    readonly DisplayBorderOverride _borderOverride;
 
     /// <summary>
     /// True once this monitor owns its bezel borders (persisted values were loaded,
     /// or a border was edited in "PerMonitor" mode). Until then <see cref="Borders"/>
     /// mirrors the shared model values, and nothing per-monitor is persisted.
     /// </summary>
+    /// <remarks>The state lives in <see cref="MonitorBorderPolicy"/>, which also sets it on its
+    /// own when it detects a user edit; the constructor republishes those changes here.</remarks>
     public bool BordersCustomized
     {
-       get;
-       set => this.RaiseAndSetIfChanged(ref field, value);
+       get => _borderPolicy.Customized;
+       set => _borderPolicy.Customized = value;
     }
 
     /// <summary>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Rulers/RulerGeometry.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Rulers/RulerGeometry.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+
+namespace LittleBigMouse.Plugin.Layout.Avalonia.Rulers;
+
+/// <summary>
+/// Which subdivision a graduation marks. Decides how far its tick reaches and what number,
+/// if any, it carries.
+/// </summary>
+public enum RulerGraduationKind
+{
+    Millimetre,
+    FiveMillimetres,
+    Centimetre,
+    FiveCentimetres,
+    Decimetre,
+}
+
+/// <summary>One mark on the ruler, in ruler coordinates — millimetres along the axis.</summary>
+/// <param name="Position">Distance from the start of the drawn axis, not from the ruler's zero.</param>
+/// <param name="TickLength">How far the tick reaches away from the axis.</param>
+/// <param name="Label">The number this graduation carries, or null when it carries none.</param>
+/// <param name="LabelSize">Font size for <paramref name="Label"/>, already scaled to the display.</param>
+/// <param name="Inside">
+/// Whether this millimetre falls within the monitor the ruler measures. Graduations run past
+/// both ends, and the ones outside are drawn dimmer rather than skipped — that overhang is how
+/// you see where the neighbouring monitor starts.
+/// </param>
+public readonly record struct RulerGraduation(
+    double Position,
+    RulerGraduationKind Kind,
+    double TickLength,
+    string? Label,
+    double LabelSize,
+    bool Inside);
+
+/// <summary>An interval along the ruler axis, in ruler coordinates.</summary>
+public readonly record struct RulerBand(double Start, double End);
+
+/// <summary>
+/// What a ruler is made of, worked out with no <c>DrawingContext</c> and no orientation: the
+/// three background bands and the sequence of graduations, all in ruler coordinates
+/// (millimetres along the axis, growing away from the axis start).
+/// <para>
+/// Turning those into screen coordinates is <see cref="RulerOrientation"/>'s job, and putting
+/// ink on them is the control's. The split is what makes the arithmetic below checkable: which
+/// millimetre gets a number, where the drawn ruler stops and the overhang begins, what happens
+/// when the ruler starts off-screen — none of that needs a window to answer.
+/// </para>
+/// </summary>
+/// <param name="AxisLength">Length of the drawn axis, in millimetres.</param>
+/// <param name="RulerStart">Where the visible window into the ruler begins, in millimetres.</param>
+/// <param name="RulerLength">Length of the monitor edge being measured, in millimetres.</param>
+/// <param name="Zero">Where the measured edge's zero falls along the drawn axis.</param>
+/// <param name="Ratio">Display units per millimetre, used to size the labels.</param>
+public readonly record struct RulerGeometry(
+    double AxisLength,
+    double RulerStart,
+    double RulerLength,
+    double Zero,
+    double Ratio)
+{
+    // How far each kind of tick reaches. A decimetre reads at a glance because it is twice a
+    // centimetre, and a millimetre is barely a notch.
+    const double DecimetreTick = 20.0;
+    const double FiveCentimetreTick = 15.0;
+    const double CentimetreTick = 10.0;
+    const double FiveMillimetreTick = 5.0;
+    const double MillimetreTick = 2.5;
+
+    // Label sizes before scaling to the display.
+    const double DecimetreLabel = 5.0;
+    const double FiveCentimetreLabel = 4.0;
+    const double CentimetreLabel = 3.0;
+
+    /// <summary>Where the measured edge ends along the drawn axis.</summary>
+    public double End => Zero + RulerLength;
+
+    /// <summary>
+    /// The overhang before the measured edge starts, or null when the axis begins at or after
+    /// the zero — a ruler scrolled so its zero is off-screen has no "before" to draw.
+    /// </summary>
+    public RulerBand? OutsideBefore =>
+        AxisLength > 0 && Zero > 0 ? new RulerBand(0, Math.Min(Zero, AxisLength)) : null;
+
+    /// <summary>The overhang after the measured edge ends, or null when it runs off the axis.</summary>
+    public RulerBand? OutsideAfter =>
+        End < AxisLength ? new RulerBand(Math.Max(End, 0), AxisLength) : null;
+
+    /// <summary>
+    /// The measured edge itself, clipped to the axis — null when it falls entirely outside.
+    /// </summary>
+    public RulerBand? Inside =>
+        Zero < AxisLength && End > 0
+            ? new RulerBand(Math.Max(Zero, 0), Math.Min(End, AxisLength))
+            : null;
+
+    /// <summary>
+    /// Every graduation the axis shows, in order. Starts a centimetre before the visible window
+    /// so a label whose tick has just scrolled off still reaches the edge it belongs to.
+    /// </summary>
+    public IEnumerable<RulerGraduation> Graduations()
+    {
+        var mm = (int)RulerStart - 10;
+        var position = Zero + mm;
+
+        while (position < AxisLength)
+        {
+            yield return Describe(mm, position);
+
+            mm++;
+            position += 1.0;
+        }
+    }
+
+    RulerGraduation Describe(int mm, double position)
+    {
+        // Outside the measured edge on either side; the tick is drawn dimmer, not dropped.
+        var inside = mm >= 0 && mm <= RulerLength;
+
+        // Coarsest first. Every step divides the one below it, so the first match wins.
+        if (mm % 100 == 0)
+            return new(position, RulerGraduationKind.Decimetre, DecimetreTick,
+                (mm / 100).ToString(), DecimetreLabel * Ratio, inside);
+
+        // Both of these number the centimetre within its decimetre, so the labels read 1..9 and
+        // restart — and carry the sign in the overhang before zero. They differ only in how far
+        // the tick reaches and how large the number is drawn: the half-decimetre is the landmark
+        // between two numbered decimetres, so it gets more of both.
+        if (mm % 50 == 0)
+            return new(position, RulerGraduationKind.FiveCentimetres, FiveCentimetreTick,
+                (mm % 100 / 10).ToString(), FiveCentimetreLabel * Ratio, inside);
+
+        if (mm % 10 == 0)
+            return new(position, RulerGraduationKind.Centimetre, CentimetreTick,
+                (mm % 100 / 10).ToString(), CentimetreLabel * Ratio, inside);
+
+        if (mm % 5 == 0)
+            return new(position, RulerGraduationKind.FiveMillimetres, FiveMillimetreTick,
+                null, 0, inside);
+
+        return new(position, RulerGraduationKind.Millimetre, MillimetreTick, null, 0, inside);
+    }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Rulers/RulerViewTop.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/Rulers/RulerViewTop.cs
@@ -1,6 +1,4 @@
-﻿#define TIMING
-
-using System.Globalization;
+﻿using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -58,6 +56,12 @@ abstract class RulerOrientation
 
     public abstract Point TextTransform(Point p, double size, double length);
 
+    /// <summary>
+    /// The ruler's outline: a trapezoid whose narrow side is the one facing the monitor, so two
+    /// rulers meeting at a corner mitre into each other instead of overlapping.
+    /// </summary>
+    public abstract IReadOnlyList<Point> ClipOutline();
+
     public Brush GetBackground(Color color)
     {
         var c = color.ToColor<double>().ToHSL().Darken(0.7).ToAvaloniaColor();
@@ -103,6 +107,14 @@ class RulerOrientationTop : RulerOrientation
     public override Point TextTransform(Point p, double size, double length)
         => Transform(p) + (new Vector(size * 0.1, -size * 1.1));
 
+    public override IReadOnlyList<Point> ClipOutline() =>
+    [
+        new Point(Bounds.Left, Bounds.Top),
+        new Point(Bounds.Left + Bounds.Height, Bounds.Bottom),
+        new Point(Bounds.Right - Bounds.Height, Bounds.Bottom),
+        new Point(Bounds.Right, Bounds.Top),
+    ];
+
     protected override Brush GetBrush(Color color) => RulerOrientation.GetBrush(0, 0, 0, 1, color);
 
     public RulerOrientationTop(double size, double length, Rect bounds) : base(size, length, bounds)
@@ -127,6 +139,14 @@ class RulerOrientationRight : RulerOrientation
 
     public override Point TextTransform(Point p, double size, double length) => Transform(p);
 
+    public override IReadOnlyList<Point> ClipOutline() =>
+    [
+        new Point(Bounds.Right, Bounds.Top),
+        new Point(Bounds.Left, Bounds.Top + Bounds.Width),
+        new Point(Bounds.Left, Bounds.Bottom - Bounds.Width),
+        new Point(Bounds.Right, Bounds.Bottom),
+    ];
+
     protected override Brush GetBrush(Color color) => RulerOrientation.GetBrush(1, 0, 0, 0, color);
 
     public RulerOrientationRight(double size, double length, Rect bounds) : base(size, length, bounds)
@@ -150,6 +170,15 @@ class RulerOrientationBottom : RulerOrientation
 
     public override Point TextTransform(Point p, double size, double length)
         => Transform(p) + new Vector(size * 0.1, -size * 0.3);
+
+    public override IReadOnlyList<Point> ClipOutline() =>
+    [
+        new Point(Bounds.Left, Bounds.Bottom),
+        new Point(Bounds.Left + Bounds.Height, Bounds.Top),
+        new Point(Bounds.Right - Bounds.Height, Bounds.Top),
+        new Point(Bounds.Right, Bounds.Bottom),
+    ];
+
     protected override Brush GetBrush(Color color) => RulerOrientation.GetBrush(0, 1, 0, 0, color);
 
     public RulerOrientationBottom(double size, double length, Rect bounds) : base(size, length, bounds)
@@ -171,6 +200,14 @@ class RulerOrientationLeft : RulerOrientation
 
     public override Point TextTransform(Point p, double size, double length)
         => Transform(p) + new Vector(-length, 0);
+
+    public override IReadOnlyList<Point> ClipOutline() =>
+    [
+        new Point(Bounds.Left, Bounds.Top),
+        new Point(Bounds.Right, Bounds.Top + Bounds.Width),
+        new Point(Bounds.Right, Bounds.Bottom - Bounds.Width),
+        new Point(Bounds.Left, Bounds.Bottom),
+    ];
 
     protected override Brush GetBrush(Color color) => RulerOrientation.GetBrush(0, 0, 1, 0, color);
 
@@ -284,12 +321,7 @@ public class RulerViewTop : Control
     readonly Pen _penIn = new(Brushes.WhiteSmoke, 1);
     readonly Pen _penOut = new(new SolidColorBrush(HLabColors.RGB(0.7, 0.7, 0.7, 0.7).ToAvaloniaColor()), 1);
 
-    protected void Render()
-    {
-        InvalidateVisual();
-        return;
-
-    }
+    protected void Render() => InvalidateVisual();
 
     public override void Render(DrawingContext dc)
     {
@@ -305,157 +337,52 @@ public class RulerViewTop : Control
         var background = o.GetBackground(Selected ? Colors.DarkGreen : Colors.DarkBlue);
         var backgroundOut = o.GetBackground(Colors.Black);
 
-        //dc.PushClip(new RoundedRect(
-        //    new Rect(
-        //        new Point(7, 7),
-        //        new Size(Bounds.Width - 13, Bounds.Height - 13))));
-        switch (Orientation)
-        {
-            case 0:
-                dc.PushGeometryClip(new PolylineGeometry(
-                    new List<Point>()
-                    {
-                        new Point(Bounds.Left, Bounds.Top),
-                        new Point(Bounds.Left + Bounds.Height, Bounds.Bottom), 
-                        new Point(Bounds.Right - Bounds.Height, Bounds.Bottom), 
-                        new Point(Bounds.Right, Bounds.Top), 
-                    }, true));
-                break;
-            case 1:
-                dc.PushGeometryClip(new PolylineGeometry(
-                    new List<Point>()
-                    {
-                        new Point(Bounds.Right, Bounds.Top), 
-                        new Point(Bounds.Left, Bounds.Top + Bounds.Width), 
-                        new Point(Bounds.Left, Bounds.Bottom - Bounds.Width), 
-                        new Point(Bounds.Right, Bounds.Bottom), 
-                    }, true));
-                break;
-            case 2:
-                dc.PushGeometryClip(new PolylineGeometry(
-                    new List<Point>()
-                    {
-                        new Point(Bounds.Left, Bounds.Bottom), 
-                        new Point(Bounds.Left + Bounds.Height, Bounds.Top), 
-                        new Point(Bounds.Right - Bounds.Height, Bounds.Top), 
-                        new Point(Bounds.Right, Bounds.Bottom), 
-                    }, true));
-                break;
-            case 3:
-                dc.PushGeometryClip(new PolylineGeometry(
-                    new List<Point>()
-                    {
-                        new Point(Bounds.Left, Bounds.Top), 
-                        new Point(Bounds.Right, Bounds.Top + Bounds.Width), 
-                        new Point(Bounds.Right, Bounds.Bottom - Bounds.Width), 
-                        new Point(Bounds.Left, Bounds.Bottom), 
-                    }, true));
-                break;
-        }
-
-
-        var rulerLength = RulerLength;
-        var rulerStart = RulerStart;
-        var zero = Zero;
-
-        //var pixelsPerDip = 96 / 185;
+        dc.PushGeometryClip(new PolylineGeometry(o.ClipOutline(), true));
 
         //   neg     0 actual ruler    L    outside positive
         // |---------|-----------------|----------|
-        // r0        r1                r2         r3
 
-        const double r0 = 0.0;
-        var r1 = zero;
-        var r2 = (zero + rulerLength);
-        var r3 = o.Length;
+        var geometry = new RulerGeometry(o.Length, RulerStart, RulerLength, Zero, o.Ratio);
 
-        var v100 = new Vector(0, 20); // size of 10cm graduations
-        var v050 = new Vector(0, 15); // size of 5cm graduations
-        var v010 = new Vector(0, 10); // size of 1cm graduations
-        var v005 = new Vector(0, 5);  // size of 5mm graduations
-        var v001 = new Vector(0, 2.5); // size of 1mm graduations
+        if (geometry.OutsideBefore is { } before)
+            dc.DrawRectangle(backgroundOut, null, o.Transform(before.Start, before.End));
 
-        var sizeT100 = 5.0 * o.Ratio;
-        var sizeT050 = 4.0 * o.Ratio;
-        var sizeT010 = 3.0 * o.Ratio;
+        if (geometry.OutsideAfter is { } after)
+            dc.DrawRectangle(backgroundOut, null, o.Transform(after.Start, after.End));
 
-        //draw outside background negative part
-        if (r0 < r3 && r1 > r0)
-            dc.DrawRectangle(backgroundOut, null,
-                o.Transform(r0, Math.Min(r1, r3)));
+        if (geometry.Inside is { } inside)
+            dc.DrawRectangle(background, null, o.Transform(inside.Start, inside.End));
 
-        //draw outside background positive part
-        if (r2 < r3)
-            dc.DrawRectangle(backgroundOut, null,
-                o.Transform(Math.Max(r2, r0), r3));
-
-        // draw inside background
-        if (r1 < r3 && r2 > r0)
-            dc.DrawRectangle(background, null,
-                o.Transform(Math.Max(r1, r0), Math.Min(r2, r3)));
-
-        var mm = (int)rulerStart - 10;
-
-        var pos = (zero + mm);
-
-        while (pos < o.Length)
-        {
-            var pen = mm < 0 || mm > rulerLength ? _penOut : _penIn;
-
-            var p0 = new Point(pos, r0);
-
-            if (mm % 5 == 0)
-            {
-                if (mm % 10 == 0)
-                {
-                    if (mm % 50 == 0)
-                    {
-                        if (mm % 100 == 0)
-                        {
-
-                            var t = mm / 100;
-                            var txt = new FormattedText(t.ToString(), CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                            new Typeface("Segoe UI"), sizeT100, pen.Brush/*, pixelsPerDip*/);
-
-                            dc.DrawText(txt, o.TextTransform(p0 + v100, sizeT100, txt.Width));
-                            dc.DrawLine(pen, o.Transform(p0), o.Transform(p0 + v100));
-
-                        }
-                        else
-                        {
-                            var txt = new FormattedText("5", CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
-                                new Typeface("Segoe UI"), sizeT050, _penIn.Brush/*, pixelsPerDip*/);
-
-                            dc.DrawText(txt, o.TextTransform(p0 + v050, sizeT050, txt.Width));
-                            dc.DrawLine(pen, o.Transform(p0), o.Transform(p0 + v050));
-                        }
-                    }
-                    else
-                    {
-                        var t = mm % 100 / 10;
-                        var txt = new FormattedText(
-                            t.ToString(),
-                            CultureInfo.CurrentCulture,
-                            FlowDirection.LeftToRight,
-                            new Typeface("Segoe UI"),
-                            sizeT010,
-                            pen.Brush/*, pixelsPerDip*/);
-
-                        dc.DrawText(txt, o.TextTransform(p0 + v010, sizeT010, txt.Width));
-                        dc.DrawLine(pen, o.Transform(p0), o.Transform(p0 + v010));
-                    }
-                }
-                else
-                    dc.DrawLine(pen, o.Transform(p0), o.Transform(p0 + v005));
-            }
-            else
-                dc.DrawLine(pen, o.Transform(p0), o.Transform(p0 + v001));
-
-            mm++;
-            pos += 1.0;
-        }
+        foreach (var graduation in geometry.Graduations())
+            Draw(dc, o, graduation);
 
         base.Render(dc);
+    }
+
+    void Draw(DrawingContext dc, RulerOrientation o, RulerGraduation graduation)
+    {
+        var pen = graduation.Inside ? _penIn : _penOut;
+
+        var origin = new Point(graduation.Position, 0);
+        var tip = origin + new Vector(0, graduation.TickLength);
+
+        if (graduation.Label is { } label)
+        {
+            // A label belongs to its tick: both dim together outside the measured edge. The 5 cm
+            // label used to be the exception, drawn with the inside brush whatever its tick did,
+            // which left it glaring in the middle of a dimmed overhang.
+            var text = new FormattedText(
+                label,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI"),
+                graduation.LabelSize,
+                pen.Brush);
+
+            dc.DrawText(text, o.TextTransform(tip, graduation.LabelSize, text.Width));
+        }
+
+        dc.DrawLine(pen, o.Transform(origin), o.Transform(tip));
     }
 
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DaemonStatusTrackerTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DaemonStatusTrackerTests.cs
@@ -1,0 +1,227 @@
+using System.ComponentModel;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using LittleBigMouse.Zoning;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// Turning what the daemon says into what the UI shows. The daemon reports facts and nothing
+/// else — it deliberately knows nothing about layouts, previews or windows — so every judgement
+/// about what an event <em>means</em> is made on this side, and can be got wrong here.
+/// </summary>
+public sealed class DaemonStatusTrackerTests
+{
+    sealed class Fixture
+    {
+        /// <summary>Rescues seen, each recording whether a preview was interrupted.</summary>
+        public List<bool> Rescues { get; } = [];
+
+        public bool Previewing { get; set; }
+
+        /// <summary>Set to hold the marshalled writes instead of running them.</summary>
+        public List<Action> Held { get; } = [];
+        public bool HoldWrites { get; set; }
+
+        public DaemonStatusTracker Tracker { get; }
+
+        public Fixture()
+        {
+            Tracker = new DaemonStatusTracker(
+                run =>
+                {
+                    if (HoldWrites) Held.Add(run);
+                    else run();
+                },
+                () => Previewing,
+                was => Rescues.Add(was));
+        }
+
+        public void Raise(LittleBigMouseEvent daemonEvent, string payload = "")
+            => Tracker.Apply(new LittleBigMouseServiceEventArgs(daemonEvent, payload));
+    }
+
+    [Theory]
+    [InlineData(LittleBigMouseEvent.Running, true, false)]
+    [InlineData(LittleBigMouseEvent.Stopped, false, false)]
+    [InlineData(LittleBigMouseEvent.Dead, false, true)]
+    public void TheEngineStateEventsSetBothFlagsTogether(
+        LittleBigMouseEvent daemonEvent, bool running, bool dead)
+    {
+        var f = new Fixture();
+
+        f.Raise(daemonEvent);
+
+        Assert.Equal(running, f.Tracker.Running);
+        Assert.Equal(dead, f.Tracker.Dead);
+    }
+
+    [Fact]
+    public void ADaemonThatComesBackIsNoLongerDead()
+    {
+        // Dead is not terminal: the UI reconnects, and a Start over a stale Dead flag would be
+        // refused by every command that guards on it.
+        var f = new Fixture();
+
+        f.Raise(LittleBigMouseEvent.Dead);
+        f.Raise(LittleBigMouseEvent.Running);
+
+        Assert.True(f.Tracker.Running);
+        Assert.False(f.Tracker.Dead);
+    }
+
+    [Fact]
+    public void ALoadOutcomeIsTheOnlyFeedbackASimulationProduces()
+    {
+        // A Load without Run is never followed by Running, so this string is the whole of what
+        // the virtual-layout badge can show.
+        var f = new Fixture();
+
+        f.Raise(LittleBigMouseEvent.Loaded, "3 zones (3 main), virtual");
+
+        Assert.Equal("3 zones (3 main), virtual", f.Tracker.LayoutInfo);
+        Assert.False(f.Tracker.Running);
+    }
+
+    [Fact]
+    public void AFailedLoadAlwaysSaysSomethingEvenWithoutAPayload()
+    {
+        var f = new Fixture();
+
+        f.Raise(LittleBigMouseEvent.LoadFailed, "zone 2 overlaps zone 1");
+        Assert.Equal("zone 2 overlaps zone 1", f.Tracker.LayoutInfo);
+
+        f.Raise(LittleBigMouseEvent.LoadFailed);
+        Assert.Equal("load failed", f.Tracker.LayoutInfo);
+    }
+
+    [Fact]
+    public void ARescueThatInterruptedAPreviewSaysTheExperimentWasThrownAway()
+    {
+        var f = new Fixture { Previewing = true };
+
+        f.Raise(LittleBigMouseEvent.Rescued);
+
+        Assert.Equal(new[] { true }, f.Rescues);
+        Assert.Equal("rescued: back to the saved layout", f.Tracker.LayoutInfo);
+    }
+
+    [Fact]
+    public void ARescueOutsideAPreviewLeavesTheEngineDownWithoutPromisingAReload()
+    {
+        // What trapped the user is what they committed to: reloading would put it straight back.
+        var f = new Fixture { Previewing = false };
+
+        f.Raise(LittleBigMouseEvent.Rescued);
+
+        Assert.Equal(new[] { false }, f.Rescues);
+        Assert.Equal("rescued: engine stopped", f.Tracker.LayoutInfo);
+    }
+
+    [Theory]
+    [InlineData(LittleBigMouseEvent.Suspended)]
+    [InlineData(LittleBigMouseEvent.Resumed)]
+    [InlineData(LittleBigMouseEvent.Probed)]
+    [InlineData(LittleBigMouseEvent.ShortcutUnavailable)]
+    public void EventsThisBuildDoesNotHandleAreIgnoredRatherThanRejected(LittleBigMouseEvent unknown)
+    {
+        // These used to throw. The handler that carries them is the one that also carries
+        // Running, so faulting on a newer daemon's vocabulary loses the engine state with it.
+        var f = new Fixture();
+        f.Raise(LittleBigMouseEvent.Running);
+
+        f.Raise(unknown, "whatever");
+
+        Assert.True(f.Tracker.Running);
+        Assert.Equal("", f.Tracker.LayoutInfo);
+    }
+
+    [Theory]
+    [InlineData(LittleBigMouseEvent.SettingsChanged)]
+    [InlineData(LittleBigMouseEvent.DisplayChanged)]
+    [InlineData(LittleBigMouseEvent.DesktopChanged)]
+    [InlineData(LittleBigMouseEvent.FocusChanged)]
+    [InlineData(LittleBigMouseEvent.Paused)]
+    [InlineData(LittleBigMouseEvent.Connected)]
+    public void EventsThatAreNotAboutTheEngineStateLeaveItAlone(LittleBigMouseEvent noise)
+    {
+        var f = new Fixture();
+        f.Raise(LittleBigMouseEvent.Running);
+        f.Raise(LittleBigMouseEvent.Loaded, "3 zones");
+
+        f.Raise(noise);
+
+        Assert.True(f.Tracker.Running);
+        Assert.False(f.Tracker.Dead);
+        Assert.Equal("3 zones", f.Tracker.LayoutInfo);
+    }
+
+    [Fact]
+    public void EveryStateWriteGoesThroughTheMarshaller()
+    {
+        // Apply runs on the daemon's receive thread. A write that skipped the marshaller would
+        // reach a bound property off the UI thread, which Avalonia only punishes intermittently.
+        var f = new Fixture { HoldWrites = true };
+
+        f.Raise(LittleBigMouseEvent.Running);
+        f.Raise(LittleBigMouseEvent.Loaded, "3 zones");
+
+        Assert.False(f.Tracker.Running);
+        Assert.Equal("", f.Tracker.LayoutInfo);
+        Assert.Equal(2, f.Held.Count);
+
+        foreach (var write in f.Held) write();
+
+        Assert.True(f.Tracker.Running);
+        Assert.Equal("3 zones", f.Tracker.LayoutInfo);
+    }
+
+    [Fact]
+    public void ARescueIsDecidedOnTheUiThreadNotWhenTheEventArrives()
+    {
+        // The preview flag is UI state; reading it on the receive thread would race the very
+        // switch the rescue is about to turn off.
+        var f = new Fixture { HoldWrites = true, Previewing = false };
+
+        f.Raise(LittleBigMouseEvent.Rescued);
+        Assert.Empty(f.Rescues);
+
+        f.Previewing = true;
+        foreach (var write in f.Held) write();
+
+        Assert.Equal(new[] { true }, f.Rescues);
+    }
+
+    [Fact]
+    public void ForgettingTheLoadOutcomeDropsItWithoutTouchingTheEngineState()
+    {
+        var f = new Fixture();
+        f.Raise(LittleBigMouseEvent.Running);
+        f.Raise(LittleBigMouseEvent.Loaded, "3 zones");
+
+        f.Tracker.ForgetLayoutInfo();
+
+        Assert.Equal("", f.Tracker.LayoutInfo);
+        Assert.True(f.Tracker.Running);
+    }
+
+    [Fact]
+    public void TheThreePropertiesNotifyOnChange()
+    {
+        // The view model republishes these through ToProperty; without notifications the
+        // bindings and every command guarding on Running would freeze at their initial value.
+        var f = new Fixture();
+        f.Raise(LittleBigMouseEvent.Running);
+
+        var changed = new List<string?>();
+        ((INotifyPropertyChanged)f.Tracker).PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        // From Running, so both flags actually move — an unchanged value notifies nobody.
+        f.Raise(LittleBigMouseEvent.Dead);
+        f.Raise(LittleBigMouseEvent.Loaded, "3 zones");
+
+        Assert.Contains(nameof(DaemonStatusTracker.Dead), changed);
+        Assert.Contains(nameof(DaemonStatusTracker.Running), changed);
+        Assert.Contains(nameof(DaemonStatusTracker.LayoutInfo), changed);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RulerGeometryTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RulerGeometryTests.cs
@@ -1,0 +1,191 @@
+using System.Linq;
+using LittleBigMouse.Plugin.Layout.Avalonia.Rulers;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The arithmetic behind a ruler, checked without a window. A ruler measures one monitor edge
+/// but is drawn across a longer axis, so most of what can go wrong is about the overhang: which
+/// millimetres fall outside the edge, where the drawn ruler stops, and what happens when the
+/// zero is scrolled off-screen entirely.
+/// </summary>
+public sealed class RulerGeometryTests
+{
+    /// <summary>A 300 mm edge drawn on a 400 mm axis, starting 50 mm in — overhang on both sides.</summary>
+    static RulerGeometry Centred() => new(
+        AxisLength: 400, RulerStart: 0, RulerLength: 300, Zero: 50, Ratio: 1);
+
+    static RulerGraduation At(RulerGeometry geometry, double position) =>
+        geometry.Graduations().Single(g => g.Position == position);
+
+    [Fact]
+    public void TheThreeBandsTileTheAxisWithoutOverlap()
+    {
+        var g = Centred();
+
+        Assert.Equal(new RulerBand(0, 50), g.OutsideBefore);
+        Assert.Equal(new RulerBand(50, 350), g.Inside);
+        Assert.Equal(new RulerBand(350, 400), g.OutsideAfter);
+    }
+
+    [Fact]
+    public void ARulerStartingAtTheAxisOriginHasNothingBeforeIt()
+    {
+        var g = Centred() with { Zero = 0 };
+
+        Assert.Null(g.OutsideBefore);
+        Assert.Equal(new RulerBand(0, 300), g.Inside);
+    }
+
+    [Fact]
+    public void ARulerLongerThanTheAxisFillsItAndOverflowsNowhere()
+    {
+        var g = Centred() with { Zero = 0, RulerLength = 900 };
+
+        Assert.Null(g.OutsideBefore);
+        Assert.Null(g.OutsideAfter);
+        Assert.Equal(new RulerBand(0, 400), g.Inside);
+    }
+
+    [Fact]
+    public void ARulerScrolledEntirelyPastTheAxisHasNoInsideBand()
+    {
+        // Zero beyond the axis: everything visible is overhang.
+        var g = Centred() with { Zero = 500 };
+
+        Assert.Null(g.Inside);
+        Assert.Equal(new RulerBand(0, 400), g.OutsideBefore);
+    }
+
+    [Fact]
+    public void ARulerEndingBeforeTheAxisStartsHasNoInsideBandEither()
+    {
+        var g = Centred() with { Zero = -400, RulerLength = 300 };
+
+        Assert.Null(g.Inside);
+        Assert.Equal(new RulerBand(0, 400), g.OutsideAfter);
+    }
+
+    [Fact]
+    public void GraduationsStartACentimetreBeforeTheWindowAndStopAtTheAxis()
+    {
+        // The lead-in exists so a decimetre label whose tick has just scrolled off still
+        // reaches the edge it belongs to.
+        var g = Centred();
+        var graduations = g.Graduations().ToList();
+
+        Assert.Equal(40, graduations[0].Position);
+        Assert.True(graduations[^1].Position < 400);
+        Assert.Equal(399, graduations[^1].Position);
+    }
+
+    [Fact]
+    public void EveryMillimetreOfTheAxisGetsExactlyOneGraduation()
+    {
+        var g = Centred();
+        var positions = g.Graduations().Select(x => x.Position).ToList();
+
+        Assert.Equal(positions.Count, positions.Distinct().Count());
+        Assert.Equal(1, positions[1] - positions[0]);
+    }
+
+    [Theory]
+    [InlineData(0, RulerGraduationKind.Decimetre, 20.0, "0")]
+    [InlineData(100, RulerGraduationKind.Decimetre, 20.0, "1")]
+    [InlineData(200, RulerGraduationKind.Decimetre, 20.0, "2")]
+    [InlineData(50, RulerGraduationKind.FiveCentimetres, 15.0, "5")]
+    [InlineData(150, RulerGraduationKind.FiveCentimetres, 15.0, "5")]
+    [InlineData(10, RulerGraduationKind.Centimetre, 10.0, "1")]
+    [InlineData(130, RulerGraduationKind.Centimetre, 10.0, "3")]
+    [InlineData(5, RulerGraduationKind.FiveMillimetres, 5.0, null)]
+    [InlineData(1, RulerGraduationKind.Millimetre, 2.5, null)]
+    [InlineData(7, RulerGraduationKind.Millimetre, 2.5, null)]
+    public void EachMillimetreGetsTheCoarsestGraduationItQualifiesFor(
+        int mm, RulerGraduationKind kind, double tick, string? label)
+    {
+        // 100 divides by 50, 10 and 5, so the order of the tests is the whole of the rule:
+        // a decimetre must not be drawn as a mere centimetre.
+        var g = Centred();
+
+        var graduation = At(g, 50 + mm);
+
+        Assert.Equal(kind, graduation.Kind);
+        Assert.Equal(tick, graduation.TickLength);
+        Assert.Equal(label, graduation.Label);
+    }
+
+    [Fact]
+    public void CentimetreLabelsRestartAtEveryDecimetre()
+    {
+        // They number the centimetre within its decimetre, so the ruler reads 1..9 and starts
+        // over rather than running to 29.
+        var g = Centred();
+
+        Assert.Equal("9", At(g, 50 + 90).Label);
+        Assert.Equal("1", At(g, 50 + 110).Label);
+        Assert.Equal("9", At(g, 50 + 290).Label);
+    }
+
+    [Fact]
+    public void GraduationsBeyondEitherEndOfTheMeasuredEdgeAreMarkedOutside()
+    {
+        // This is what dims the overhang. Getting it wrong makes the ruler look as though the
+        // monitor extends past where it does.
+        var g = Centred();
+
+        Assert.False(At(g, 50 - 10).Inside);
+        Assert.True(At(g, 50).Inside);
+        Assert.True(At(g, 50 + 300).Inside);
+        Assert.False(At(g, 50 + 301).Inside);
+    }
+
+    [Fact]
+    public void LabelSizesScaleWithTheDisplayRatio()
+    {
+        // The ruler is drawn in display units, so a label sized in millimetres would shrink to
+        // nothing as the layout zooms out.
+        var g = Centred() with { Ratio = 3 };
+
+        Assert.Equal(15.0, At(g, 50 + 100).LabelSize); // decimetre: 5 * 3
+        Assert.Equal(12.0, At(g, 50 + 50).LabelSize);  // five centimetres: 4 * 3
+        Assert.Equal(9.0, At(g, 50 + 10).LabelSize);   // centimetre: 3 * 3
+        Assert.Equal(0.0, At(g, 50 + 1).LabelSize);    // unlabelled
+    }
+
+    [Fact]
+    public void AWindowScrolledIntoTheRulerStartsItsGraduationsThere()
+    {
+        // RulerStart is the visible window into a ruler longer than the axis; the lead-in is
+        // relative to it, not to the ruler's zero.
+        var g = Centred() with { RulerStart = 120, Zero = 0 };
+
+        Assert.Equal(110, g.Graduations().First().Position);
+    }
+
+    [Fact]
+    public void NegativeGraduationsKeepSignedLabels()
+    {
+        // The overhang before zero is numbered too, and integer division has to carry the sign
+        // rather than fold -100 onto 1.
+        var g = Centred() with { RulerStart = -250, Zero = 300 };
+
+        Assert.Equal("-1", At(g, 300 - 100).Label);
+        Assert.Equal("-2", At(g, 300 - 200).Label);
+        Assert.Equal("-3", At(g, 300 - 30).Label);
+    }
+
+    [Fact]
+    public void TheHalfDecimetreIsSignedLikeEveryOtherNumber()
+    {
+        // It used to be a hardcoded "5", which read as +5 cm in the middle of an overhang whose
+        // every other label was negative.
+        // A wider axis than Centred()'s, so the run reaches past the zero on both sides.
+        var g = Centred() with { AxisLength = 600, RulerStart = -250, Zero = 300 };
+
+        Assert.Equal("-5", At(g, 300 - 50).Label);
+        Assert.Equal("-5", At(g, 300 - 150).Label);
+        Assert.Equal("5", At(g, 300 + 50).Label);
+        Assert.Equal("5", At(g, 300 + 150).Label);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RulerOrientationTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RulerOrientationTests.cs
@@ -1,0 +1,117 @@
+using System;
+using LittleBigMouse.Plugin.Layout.Avalonia.Rulers;
+using Xunit;
+
+// The outline is in the UI's coordinates, so it speaks Avalonia's geometry.
+using Point = global::Avalonia.Point;
+using Rect = global::Avalonia.Rect;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// A ruler is a trapezoid, not a rectangle: the side facing the monitor is inset by the ruler's
+/// own thickness at each end, so two rulers meeting at a corner mitre into each other at 45°
+/// instead of overlapping into a dark square. Which side that is depends on where the ruler sits,
+/// which is the whole of what these four orientations disagree about.
+/// </summary>
+public sealed class RulerOrientationTests
+{
+    const double Thickness = 20;
+    const double Span = 400;
+
+    /// <summary>Horizontal rulers lie above (0) or below (2) the monitor.</summary>
+    static readonly Rect Horizontal = new(0, 0, Span, Thickness);
+
+    /// <summary>Vertical rulers stand to the right (1) or the left (3) of it.</summary>
+    static readonly Rect Vertical = new(0, 0, Thickness, Span);
+
+    static IReadOnlyList<Point> Outline(int orientation)
+    {
+        var bounds = orientation is 0 or 2 ? Horizontal : Vertical;
+        return RulerOrientation.Create(Thickness, Span, bounds, orientation).ClipOutline();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void EveryOrientationOutlinesAQuadrilateral(int orientation)
+    {
+        Assert.Equal(4, Outline(orientation).Count);
+    }
+
+    [Theory]
+    // The narrow side faces the monitor: below a top ruler, left of a right-hand ruler, and so on.
+    [InlineData(0, 0, Thickness)]   // top ruler   -> narrow side is its bottom edge
+    [InlineData(2, 0, 0.0)]         // bottom ruler-> narrow side is its top edge
+    [InlineData(1, 1, 0.0)]         // right ruler -> narrow side is its left edge
+    [InlineData(3, 1, Thickness)]   // left ruler  -> narrow side is its right edge
+    public void TheSideFacingTheMonitorIsInsetByTheRulersOwnThickness(
+        int orientation, int axis, double facingCoordinate)
+    {
+        // axis 0: the narrow side is a horizontal edge, so it is the Y coordinate that pins it
+        // and the X coordinates that are inset. axis 1 is the transpose.
+        var outline = Outline(orientation);
+
+        double Along(Point p) => axis == 0 ? p.X : p.Y;
+        double Across(Point p) => axis == 0 ? p.Y : p.X;
+
+        var facing = outline.Where(p => Math.Abs(Across(p) - facingCoordinate) < double.Epsilon)
+            .Select(Along)
+            .OrderBy(v => v)
+            .ToList();
+
+        Assert.Equal(2, facing.Count);
+        Assert.Equal(Thickness, facing[0]);          // inset by one thickness at the near end
+        Assert.Equal(Span - Thickness, facing[1]);   // and one at the far end — a 45° mitre
+    }
+
+    [Theory]
+    [InlineData(0, 0, Thickness)]
+    [InlineData(2, 0, 0.0)]
+    [InlineData(1, 1, 0.0)]
+    [InlineData(3, 1, Thickness)]
+    public void TheSideAwayFromTheMonitorSpansTheWholeRuler(
+        int orientation, int axis, double facingCoordinate)
+    {
+        var outline = Outline(orientation);
+
+        double Along(Point p) => axis == 0 ? p.X : p.Y;
+        double Across(Point p) => axis == 0 ? p.Y : p.X;
+
+        var back = outline.Where(p => Math.Abs(Across(p) - facingCoordinate) >= double.Epsilon)
+            .Select(Along)
+            .OrderBy(v => v)
+            .ToList();
+
+        Assert.Equal(2, back.Count);
+        Assert.Equal(0, back[0]);
+        Assert.Equal(Span, back[1]);
+    }
+
+    [Fact]
+    public void AnOrientationOutsideTheFourQuartersIsRejected()
+    {
+        // Render dispatches on the same value; a silent fallback here would draw a ruler with
+        // the wrong transform rather than tell anyone.
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RulerOrientation.Create(Thickness, Span, Horizontal, 4));
+    }
+
+    [Theory]
+    [InlineData(0, Span, Thickness)]
+    [InlineData(2, Span, Thickness)]
+    [InlineData(1, Span, Thickness)]
+    [InlineData(3, Span, Thickness)]
+    public void TheDisplayedLengthRunsAlongTheRulerWhicheverWayItFaces(
+        int orientation, double length, double size)
+    {
+        var bounds = orientation is 0 or 2 ? Horizontal : Vertical;
+
+        var o = RulerOrientation.Create(Thickness, Span, bounds, orientation);
+
+        Assert.Equal(length, o.DisplayLength);
+        Assert.Equal(size, o.DisplaySize);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -61,6 +62,26 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
         _persistence = persistence;
 
         _monitorsService = monitorsService;
+
+        // What the daemon says about itself — see DaemonStatusTracker. Built before the commands
+        // below, whose canExecute reads Running and Dead through the helpers wired here.
+        _status = new DaemonStatusTracker(
+            run => Dispatcher.UIThread.Invoke(run),
+            () => LiveUpdate,
+            wasPreviewing =>
+            {
+                LiveUpdate = false;
+                if (wasPreviewing) _ = AbandonPreviewAsync();
+            });
+
+        _running = _status.WhenAnyValue(e => e.Running)
+            .ToProperty(this, e => e.Running, scheduler: Scheduler.Immediate);
+
+        _dead = _status.WhenAnyValue(e => e.Dead)
+            .ToProperty(this, e => e.Dead, scheduler: Scheduler.Immediate);
+
+        _daemonLayoutInfo = _status.WhenAnyValue(e => e.LayoutInfo)
+            .ToProperty(this, e => e.DaemonLayoutInfo, scheduler: Scheduler.Immediate);
 
         SaveCommand = ReactiveCommand.CreateFromTask(
             SaveAsync, 
@@ -184,99 +205,17 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
 
         this.UnsavedOn(e => e.Model);
 
-        service.DaemonEventReceived += StateChanged;
-        StateChanged(this,new LittleBigMouseServiceEventArgs(service.State,""));
+        service.DaemonEventReceived += (_, e) => _status.Apply(e);
+        _status.Apply(new LittleBigMouseServiceEventArgs(service.State, ""));
     }
 
-    void StateChanged(object? sender, LittleBigMouseServiceEventArgs e)
-    {
-        try
-        {
-            switch (e.Event)
-            {
-                case LittleBigMouseEvent.Running:
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        Dead = false;
-                        Running = true;
-                    });
-                    break;
-                case LittleBigMouseEvent.Stopped:
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        Dead = false;
-                        Running = false;
-                    });
-                    break;
-                case LittleBigMouseEvent.Dead:
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        Dead = true;
-                        Running = false;
-                    });
-                    break;
-                case LittleBigMouseEvent.Loaded:
-                    Dispatcher.UIThread.Invoke(() => DaemonLayoutInfo = e.Payload);
-                    break;
-                case LittleBigMouseEvent.LoadFailed:
-                    Dispatcher.UIThread.Invoke(() =>
-                        DaemonLayoutInfo = string.IsNullOrEmpty(e.Payload) ? "load failed" : e.Payload);
-                    break;
-                // The panic shortcut ran. Ending live preview is not cosmetic: the pump
-                // would otherwise hand the daemon back, within its next tick, the very
-                // geometry the user just escaped from.
-                // The panic shortcut ran: the daemon has freed the cursor and is coming
-                // down. That is all it can decide knowing nothing — and it deliberately
-                // knows nothing, because it must work with no UI reachable at all.
-                //
-                // What it means is ours. Previewing? Then there is an experiment to
-                // throw away: drop it, go back to the saved layout and start again.
-                // Not previewing? Then what trapped the user is what they committed to,
-                // and leaving the engine down is the right answer — no second press.
-                case LittleBigMouseEvent.Rescued:
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        var wasPreviewing = LiveUpdate;
-                        LiveUpdate = false;
-                        DaemonLayoutInfo = wasPreviewing
-                            ? "rescued: back to the saved layout"
-                            : "rescued: engine stopped";
-                        if (wasPreviewing) _ = AbandonPreviewAsync();
-                    });
-                    break;
-                case LittleBigMouseEvent.SettingsChanged:
-                case LittleBigMouseEvent.DisplayChanged:
-                case LittleBigMouseEvent.DesktopChanged:
-                case LittleBigMouseEvent.FocusChanged:
-                case LittleBigMouseEvent.Paused:
-                case LittleBigMouseEvent.Connected:
-                    break;
-                // Anything else — including events a newer daemon knows about and this
-                // build does not — is not ours to react to. This used to throw, which
-                // made every Suspended, Resumed and Probed fault the handler.
-                default:
-                    break;
-            }
-            //Dispatcher.UIThread.Invoke(new Action(() =>
-            //    Running = e.Event switch
-            //    {
-            //        LittleBigMouseEvent.Running => true,
-            //        LittleBigMouseEvent.Stopped => false,
-            //        LittleBigMouseEvent.Dead => false,
-            //        _ => Running
-            //    }
-            //));
-        }
-        catch(TaskCanceledException)
-        {
-             
-        }
-    }
+    readonly DaemonStatusTracker _status;
 
     protected override MonitorsLayout? OnModelChanging(MonitorsLayout? oldModel, MonitorsLayout? newModel)
     {
-        // The last Load outcome belongs to the previous layout generation.
-        Dispatcher.UIThread.Post(() => DaemonLayoutInfo = "");
+        // The last Load outcome belongs to the previous layout generation. Runs before the
+        // field is assigned on the very first model, where there is nothing to forget.
+        Dispatcher.UIThread.Post(() => _status?.ForgetLayoutInfo());
 
         // A rebuild (display change, refresh, virtual layout opened) goes through
         // MainService, which feeds the daemon itself: what we believe it holds no longer
@@ -423,19 +362,11 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
 
 
 
-    public bool Running
-    {
-        get => _running;
-        private set => this.RaiseAndSetIfChanged(ref _running,value);
-    }
-    bool _running;
+    public bool Running => _running.Value;
+    readonly ObservableAsPropertyHelper<bool> _running;
 
-    public bool Dead
-    {
-        get => _dead;
-        private set => this.RaiseAndSetIfChanged(ref _dead,value);
-    }
-    bool _dead;
+    public bool Dead => _dead.Value;
+    readonly ObservableAsPropertyHelper<bool> _dead;
 
     /// <summary>
     /// How the apply button delivers: on click, or continuously. While it is on, every
@@ -469,12 +400,8 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     /// message). This is the only feedback a Load-without-Run produces — the virtual
     /// layout badge displays it as the simulation status.
     /// </summary>
-    public string DaemonLayoutInfo
-    {
-        get => _daemonLayoutInfo;
-        private set => this.RaiseAndSetIfChanged(ref _daemonLayoutInfo, value);
-    }
-    string _daemonLayoutInfo = "";
+    public string DaemonLayoutInfo => _daemonLayoutInfo.Value;
+    readonly ObservableAsPropertyHelper<string> _daemonLayoutInfo;
 
     public bool IsVirtualLayout => _isVirtualLayout.Value;
     readonly ObservableAsPropertyHelper<bool> _isVirtualLayout;

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/DaemonStatusTracker.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/DaemonStatusTracker.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Threading.Tasks;
+using LittleBigMouse.Zoning;
+using ReactiveUI;
+
+namespace LittleBigMouse.Ui.Avalonia.Remote;
+
+/// <summary>
+/// What the daemon says about itself, reduced to the three things the UI binds to: whether the
+/// engine is hooked (<see cref="Running"/>), whether it is gone altogether (<see cref="Dead"/>),
+/// and what it made of the last layout it was handed (<see cref="LayoutInfo"/>).
+/// <para>
+/// This is a translation, not a policy. It owns no command, no layout and no persistence: it turns
+/// a <see cref="LittleBigMouseEvent"/> into state, and that is all. The one event carrying a
+/// decision — <see cref="LittleBigMouseEvent.Rescued"/> — is handed straight back out through
+/// <c>onRescued</c>, because what a rescue *means* depends on whether the user was previewing,
+/// which is the view model's business.
+/// </para>
+/// <para>
+/// Events that this build does not know about are ignored rather than rejected: a newer daemon
+/// sending Suspended, Resumed or Probed must not fault the handler that also carries Running.
+/// </para>
+/// </summary>
+/// <param name="onUiThread">
+/// Runs a state write on the UI thread. <see cref="Apply"/> is called from the daemon's receive
+/// thread, so every write to the properties below goes through here; the rest of this class is
+/// only ever touched from the UI thread and does not marshal.
+/// </param>
+/// <param name="previewing">Whether a live preview is currently running — read only on a rescue.</param>
+/// <param name="onRescued">
+/// The panic shortcut ran. The daemon has freed the cursor and is coming down; that is all it can
+/// decide knowing nothing, and it deliberately knows nothing, because it must work with no UI
+/// reachable at all. The argument says whether a preview was interrupted.
+/// </param>
+public sealed class DaemonStatusTracker(
+    Action<Action> onUiThread,
+    Func<bool> previewing,
+    Action<bool> onRescued) : ReactiveObject
+{
+    /// <summary>The daemon reports Running only while its low-level mouse hook is installed.</summary>
+    public bool Running
+    {
+        get => _running;
+        private set => this.RaiseAndSetIfChanged(ref _running, value);
+    }
+    bool _running;
+
+    /// <summary>No daemon to talk to at all — distinct from one that is merely stopped.</summary>
+    public bool Dead
+    {
+        get => _dead;
+        private set => this.RaiseAndSetIfChanged(ref _dead, value);
+    }
+    bool _dead;
+
+    /// <summary>
+    /// Last Load outcome reported by the daemon ("3 zones (3 main), virtual" / a failure
+    /// message). This is the only feedback a Load-without-Run produces — the virtual
+    /// layout badge displays it as the simulation status.
+    /// </summary>
+    public string LayoutInfo
+    {
+        get => _layoutInfo;
+        private set => this.RaiseAndSetIfChanged(ref _layoutInfo, value);
+    }
+    string _layoutInfo = "";
+
+    /// <summary>
+    /// Drop the last Load outcome: it belongs to the layout generation that just went away.
+    /// Called from the UI thread, unlike <see cref="Apply"/>.
+    /// </summary>
+    public void ForgetLayoutInfo() => LayoutInfo = "";
+
+    /// <summary>
+    /// Fold one daemon event into the state above. Safe to call from the receive thread.
+    /// </summary>
+    public void Apply(LittleBigMouseServiceEventArgs e)
+    {
+        try
+        {
+            switch (e.Event)
+            {
+                case LittleBigMouseEvent.Running:
+                    onUiThread(() =>
+                    {
+                        Dead = false;
+                        Running = true;
+                    });
+                    break;
+
+                case LittleBigMouseEvent.Stopped:
+                    onUiThread(() =>
+                    {
+                        Dead = false;
+                        Running = false;
+                    });
+                    break;
+
+                case LittleBigMouseEvent.Dead:
+                    onUiThread(() =>
+                    {
+                        Dead = true;
+                        Running = false;
+                    });
+                    break;
+
+                case LittleBigMouseEvent.Loaded:
+                    onUiThread(() => LayoutInfo = e.Payload);
+                    break;
+
+                case LittleBigMouseEvent.LoadFailed:
+                    onUiThread(() =>
+                        LayoutInfo = string.IsNullOrEmpty(e.Payload) ? "load failed" : e.Payload);
+                    break;
+
+                // Previewing? Then there is an experiment to throw away: drop it, go back to the
+                // saved layout and start again. Not previewing? Then what trapped the user is what
+                // they committed to, and leaving the engine down is the right answer — no second
+                // press. Either way the preview must end here, or the pump would hand the daemon
+                // back, within its next tick, the very geometry the user just escaped from.
+                case LittleBigMouseEvent.Rescued:
+                    onUiThread(() =>
+                    {
+                        var wasPreviewing = previewing();
+                        LayoutInfo = wasPreviewing
+                            ? "rescued: back to the saved layout"
+                            : "rescued: engine stopped";
+                        onRescued(wasPreviewing);
+                    });
+                    break;
+
+                case LittleBigMouseEvent.SettingsChanged:
+                case LittleBigMouseEvent.DisplayChanged:
+                case LittleBigMouseEvent.DesktopChanged:
+                case LittleBigMouseEvent.FocusChanged:
+                case LittleBigMouseEvent.Paused:
+                case LittleBigMouseEvent.Connected:
+                    break;
+
+                // Anything else — including events a newer daemon knows about and this
+                // build does not — is not ours to react to. This used to throw, which
+                // made every Suspended, Resumed and Probed fault the handler.
+                default:
+                    break;
+            }
+        }
+        catch (TaskCanceledException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
A targeted review-and-refactor pass over three files, one extraction each, plus two rendering fixes found by running the app.

Each extraction pulls out a responsibility that was tangled into a larger class, and each is chosen so the result is testable without the machinery that used to be required. All three follow the convention already in the repo — sealed classes with injected delegates, as in `LiveLayoutUpdater`, `EngineController` and `BorderSectionGeometry`.

| File | Extraction | Lines | Tests |
|---|---|---|---|
| `PhysicalMonitor.cs` | `MonitorBorderPolicy` | 395 → 331 | +14 |
| `LocationControlViewModel.cs` | `DaemonStatusTracker` | 499 → 426 | +22 |
| `RulerViewTop.cs` | `RulerGeometry` | 461 → 391 | +40 |

Each commit stands on its own and explains its own reasoning; the three do not depend on each other.

## What actually got decoupled

Not file-splitting. In each case a dependency disappears:

- `PhysicalMonitor` no longer reads `Layout.Options.BorderValues` nor subscribes to `ILayoutOptions.PropertyChanged`. The geometry chain consumes a size stream and never asks which mode produced it.
- `LittleBigMouseEvent` no longer appears in `LocationControlViewModel` at all, and its `Dispatcher.UIThread` references drop from 7 to 2.
- `RulerViewTop` no longer dispatches on `Orientation` — that switch moved into the hierarchy that already existed for it, so orientation is handled in one place instead of two. `Render` goes from 166 lines to 35.

Public API and observable behaviour are preserved throughout, except for the two fixes below.

## Two deliberate behaviour changes

Both on the 5 cm graduation, both visible in the running app:

- Its label was drawn with the inside brush whatever its tick did, so it stayed bright white in the middle of a dimmed overhang.
- Its text was hardcoded `"5"`, so it read as +5 cm where every neighbouring label was negative. Its semantics are the centimetre within its decimetre — the same expression the centimetre branch already used — which carries the sign. It now reads `-5` before zero.

The second was mine to catch and I missed it: I transcribed the constant from the original and my own comment ("Always 5") entrenched the error. The test that would have caught it now exists.

## How this was checked

- **507 tests pass** (296 UI, 211 core, 16 skipped Windows-only registry tests), up from 431 before. No existing test was modified.
- **Mutation testing** on every extracted rule — 8 mutations, each caught by the intended test and no other. Reverting the mirror guard, the `Replay(1)`, the coarsest-first ordering, the `Inside` boundary, the load-failed fallback, the rescue's preview read, the mitre inset, and the hardcoded label each turn exactly the expected test red.
- **Run in the app** on Linux/KWin. The window renders three monitors with correct geometry and wallpapers; the rulers were enabled and captured. The 45° mitre is confirmed by pixel measurement rather than by eye, since the clip is invisible against a black background: at the ruler's end, content is confined to `y <= x`, cut exactly on the diagonal. Both label fixes are confirmed the same way — near-white pixels across the ruler go from 331 to 0.

## What is not established

- The rulers' `Inside` band never appears, because the monitor's zero falls outside the drawn axis. The extracted band arithmetic is identical to the original term for term, and the observed inputs produce `null` under either version — but that equivalence is a derivation, not a comparison against a pre-refactor build. The maintainer has confirmed the zero behaviour is expected.
- `RulerGraduationKind` now has no production consumer; only the tests read it. Kept because it is the primary fact from which tick length and label follow, and it makes the assertions readable. Easy to drop.

## Noticed in passing, not addressed

Two follow-ups, deliberately left out of this branch:

- `EngineController.StartFromUserAsync`/`StopFromUserAsync` (tray) duplicate `LocationControlViewModel.StartAsync`/`StopAsync` (main window) with subtle differences that may be intentional.
- On Linux, exiting the UI leaves an orphan `lbm-hook` with a *new* PID — four times out of four. It releases its input devices, so nothing is left captive, but it must be killed by hand. `Stop` and `Quit` on its socket had no effect either; my framing may simply have been wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
