### PR TITLE
Make the two user Start/Stop paths one path

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/EngineControllerTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/EngineControllerTests.cs
@@ -24,9 +24,13 @@ public sealed class EngineControllerTests
         public MonitorsLayout Layout { get; }
         public EngineController Engine { get; }
 
-        public Fixture(bool enabled = true, bool withLayout = true, ResumeWatchdogTimings? timings = null)
+        public Fixture(
+            bool enabled = true,
+            bool withLayout = true,
+            ResumeWatchdogTimings? timings = null,
+            LayoutSource source = LayoutSource.System)
         {
-            Layout = MainServiceFakes.NewLayout(new LbmOptions(), enabled);
+            Layout = MainServiceFakes.NewLayout(new LbmOptions(), enabled, source);
             var layout = withLayout ? Layout : null;
             Engine = new EngineController(Daemon, Persistence, () => layout, timings ?? Fast);
         }
@@ -43,6 +47,57 @@ public sealed class EngineControllerTests
 
         Assert.True(f.Layout.Options.Enabled);
         Assert.Equal(true, f.Persistence.LastEnabledWritten);
+        Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
+
+        // ...and nothing more: the tray has no editor behind it, so an unsaved geometry is
+        // handed to the engine without being adopted. Only the apply button keeps it.
+        Assert.Equal(0, f.Persistence.LayoutWrites);
+    }
+
+    [Fact]
+    public async Task AStartFromTheEditorKeepsTheGeometryItStarts()
+    {
+        // "Apply and start": the window's button comes from an editor, so the layout being
+        // started is also the layout being kept. A full save writes Enabled too — one write,
+        // not two.
+        var f = new Fixture(enabled: false);
+        f.Layout.Saved = false;
+
+        await f.Engine.StartFromUserAsync(keepLayout: true);
+
+        Assert.True(f.Layout.Options.Enabled);
+        Assert.Equal(1, f.Persistence.LayoutWrites);
+        Assert.Equal(0, f.Persistence.EnabledWrites);
+        Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task AStartFromTheEditorWithNothingToKeepWritesOnlyEnabled()
+    {
+        var f = new Fixture(enabled: false);
+        f.Layout.Saved = true;
+
+        await f.Engine.StartFromUserAsync(keepLayout: true);
+
+        Assert.Equal(0, f.Persistence.LayoutWrites);
+        Assert.Equal(true, f.Persistence.LastEnabledWritten);
+        Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
+    }
+
+    [Fact]
+    public async Task StartingAForeignLayoutSimulatesItWithoutAdoptingIt()
+    {
+        // A virtual layout is sent for validation — the client turns that into a Load without
+        // a Run — but nothing about it is adopted: Enabled stays false, so no recovery path
+        // can later mistake a foreign geometry for something the user asked to run, and
+        // nothing is written (the store would refuse it anyway, loudly).
+        var f = new Fixture(enabled: false, source: LayoutSource.VirtualImport);
+
+        await f.Engine.StartFromUserAsync(keepLayout: true);
+
+        Assert.False(f.Layout.Options.Enabled);
+        Assert.Equal(0, f.Persistence.EnabledWrites);
+        Assert.Equal(0, f.Persistence.LayoutWrites);
         Assert.Equal(new[] { "Start" }, f.Daemon.Commands);
     }
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceFakes.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceFakes.cs
@@ -23,9 +23,10 @@ static class MainServiceFakes
     /// A layout that is real — <c>ComputeZones</c> walks it for every Start — but minimal: one
     /// monitor, one source, attached.
     /// </summary>
-    public static MonitorsLayout NewLayout(ILayoutOptions options, bool enabled = true)
+    public static MonitorsLayout NewLayout(
+        ILayoutOptions options, bool enabled = true, LayoutSource source = LayoutSource.System)
     {
-        var layout = new MonitorsLayout(options) { Id = "TESTMON1", Source = LayoutSource.System };
+        var layout = new MonitorsLayout(options) { Id = "TESTMON1", Source = source };
         layout.Options.Enabled = enabled;
 
         var model = new PhysicalMonitorModel("TST1234");
@@ -109,9 +110,16 @@ sealed class FakePersistence : ILayoutPersistence
     public bool? LastEnabledWritten { get; private set; }
     public int LiveOptionWrites { get; private set; }
 
+    /// <summary>Full layout saves — the geometry, not just the engine's on/off.</summary>
+    public int LayoutWrites { get; private set; }
+
     public void Load(MonitorsLayout layout) { }
 
-    public bool Save(MonitorsLayout layout) => true;
+    public bool Save(MonitorsLayout layout)
+    {
+        LayoutWrites++;
+        return true;
+    }
 
     public bool SaveEnabled(IMonitorsLayout layout)
     {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceLifecycleTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/MainServiceLifecycleTests.cs
@@ -62,7 +62,8 @@ public sealed class MainServiceLifecycleTests
                 layoutPersistence: Persistence,
                 processesCollector: new ProcessesCollector(),
                 updaterLocator: () => throw new NotSupportedException(),
-                options: Options);
+                options: Options,
+                engine: new EngineController(Daemon, Persistence, () => Service?.MonitorsLayout));
         }
     }
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -52,14 +52,16 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     readonly ISystemMonitorsService _monitorsService;
     readonly IMainService _mainService;
     readonly ILayoutPersistence _persistence;
+    readonly EngineController _engine;
 
     readonly ILittleBigMouseClientService _service;
 
-    public LocationControlViewModel(ILittleBigMouseClientService service,IMainService main, ISystemMonitorsService monitorsService, ILayoutPersistence persistence)
+    public LocationControlViewModel(ILittleBigMouseClientService service,IMainService main, ISystemMonitorsService monitorsService, ILayoutPersistence persistence, EngineController engine)
     {
         _service = service;
         _mainService = main;
         _persistence = persistence;
+        _engine = engine;
 
         _monitorsService = monitorsService;
 
@@ -290,41 +292,23 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     public ReactiveCommand<Unit, Unit> StartCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
 
-    async Task StartAsync()
-    {
-        if(Model == null) return;
-
-        // Virtual layout: "simulate" — hand the zones to the daemon for validation
-        // (the client service sends Load without Run). Nothing is persisted, and
-        // Enabled stays false so a layout rebuild can never auto-engage a foreign
-        // geometry.
-        if (Model.IsVirtual)
-        {
-            await _service.StartAsync(Model.ComputeZones());
-            return;
-        }
-
-        Model.Options.Enabled = true;
-
-        if (!Model.Saved)
-            await SaveAsync();
-        else
-            await SaveEnabledAsync();
-
-        await _service.StartAsync(_mainService.MonitorsLayout.ComputeZones());
-    }
+    /// <summary>
+    /// "Apply and start" — the same gesture as the tray's Start, so it is the same code:
+    /// <see cref="EngineController"/> owns what starting means (the virtual-layout
+    /// simulation, recording Enabled, handing the zones over). What the button adds is
+    /// <c>keepLayout</c>: this one comes from an editor, so the geometry on screen is kept
+    /// too.
+    /// </summary>
+    Task StartAsync() => _engine.StartFromUserAsync(keepLayout: true);
 
     async Task StopAsync()
     {
-        if(Model == null) return;
-
         // Asking for the engine to stop outranks previewing into it — otherwise the
-        // next tick would hook it straight back up.
+        // next tick would hook it straight back up. The rest of stopping is the tray's
+        // Stop, unchanged.
         LiveUpdate = false;
 
-        Model.Options.Enabled = false;
-        await Task.Run(() => _persistence.SaveEnabled(Model));
-        await _service.StopAsync();
+        await _engine.StopFromUserAsync();
     }
 
     Task SaveAsync() =>
@@ -332,12 +316,6 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
         {
             if (!(Model?.Saved??true))
                 _persistence.Save(Model);
-        });
-
-    Task SaveEnabledAsync() =>
-        Task.Run(() =>
-        {
-            if (Model != null) _persistence.SaveEnabled(Model);
         });
 
     /// <summary>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/EngineController.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/EngineController.cs
@@ -89,30 +89,68 @@ public sealed class EngineController(
     public Task StartIfEnabledAsync() => Enabled ? StartAsync() : Task.CompletedTask;
 
     /// <summary>
-    /// The tray's Start. Persists Enabled=true first: the recovery guards all test
+    /// The user's Start — the tray entry and the window's apply button are the same gesture,
+    /// and this is it. Persists Enabled=true first: the recovery guards all test
     /// <c>Options.Enabled</c>, so a start that doesn't record itself is one they will keep
     /// undoing.
     /// </summary>
-    public async Task StartFromUserAsync()
+    /// <param name="keepLayout">
+    /// What the window's button adds over the tray's: "Apply and start" also keeps the geometry
+    /// being edited, not merely the fact that the engine was asked for. The tray has no editor
+    /// behind it — it hands over whatever the layout currently is and writes nothing else.
+    /// </param>
+    public async Task StartFromUserAsync(bool keepLayout = false)
     {
         if (currentLayout() is not { } layout) return;
 
+        // A foreign layout is simulated, never adopted: the client sends Load without Run, so
+        // the daemon validates the zones and reports on them with the input hook left down.
+        // Enabled stays false — VirtualLayoutFactory sets it that way on purpose — so that no
+        // recovery path (a rebuild, a re-hook, the resume watchdog) can mistake a foreign
+        // geometry for something the user asked to run. Nothing is persisted either; the store
+        // refuses a virtual layout anyway.
+        if (layout.IsVirtual)
+        {
+            await StartAsync();
+            return;
+        }
+
         layout.Options.Enabled = true;
-        persistence.SaveEnabled(layout);
+        await PersistStartAsync(layout, keepLayout);
         await StartAsync();
     }
 
-    /// <summary>The tray's Stop, symmetric to <see cref="StartFromUserAsync"/>.</summary>
+    /// <summary>
+    /// The user's Stop, symmetric to <see cref="StartFromUserAsync"/> — and with no virtual
+    /// branch, on purpose: Enabled=false is the right value for a foreign layout anyway, and
+    /// the store's own guard is what turns the write into a no-op. That guard exists for this
+    /// exact call.
+    /// </summary>
     public async Task StopFromUserAsync()
     {
         if (currentLayout() is { } layout)
         {
             layout.Options.Enabled = false;
-            persistence.SaveEnabled(layout);
+            await Task.Run(() => persistence.SaveEnabled(layout));
         }
 
         await client.StopAsync();
     }
+
+    /// <summary>
+    /// Write the start down. Off the calling thread: both user Starts are clicks, and this
+    /// reaches the store (registry, JSON file) and the autostart scheduling behind it.
+    /// </summary>
+    Task PersistStartAsync(IMonitorsLayout layout, bool keepLayout) =>
+        Task.Run(() =>
+        {
+            // A full save writes Enabled too, so it stands in for the narrow one — but only an
+            // edited layout is worth it, and only a MonitorsLayout can be saved whole at all.
+            if (keepLayout && layout is MonitorsLayout { Saved: false } edited)
+                persistence.Save(edited);
+            else
+                persistence.SaveEnabled(layout);
+        });
 
     /// <summary>
     /// Re-hook if the engine should be running but is not — WITHOUT rebuilding the layout.

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -46,14 +46,19 @@ namespace LittleBigMouse.Ui.Avalonia.Main;
 /// the platform report, and decides what those reports <em>mean</em> — but it performs none of
 /// it itself.
 /// <para>
-/// Five collaborators do the performing, and this class <em>owns</em> them rather than
-/// resolving them: <see cref="DisplayChangeCoordinator"/> decides when a display change
-/// deserves a rebuild, <see cref="EngineController"/> decides whether the mouse engine should
-/// be hooked, <see cref="MainWindowManager"/> and <see cref="TrayIconController"/> put that
-/// state in front of the user, and <see cref="WallpaperRefresher"/> keeps the drawn desktop
-/// current. They are constructed here, wired to each other here, and released here, because
-/// the wiring — a display change may rebuild, or may only re-hook; a resume must do both, in
-/// that order — is the decision this class exists to make.
+/// Five collaborators do the performing, and this class <em>owns</em> four of them rather
+/// than resolving them: <see cref="DisplayChangeCoordinator"/> decides when a display change
+/// deserves a rebuild, <see cref="MainWindowManager"/> and <see cref="TrayIconController"/>
+/// put that state in front of the user, and <see cref="WallpaperRefresher"/> keeps the drawn
+/// desktop current. They are constructed here, wired to each other here, and released here,
+/// because the wiring — a display change may rebuild, or may only re-hook; a resume must do
+/// both, in that order — is the decision this class exists to make.
+/// </para>
+/// <para>
+/// The fifth, <see cref="EngineController"/>, is the exception: it decides whether the mouse
+/// engine should be hooked, and the window's Start/Stop buttons ask that same question as the
+/// tray's menu entries. It is injected rather than built here so that both sides go through
+/// one instance — two would be two answers.
 /// </para>
 /// </summary>
 public class MainService : ReactiveModel, IMainService
@@ -86,7 +91,8 @@ public class MainService : ReactiveModel, IMainService
         ILayoutPersistence layoutPersistence,
         IProcessesCollector processesCollector,
         Func<ApplicationUpdaterViewModel> updaterLocator,
-        ILayoutOptions options)
+        ILayoutOptions options,
+        EngineController engine)
     {
         _layoutFactory = layoutFactory;
         _layoutPersistence = layoutPersistence;
@@ -94,8 +100,7 @@ public class MainService : ReactiveModel, IMainService
         _processesCollector = processesCollector;
         _updaterLocator = updaterLocator;
 
-        _engine = new EngineController(
-            littleBigMouseClientService, layoutPersistence, () => MonitorsLayout);
+        _engine = engine;
 
         _displayChanges = new DisplayChangeCoordinator(
             layoutFactory.DisplaySignature,
@@ -250,7 +255,9 @@ public class MainService : ReactiveModel, IMainService
                 ? () => _updaterLocator().CheckUpdateAsync(true)
                 : null,
             OpenAsync: ShowControlAsync,
-            StartAsync: _engine.StartFromUserAsync,
+            // The tray starts the layout as it stands; keeping the geometry is the window
+            // apply button's business, and there is no editor behind a menu entry.
+            StartAsync: () => _engine.StartFromUserAsync(keepLayout: false),
             StopAsync: _engine.StopFromUserAsync,
             RefreshAsync: _displayChanges.RefreshAsync,
             QuitAsync: QuitAsync));

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
@@ -164,6 +164,16 @@ internal class Program
 
             services.AddSingleton<IMainService, MainService>();
 
+            // Shared, not owned by MainService: the window's Start/Stop buttons and the tray's
+            // menu entries are the same gesture, so they have to reach the same controller —
+            // two instances would be two answers to "should the engine be hooked". The layout
+            // accessor resolves IMainService lazily, inside the lambda, so that MainService can
+            // still take the controller in its own constructor.
+            services.AddSingleton(sp => new EngineController(
+                sp.GetRequiredService<ILittleBigMouseClientService>(),
+                sp.GetRequiredService<ILayoutPersistence>(),
+                () => sp.GetRequiredService<IMainService>().MonitorsLayout));
+
             // The MVVM locator: registered services come from the container, anything
             // else (views, view-models, MonitorsLayout…) is built by ActivatorUtilities.
             // Instances created that way are transient and NOT tracked by the root


### PR DESCRIPTION
"The user asked for the engine" was implemented twice: `EngineController.StartFromUserAsync`/`StopFromUserAsync` behind the tray menu, and two private methods in `LocationControlViewModel` behind the window's buttons. Almost the same thing — `Options.Enabled`, `SaveEnabled`, then the client — with four divergences. Each was checked before being flattened.

`EngineController` now owns the gesture and the view-model asks it.

| Divergence | Verdict |
|---|---|
| View-model's `IsVirtual` branch | Deliberate — and missing from the tray, which is a bug (below). Moved into the controller. |
| Full `SaveAsync()` when the layout is dirty | Deliberate: that is what "Apply and start" means. Became the `keepLayout` parameter. |
| `LiveUpdate = false` before Stop | Deliberate, and purely the view-model's. No extension point needed: cut the preview, then delegate. |
| `Task.Run` around the store write | Accidental. Both Starts are clicks and there is a registry/JSON write plus autostart scheduling behind `SaveEnabled`; the shared path now does it off the calling thread. |

### One deliberate behaviour change

The virtual-layout branch existed only in the view-model, so **Start from the tray over a foreign layout set `Options.Enabled = true` on it**. That contradicts `VirtualLayoutFactory`, which sets `Enabled = false` precisely so *"a virtual layout must never engage the engine on its own"*, and it left the flag every recovery path reads pointing at a foreign geometry: `EnsureHookedAsync` and the resume watchdog would re-send it, the watchdog burning its six restarts because a layout the daemon refuses to hook never reports `Running`. The store was never polluted — `SaveEnabled` refuses virtual layouts — so nothing was written wrong; it was in-memory state pointing the wrong way. The tray now simulates like the window does.

Two smaller ones, both on the window path: a Stop with a null model used to do nothing at all (not even cut the preview) and now cuts it and sends the Stop; and the virtual Start computes its zones from the same layout the rest of the method reads, where the old code took `Enabled`/save from `Model` and the zones from `_mainService.MonitorsLayout`.

### Wiring

`EngineController` stops being `MainService`'s private collaborator and comes from the container, because two instances would be two answers to "should the engine be hooked". The layout accessor resolves `IMainService` lazily inside the lambda so `MainService` can still take the controller in its constructor.

### Verification

299 tests green, four of them new (`keepLayout` both ways, the tray writing only `Enabled`, and the foreign layout being simulated without being adopted).

Run on Linux/KDE end to end: `Loaded → Running` on Apply, `Stopped` on Stop, three times over. The layout files came out **byte-identical** afterwards, which is `keepLayout` correctly taking the narrow branch on a clean layout — a full save would have rewritten them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)