### PR TITLE
Stop relaunching the daemon the UI is quitting

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UiLifecycleTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Net.Sockets;
 using MsBox.Avalonia.Enums;
 using LittleBigMouse.Ui.Avalonia.Main;
 using LittleBigMouse.Ui.Avalonia.MonitorFrame;
@@ -62,6 +63,112 @@ public sealed class UiLifecycleTests
         client.Listen();
 
         await failed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ADaemonThatDisappearsAsksForARelaunch()
+    {
+        // The crash-recovery contract, and the reason ConnectionFailed exists at all.
+        // Pinned here so the shutdown fix below cannot be made to work by silencing it.
+        if (OperatingSystem.IsWindows()) return;
+
+        using var daemon = new FakeDaemon();
+        using var client = new LocalIpcClient(daemon.SocketPath);
+        var failed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var connected = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Connected += (_, _) => connected.TrySetResult();
+        client.ConnectionFailed += (_, _) => failed.TrySetResult();
+
+        client.Listen();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        daemon.Stop();
+
+        await failed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task AfterStopListeningAVanishingDaemonIsNotRelaunched()
+    {
+        // The orphan: a UI Exit sends Quit, the daemon closes the socket on its way
+        // out, and the listener read that as a daemon to bring back — spawning the
+        // `lbm-hook` that then outlived the UI. StopListening is what closes that door.
+        if (OperatingSystem.IsWindows()) return;
+
+        using var daemon = new FakeDaemon();
+        using var client = new LocalIpcClient(daemon.SocketPath);
+        var connected = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var relaunches = 0;
+        client.Connected += (_, _) => connected.TrySetResult();
+        client.ConnectionFailed += (_, _) => Interlocked.Increment(ref relaunches);
+
+        client.Listen();
+        await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        client.StopListening();
+        daemon.Stop();
+
+        // Comfortably past the listener's ~350 ms reconnect cycle.
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, Volatile.Read(ref relaunches));
+    }
+
+    /// <summary>
+    /// A Unix socket that accepts and then says nothing — enough for the client to
+    /// report Connected and send its Listen frame. <see cref="Stop"/> is the daemon
+    /// exiting: the socket file is left behind, exactly as `lbm-hook` leaves it.
+    /// </summary>
+    sealed class FakeDaemon : IDisposable
+    {
+        readonly Socket _listener;
+        readonly List<Socket> _accepted = [];
+
+        public FakeDaemon()
+        {
+            // Well under SUN_LEN (108): a long temp path fails to bind at all.
+            SocketPath = Path.Combine(Path.GetTempPath(), $"lbm-{Guid.NewGuid():N}.sock");
+            _listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            _listener.Bind(new UnixDomainSocketEndPoint(SocketPath));
+            _listener.Listen(4);
+            _ = Task.Run(AcceptAsync);
+        }
+
+        public string SocketPath { get; }
+
+        async Task AcceptAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    var accepted = await _listener.AcceptAsync();
+                    lock (_accepted) _accepted.Add(accepted);
+                }
+            }
+            catch (Exception error) when (error is SocketException or ObjectDisposedException)
+            {
+                // Stopped.
+            }
+        }
+
+        public void Stop()
+        {
+            _listener.Dispose();
+            lock (_accepted)
+            {
+                foreach (var accepted in _accepted) accepted.Dispose();
+                _accepted.Clear();
+            }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            try { File.Delete(SocketPath); } catch (IOException) { }
+        }
     }
 
     [Fact]

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -42,6 +42,11 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
 
         _client.ConnectionFailed += (sender, args) =>
         {
+            // Not after a Quit. The daemon we just asked to exit closes the socket on
+            // its way out, which is a connection failure like any other — and launching
+            // its replacement here is what left an orphan `lbm-hook` behind every UI
+            // Exit: the successor outlives the process that spawned it.
+            if (_quitting) return;
             Debug.WriteLine($"ConnectionFailed : Launch daemon");
             LaunchDaemon();
         };
@@ -145,12 +150,65 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
 
     public async Task QuitAsync(CancellationToken token = default)
     {
-        await SendAsync(token);
+        // Both before a single byte is sent: the daemon can be gone before the send
+        // even completes. `_quitting` closes the relaunch path for good (the send has
+        // its own ConnectionFailed to raise), and StopListening takes down the
+        // reconnect loop that would otherwise spend the rest of the shutdown
+        // rediscovering a daemon that is meant to be dead.
+        _quitting = true;
+        _client.StopListening();
+
+        try
+        {
+            await SendAsync(token);
+        }
+        catch (Exception error) when (error is IOException
+                                      or OperationCanceledException
+                                      or UnauthorizedAccessException)
+        {
+            // Nothing answered: there is no daemon left to ask to exit, which is the
+            // outcome Quit wanted. Never fault the shutdown over it — an unobserved
+            // throw here is what makes QuitAsync "sometimes not return".
+            Debug.WriteLine($"Quit IPC failed, continuing shutdown: {error}");
+        }
+
+        await EnsureLaunchedDaemonExitedAsync();
         await Task.Run(_displayController.RestoreAfterEngine, token);
     }
 
+    /// <summary>
+    /// The Quit command is the polite ask; this is the guarantee an Exit owes the user.
+    /// Scoped to the daemon this UI launched for the same reason as
+    /// <see cref="ForceStopCurrentSessionDaemons"/>: on Unix a standalone or autostart
+    /// `lbm-hook` is not ours to kill.
+    /// </summary>
+    async Task EnsureLaunchedDaemonExitedAsync()
+    {
+        if (_daemonProcess is not { } daemon) return;
+        try
+        {
+            using var grace = new CancellationTokenSource(QuitGrace);
+            await daemon.WaitForExitAsync(grace.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Debug.WriteLine("Daemon still alive after Quit; stopping it.");
+            TryStopProcess(daemon);
+        }
+        catch (Exception error) when (error is InvalidOperationException
+                                      or System.ComponentModel.Win32Exception)
+        {
+            Debug.WriteLine($"Could not wait on the daemon: {error.Message}");
+        }
+    }
+
+    static readonly TimeSpan QuitGrace = TimeSpan.FromSeconds(2);
+
     readonly object _daemonLaunchGate = new();
     Process? _daemonProcess;
+
+    /// <summary>Set once, on the way out: see the ConnectionFailed handler.</summary>
+    volatile bool _quitting;
 
     bool ForceStopCurrentSessionDaemons()
     {

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LocalIpcClient.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LocalIpcClient.cs
@@ -22,6 +22,12 @@ sealed class LocalIpcClient : IDisposable
     const string WindowsPipePrefix = @"\\.\pipe\";
 
     readonly CancellationTokenSource _stopping = new();
+
+    // The event listener alone, so it can be shut down while the send path stays
+    // open: a Quit is delivered through this very client, and the listener must
+    // already be gone when the daemon it kills closes the socket.
+    readonly CancellationTokenSource _listening;
+
     readonly SemaphoreSlim _sendGate = new(1, 1);
     readonly string _windowsPipeName;
     readonly string? _unixSocketPath;
@@ -32,8 +38,13 @@ sealed class LocalIpcClient : IDisposable
     // Windows, the socket path elsewhere): a launched daemon inherits the
     // variable, so a test pair runs side by side with the production pair.
     public LocalIpcClient()
+        : this(Environment.GetEnvironmentVariable("LBM_HOOK_ENDPOINT"))
     {
-        var endpoint = Environment.GetEnvironmentVariable("LBM_HOOK_ENDPOINT");
+    }
+
+    internal LocalIpcClient(string? endpoint)
+    {
+        _listening = CancellationTokenSource.CreateLinkedTokenSource(_stopping.Token);
         if (OperatingSystem.IsWindows())
         {
             _windowsPipeName = endpoint is null
@@ -45,11 +56,6 @@ sealed class LocalIpcClient : IDisposable
             _windowsPipeName = string.Empty;
             _unixSocketPath = endpoint;
         }
-    }
-
-    internal LocalIpcClient(string windowsPipeName)
-    {
-        _windowsPipeName = windowsPipeName;
     }
 
     // NamedPipeClientStream wants the bare pipe name while the daemon binds the
@@ -65,23 +71,31 @@ sealed class LocalIpcClient : IDisposable
 
     public void Listen() => _listener ??= Task.Run(ListenAsync);
 
+    /// <summary>
+    /// Give up on the daemon for good: no reconnect, and so no
+    /// <see cref="ConnectionFailed"/> from the listener. Sends keep working — the
+    /// caller still has a Quit to deliver, and it is exactly the daemon answering
+    /// it whose disappearance must stop being reported as something to recover from.
+    /// </summary>
+    public void StopListening() => _listening.Cancel();
+
     async Task ListenAsync()
     {
-        while (!_stopping.IsCancellationRequested)
+        while (!_listening.IsCancellationRequested)
         {
             try
             {
-                await using var stream = await ConnectWithRetryAsync(_stopping.Token);
+                await using var stream = await ConnectWithRetryAsync(_listening.Token);
                 Connected?.Invoke(this, EventArgs.Empty);
                 await WriteFrameAsync(stream,
-                    "<CommandMessage Command=\"Listen\" Payload=\"\"/>", _stopping.Token);
-                while (!_stopping.IsCancellationRequested)
+                    "<CommandMessage Command=\"Listen\" Payload=\"\"/>", _listening.Token);
+                while (!_listening.IsCancellationRequested)
                 {
-                    var message = await ReadFrameAsync(stream, _stopping.Token);
+                    var message = await ReadFrameAsync(stream, _listening.Token);
                     MessageReceived?.Invoke(this, message);
                 }
             }
-            catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+            catch (OperationCanceledException) when (_listening.IsCancellationRequested)
             {
                 break;
             }
@@ -93,7 +107,7 @@ sealed class LocalIpcClient : IDisposable
                 // exception here would kill the listener silently forever.
                 MessageReceived?.Invoke(this,
                     "<DaemonMessage><Event>Dead</Event></DaemonMessage>");
-                try { await Task.Delay(RetryDelay, _stopping.Token); }
+                try { await Task.Delay(RetryDelay, _listening.Token); }
                 catch (OperationCanceledException) { break; }
             }
         }


### PR DESCRIPTION
A UI Exit left an orphan `lbm-hook` behind, every time, with a PID **different** from the one it had launched — so it was not a kill that failed, it was a spawn that should never have happened.

## Why

`LaunchDaemon` has exactly one caller: the `ConnectionFailed` handler on the IPC client. That event fires on the *first* failed connect attempt, and the listener's reconnect loop is still running while the UI shuts down.

1. `QuitAsync` sends `Quit`; the daemon exits in ~50 ms.
2. The listener takes an EOF, reports `Dead`, waits 100 ms, reconnects.
3. The socket file is still there (the daemon does not unlink it on the way out) but gives `ECONNREFUSED`.
4. `ConnectionFailed` → `LaunchDaemon` → a brand new daemon.
5. `RestoreAfterEngine` shells out to `kscreen-doctor`, which leaves plenty of time for all of the above, and then the UI exits and orphans the child.

The successor inherits a parent path containing `LittleBigMouse`, so it comes up in UI mode: it waits for commands and never hooks anything. That is why the orphan held no `/dev/input/event*` — it had never grabbed one.

## What changed

- **`_quitting` gates the `ConnectionFailed` handler.** It covers the send path too, which raises the same event through its own `ConnectWithRetryAsync` when the daemon is already gone — that one used to spawn a daemon just to be able to ask it to exit.
- **`LocalIpcClient.StopListening()`** — a `CancellationTokenSource` for the listener alone, linked to the existing one. It cuts the reconnect loop while leaving the send path open, because the `Quit` still has to go out through this same client.
- **The Quit send is now tolerant of IPC failure**, like `StopAsync` already was. Nothing answering means there is no daemon left to ask, which is the outcome Quit wanted. This is also the `TODO : it should not append by sometimes the QuitAsync does not return` in `MainService`: an `OperationCanceledException` from the 5 s budget propagated out of an Exit that had nothing left to do but finish.
- **`EnsureLaunchedDaemonExitedAsync`** turns the polite ask into a guarantee: wait 2 s, then stop it. Scoped to the daemon this UI launched, for the same reason `ForceStopCurrentSessionDaemons` is — on Unix a standalone or autostart `lbm-hook` is not ours to kill.

The two `LocalIpcClient` constructors collapse into one taking the endpoint, which is what makes the client testable against a Unix socket; the Windows test keeps working, since `PipeNameFromEndpoint` passes a bare name through.

## Tests

Two tests on a fake daemon that ends the way `lbm-hook` does (close, and leave the socket file behind). One pins the crash-recovery contract, so the fix cannot be made to pass by silencing `ConnectionFailed`; the other is the orphan, **verified red before the fix and green after**. Full Linux suite: 696 passed, 0 failed. No Rust changes.

## Not verified here

The tray-Exit smoke test itself. Clicking a KWin/Wayland tray menu is out of reach from the agent, and starting the real UI would grab the mouse through evdev and move outputs through `PrepareForEngine`. The chain was verified piecewise instead: the daemon exits on a framed `Quit`, it leaves its socket file behind, and connecting to that stale file gives `ECONNREFUSED` rather than hanging. **Please run steps 1–3 of the original repro before merging.**

## Aside, since it cost an investigation

The local IPC socket is length-prefixed (4-byte LE + UTF-8), **not** line-delimited. Poking it with `printf '<CommandMessage Command="Stop"/>' | socat` makes the daemon read `<Com` as a 1.8 GB frame length, refuse it and close — `Connection reset by peer`, with nothing logged, because the command was never parsed. A correctly framed `Stop`/`Quit` has always worked; there was no daemon-side bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
