### PR TITLE
Run the application's entry point once

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/App.axaml.cs
@@ -10,8 +10,20 @@ public partial class App : Application
         AvaloniaXamlLoader.Load(this);
     }
 
-    public override void OnFrameworkInitializationCompleted()
-    {
-        Program.UIMain(this, new string[] { });
-    }
+    // No OnFrameworkInitializationCompleted override, on purpose. Program.Main runs the
+    // application through `BuildAvaloniaApp().Start(UIMain, args)`, and Start does Setup()
+    // *then* invokes the delegate — so overriding this to call Program.UIMain, as this class
+    // used to, wired the entry point up twice.
+    //
+    // The second call is invisible while the app is alive, because the first one is still
+    // parked in app.Run inside Setup(). It only lands on the way out: app.Run returns at
+    // shutdown, the override returns, Setup() returns, and Start then calls UIMain again —
+    // which rebuilds the whole application over a dead dispatcher. A second ServiceCollection,
+    // a second container, a second LittleBigMouseClientService with its own IPC listener; that
+    // listener finds no daemon (the Quit just took it down), asks for one to be launched, and
+    // the daemon it spawns outlives the process. That was the orphaned `lbm-hook` after every
+    // Exit. The second app.Run then throws "the Dispatcher shut down" and the process exits.
+    //
+    // Running UIMain from Start alone also hands it the real command line rather than the
+    // empty array this override passed.
 }


### PR DESCRIPTION
Every UI Exit left an orphan `lbm-hook` behind, with a PID **different** from the one it had launched. Not a kill that failed — a spawn that should never have happened.

## Why

`Program.Main` runs the app through `BuildAvaloniaApp().Start(UIMain, args)`, and `AppBuilder.Start` does `Setup()` and *then* invokes the delegate (confirmed in the Avalonia 12.1.1 IL: `Setup()` at IL_0001, `AppMainDelegate::Invoke` at IL_000e). `App` also overrode `OnFrameworkInitializationCompleted` to call `Program.UIMain` — so the entry point was wired up twice.

The duplicate is invisible while the app is alive: the call from `Setup()` is still parked in `app.Run`, so `Start`'s own call never gets a turn. It lands on the way out.

1. Exit shuts the dispatcher down and `app.Run` returns.
2. The override returns, and so does `Setup()`.
3. `Start` now invokes `UIMain` — a second time, over a dead dispatcher.

That second pass rebuilds the entire application: a new `ServiceCollection`, a new container, and therefore **a second `LittleBigMouseClientService` singleton with its own IPC listener**. That listener finds no daemon — the `Quit` two steps earlier took it down — raises `ConnectionFailed`, and `LaunchDaemon` spawns the successor that then outlives the process. The second `app.Run` throws "the Dispatcher shut down", it is swallowed, and the UI exits leaving the daemon orphaned and reparented to init.

It came up in UI mode (its parent path contained `LittleBigMouse`), so it sat waiting for commands and never hooked anything — which is why the orphan held no `/dev/input/event*` despite the engine having been running.

Traced through a real Exit, same PID and same thread:

```
app.Run returned
UIMain: container built, booting      ← second pass
ClientService ctor #14463294          ← second singleton
ConnectionFailed #14463294 quitting=False
LaunchDaemon                          ← the orphan
app.Run threw: Dispatcher shut down
```

## The fix

Remove the override. `UIMain` now runs exactly once, from `Start`, and gets the real command line instead of the empty array the override passed it.

## Verification

Smoke-tested on KDE/Wayland with the engine actually hooked (3 zones loaded, evdev armed): after Exit the launched daemon is gone and no `lbm-hook` remains. The same smoke test reproduced the orphan three times out of three before the change. Full Linux suite: 694 passed, 0 failed.

**No regression test.** "UIMain runs once" is a property of the Avalonia startup handshake, not something reachable from the test host. The mechanism was established by tracing `UIMain`, the container, the service instances and `LaunchDaemon` through a real Exit — two passes, two distinct service instances, the second one doing the spawning.

## Supersedes #575

#575 was built on a wrong diagnosis: it assumed the surviving listener belonged to the instance being shut down, and guarded it with a `_quitting` flag plus a `StopListening()`. The guard worked on its own terms and the orphan still appeared — which is what led to the tracing that found this. That approach is dropped entirely; nothing from it is kept here.

## Aside, since it cost an investigation

The local IPC socket is length-prefixed (4-byte LE + UTF-8), **not** line-delimited. Poking it with `printf '<CommandMessage Command="Stop"/>' | socat` makes the daemon read `<Com` as a 1.8 GB frame length, refuse it and close — `Connection reset by peer`, with nothing logged, because the command was never parsed. A correctly framed `Stop`/`Quit` has always worked; there was no daemon-side bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
