### PR TITLE
Drop DaemonPort, the last leftover of the TCP transport

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/JsonLayoutStoreTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/JsonLayoutStoreTests.cs
@@ -63,8 +63,10 @@ public class JsonLayoutStoreTests : IDisposable
         var store = new JsonLayoutStore(_dir);
         var data = store.Read("LAYOUT1", ["TST1234"]);
 
-        Assert.Equal(25196, data.GlobalOptions!.DaemonPort);
-        Assert.Equal("Normal", data.GlobalOptions.Priority);
+        // "DaemonPort" is still in the document above on purpose: the TCP transport it
+        // configured is gone, so it is now an unknown property, and a user's existing
+        // options.json must keep reading cleanly rather than throwing.
+        Assert.Equal("Normal", data.GlobalOptions!.Priority);
         Assert.True(data.GlobalOptions.ShowMonitorActionWarning);
 
         Assert.Equal(600, data.Models["TST1234"].Width);

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceGoldenTests.cs
@@ -55,7 +55,6 @@ public class LayoutPersistenceGoldenTests : IDisposable
         var (layout, monitor, _) = Load("v5.2-pre-sections");
 
         // Options that lived in the store before 5.5 arrive unchanged...
-        Assert.Equal(25196, layout.Options.DaemonPort);
         Assert.Equal("High", layout.Options.Priority);
         Assert.Equal("Idle", layout.Options.PriorityUnhooked);
         Assert.True(layout.Options.Pinned);
@@ -296,7 +295,6 @@ public class LayoutPersistenceGoldenTests : IDisposable
         var (layout, monitor, source) = Load("incomplete-empty");
 
         // "{}" everywhere is indistinguishable from a missing file: the live model wins.
-        Assert.Equal(25196, layout.Options.DaemonPort);
         Assert.Equal("Normal", layout.Options.Priority);
         Assert.Equal("Strait", layout.Options.Algorithm);
         Assert.True(layout.Options.Enabled);
@@ -390,7 +388,6 @@ public class LayoutPersistenceGoldenTests : IDisposable
         Assert.True(options.VcpControl);
         Assert.True(options.StartMinimized);
         Assert.Equal("PerMonitor", options.BorderValues);
-        Assert.Equal(25196, options.DaemonPort);
 
         foreach (var entry in ExcludedProcessDefaults.All)
         {

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/RegistryLayoutStoreTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/RegistryLayoutStoreTests.cs
@@ -340,11 +340,12 @@ public class RegistryLayoutStoreTests : IDisposable
         CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
         try
         {
-            Store.WriteGlobalOptions(new GlobalOptionsDto { DaemonPort = 25196, Pinned = true, HomeCinema = false });
+            Store.WriteGlobalOptions(new GlobalOptionsDto
+                { ExcludedDefaultsVersion = 3, Pinned = true, HomeCinema = false });
             WriteMonitor(new MonitorDto { XLocationInMm = 12.5 });
 
             using var root = Registry.CurrentUser.OpenSubKey(_root)!;
-            Assert.Equal("25196", root.GetValue("DaemonPort"));
+            Assert.Equal("3", root.GetValue("ExcludedDefaultsVersion"));
             Assert.Equal("1", root.GetValue("Pinned"));
             Assert.Equal("0", root.GetValue("HomeCinema"));
             Assert.Equal(RegistryValueKind.String, root.GetValueKind("Pinned"));

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/TestData/Persistence/v5.6-current-saved/options.json
@@ -1,5 +1,4 @@
 {
-  "DaemonPort": 25196,
   "Priority": "Realtime",
   "PriorityUnhooked": "Idle",
   "HomeCinema": false,

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/Monitors/ILayoutOptions.cs
@@ -51,7 +51,6 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
       public bool ExperimentalFeatures { get; set; } = false;
       public bool VcpControl { get; set; } = false;
       public bool ShowMonitorActionWarning { get; set; } = true;
-      public int DaemonPort { get; set; } = 25196;
 
       public bool AdjustSpeedAllowed { get; } = false;
       public ObservableCollection<string> ExcludedList { get; } = new ObservableCollection<string> { "/game/", "/another/game/" };
@@ -241,12 +240,6 @@ public interface ILayoutOptions : INotifyPropertyChanged // Change IPropertyChan
    /// detaching, or making a monitor the primary display
    /// </summary>
    bool ShowMonitorActionWarning { get; set; }
-
-   /// <summary>
-   /// Legacy persisted setting retained so older layouts still deserialize.
-   /// Local IPC does not use a TCP port.
-   /// </summary>
-   public int DaemonPort { get; set; }
 
    public bool LoopAllowed { get; }
    public ObservableCollection<string> ExcludedList { get; }

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -60,7 +60,6 @@ public class RegistryLayoutStore : ILayoutStore
 
     static GlobalOptionsDto ReadGlobalOptions(RegistryKey root, RegistryKey? layoutKey) => new()
     {
-        DaemonPort = root.TryGetInt("DaemonPort"),
         // These options historically lived in the layout key: fall back to it so old
         // configs keep their values (they reach the root key at the next save).
         Priority = root.TryGetString("Priority") ?? layoutKey?.TryGetString("Priority"),
@@ -263,7 +262,6 @@ public class RegistryLayoutStore : ILayoutStore
         using var root = OpenRoot(create: true);
         if (root == null) return;
 
-        Set(root, "DaemonPort", o.DaemonPort);
         Set(root, "Priority", o.Priority);
         Set(root, "PriorityUnhooked", o.PriorityUnhooked);
         Set(root, "HomeCinema", o.HomeCinema);

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtoMapper.cs
@@ -26,7 +26,6 @@ public static class LayoutDtoMapper
     {
         if (dto == null) return;
 
-        o.DaemonPort = dto.DaemonPort ?? o.DaemonPort;
         o.Priority = dto.Priority ?? o.Priority;
         o.PriorityUnhooked = dto.PriorityUnhooked ?? o.PriorityUnhooked;
         o.HomeCinema = dto.HomeCinema ?? o.HomeCinema;
@@ -176,7 +175,6 @@ public static class LayoutDtoMapper
     /// </summary>
     public static GlobalOptionsDto ToGlobalOptionsDto(ILayoutOptions o, int? excludedDefaultsVersion) => new()
     {
-        DaemonPort = o.DaemonPort,
         Priority = o.Priority,
         PriorityUnhooked = o.PriorityUnhooked,
         HomeCinema = o.HomeCinema,

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutDtos.cs
@@ -16,7 +16,6 @@ namespace LittleBigMouse.Plugins.Persistence;
 /// <summary>App-level options, stored once (registry root key / options.json).</summary>
 public class GlobalOptionsDto
 {
-    public int? DaemonPort { get; set; }
     public string? Priority { get; set; }
     public string? PriorityUnhooked { get; set; }
     public bool? HomeCinema { get; set; }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/LbmOptions.cs
@@ -97,15 +97,6 @@ public class LbmOptions : SavableReactiveModel, ILayoutOptions
     }
     bool _showMonitorActionWarning = true;
 
-    // Compatibility-only value for settings written by TCP-era releases.
-    // The current daemon uses authenticated local IPC and ignores this value.
-    public int DaemonPort
-    { 
-        get => _daemonPort; 
-        set => this.SetAndRaise(ref _daemonPort, value); 
-    }
-    int _daemonPort = 25196;
-
     [DataMember]
     public string Priority 
     {

--- a/docs/test-session-persistence-windows.md
+++ b/docs/test-session-persistence-windows.md
@@ -30,7 +30,7 @@ Avec le registre actuel déjà peuplé :
 - [ ] Les options layout sont restaurées : Enabled, Algorithm, MaxTravelDistance, Freelook*, LoopX/Y,
   AdjustPointer/Speed, AllowOverlaps/Discontinuity
 - [ ] Les options globales sont restaurées : Pinned, AutoUpdate, StartMinimized, StartElevated,
-  DebugTools, ShowMonitorActionWarning, BorderValues, HideTrayIcon, DaemonPort
+  DebugTools, ShowMonitorActionWarning, BorderValues, HideTrayIcon
 - [ ] **Lecture pure** : `reg export` avant/après lancement (sans sauvegarder) → diff vide, à une
   exception près : `ExcludedDefaultsVersion` peut être écrit une fois si absent (migration top-up).
   L'ancien code seedait le registre au chargement (`GetOrSet`) ; le nouveau ne doit RIEN écrire d'autre.
@@ -123,8 +123,9 @@ Simuler un vieux profil dans regedit :
 
 - [ ] Changer la topologie (débrancher/rebrancher un écran, dock) → chaque combinaison garde sa propre
   clé `Layouts\{id}` avec ses valeurs, sans contamination croisée
-- [ ] `DaemonPort` personnalisé dans le registre → toujours honoré (il n'est plus seedé au chargement,
-  mais il est maintenant écrit à la sauvegarde)
+- [ ] `DaemonPort` présent dans le registre d'un utilisateur existant → ignoré sans erreur, et la
+  valeur résiduelle est laissée en place (le transport TCP qu'elle configurait n'existe plus depuis
+  la 5.6 ; l'IPC local n'utilise pas de port)
 - [ ] Lancement en admin → `Elevated` détecté, UI cohérente
 - [ ] Exclusion process : lancer un jeu sous un chemin exclu → LBM ne traverse pas (le daemon lit
   toujours le même `Excluded.txt`, chemin inchangé)


### PR DESCRIPTION
## What

`DaemonPort` (default 25196) configured the loopback-TCP transport that v5.6.0 replaced with per-user local IPC — a named pipe on Windows, a Unix socket elsewhere. The setting survived the move: fully plumbed through persistence (interface, view model, DTO, mapper, registry read *and* write), but never consumed to open a connection.

Verified before removing:

- No `TcpClient`/`TcpListener` for the daemon in either tree. Every TCP hit in the C# side belongs to the VCP plugin (Hisense VIDAA, Samsung Tizen, Wake-on-LAN) or `SingleInstance`; the Rust daemon has no port concept at all.
- `LocalIpcClient` resolves its endpoint from `LBM_HOOK_ENDPOINT` or a fixed per-session pipe/socket name.
- No XAML binds the property, so it was never reachable from the UI — customising it meant hand-editing the registry.

## Compatibility

Existing configurations keep loading. An unknown JSON property is ignored rather than fatal (already locked by `Load_PartialDocuments_FillWhatIsThereAndKeepTheRest`), and a residual `DaemonPort` registry value is simply left in place, unread.

The pre-5.6 fixtures (`v5.2-pre-sections`, `v5.5-sections`, `v5.6-current`) keep their `DaemonPort` — they record what those versions actually wrote. Only the round-trip golden `v5.6-current-saved/options.json` loses the line, regenerated with `LBM_UPDATE_GOLDEN=1`; the diff is exactly that one line, nothing else orphaned.

The one behaviour change: a hand-customised port would no longer survive a downgrade to a TCP-era release (v5.5.x or earlier).

## Tests

Two spots needed judgement rather than plain deletion:

- **`JsonLayoutStoreTests`** keeps `"DaemonPort": 25196` in its input document on purpose. It now covers the case that actually matters — a user's existing `options.json` still reading cleanly with the property gone from the DTO.
- **`RegistryLayoutStoreTests`** used it as the *only* integer in `Values_AreStoredAsTheHistoricalInvariantStrings`, which guards against a comma-decimal culture writing `"12,5"`. `ExcludedDefaultsVersion` (also `int?`, same `Set` overload) takes over that role so the case isn't lost.

The three `LayoutPersistenceGoldenTests` assertions were dropped outright — each sits beside siblings (`Priority`, `Pinned`, `BorderValues`, `VcpControl`) proving the same behaviour.

`dotnet build LittleBigMouse-Linux.slnf` → 0 errors. `dotnet test LittleBigMouse-Linux.slnf` → 694 passed, 0 failed.

⚠️ The 16 skipped tests are the `[WindowsFact]` registry ones, so the `RegistryLayoutStoreTests` change compiled but did not execute on Linux. Low risk — same `Set(int?)` overload the removed assertion exercised — but it wants a Windows run to be properly verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)