### PR TITLE
Drop csproj settings and package references nothing consumes

### DIFF
--- a/HLab.Sys/HLab.Sys.Argyll/HLab.Sys.Argyll.csproj
+++ b/HLab.Sys/HLab.Sys.Argyll/HLab.Sys.Argyll.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Avalonia" Version="12.1.1" />
 	  <PackageReference Include="ReactiveUI" Version="23.2.28" />
   </ItemGroup>
 

--- a/HLab.Sys/HLab.Sys.Monitors.Edid/HLab.Sys.Monitors.Edid.csproj
+++ b/HLab.Sys/HLab.Sys.Monitors.Edid/HLab.Sys.Monitors.Edid.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <Platforms>x64</Platforms>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp.Avalonia/HLab.Sys.Windows.MonitorVcp.Avalonia.csproj
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp.Avalonia/HLab.Sys.Windows.MonitorVcp.Avalonia.csproj
@@ -4,7 +4,6 @@
 	<TargetFrameworks>net10.0</TargetFrameworks>
 	<AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
 	<Version>2.5.0.0</Version>
   </PropertyGroup>

--- a/HLab.Sys/HLab.Sys.Windows.MonitorVcp/HLab.Sys.Windows.MonitorVcp.csproj
+++ b/HLab.Sys/HLab.Sys.Windows.MonitorVcp/HLab.Sys.Windows.MonitorVcp.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.1" />
     <PackageReference Include="OneOf" Version="3.0.271" />
   </ItemGroup>
 

--- a/HLab.Sys/HLab.Sys.Windows.Monitors/HLab.Sys.Windows.Monitors.csproj
+++ b/HLab.Sys/HLab.Sys.Windows.Monitors/HLab.Sys.Windows.Monitors.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <Platforms>x64;x86;AnyCpu</Platforms>
-    <Nullable>enable</Nullable>
-    <RootNamespace>HLab.Sys.Windows.Monitors</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<LangVersion>12</LangVersion>
@@ -13,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicData" Version="9.4.1" />
-    <PackageReference Include="System.Management" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,27 +18,6 @@
     <ProjectReference Include="..\..\HLab.Core\HLab.ColorTools\HLab.ColorTools.csproj" />
     <ProjectReference Include="..\..\HLab.Core\HLab.Geo\HLab.Geo.csproj" />
     <ProjectReference Include="..\..\HLab.Core\HLab.Sys.Windows.API\HLab.Sys.Windows.API.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="Properties\Settings.Designer.cs">
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Page Update="DisplayChangesView.xaml">
-      <SubType>Designer</SubType>
-    </Page>
   </ItemGroup>
 
 </Project>

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LittleBigMouse.DisplayLayout.Tests.csproj
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LittleBigMouse.DisplayLayout.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/LittleBigMouse.DisplayLayout.csproj
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout/LittleBigMouse.DisplayLayout.csproj
@@ -2,14 +2,12 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
-	<LangVersion>preview</LangVersion>
     <Platforms>x64</Platforms>
     <OutputType>Library</OutputType>
     <Configurations>Debug;Release;ReleaseDebug</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.Pipes" Version="15.0.0" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
   </ItemGroup>
 

--- a/LittleBigMouse.Core/LittleBigMouse.Zones/LittleBigMouse.Zoning.csproj
+++ b/LittleBigMouse.Core/LittleBigMouse.Zones/LittleBigMouse.Zoning.csproj
@@ -3,13 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\HLab.Core\HLab.Geo\HLab.Geo.csproj" />

--- a/LittleBigMouse.Platform.Linux/LittleBigMouse.Platform.Linux.csproj
+++ b/LittleBigMouse.Platform.Linux/LittleBigMouse.Platform.Linux.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <Platforms>x64</Platforms>
     <OutputType>Library</OutputType>
     <Configurations>Debug;Release;ReleaseDebug</Configurations>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LittleBigMouse.Platform.Windows/LittleBigMouse.Platform.Windows.csproj
+++ b/LittleBigMouse.Platform.Windows/LittleBigMouse.Platform.Windows.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <Platforms>x64</Platforms>
     <OutputType>Library</OutputType>
     <Configurations>Debug;Release;ReleaseDebug</Configurations>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LittleBigMouse.Plugin.Layout.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Layout.Avalonia/LittleBigMouse.Plugin.Layout.Avalonia.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
 	<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/LittleBigMouse.Plugin.Vcp.Avalonia.Tests.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/LittleBigMouse.Plugin.Vcp.Avalonia.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/LittleBigMouse.Plugin.Vcp.Avalonia.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
-    <LangVersion>preview</LangVersion>
 	<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/LittleBigMouse.Plugin.Vcp.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp/LittleBigMouse.Plugin.Vcp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Wallpaper.Avalonia/LittleBigMouse.Plugin.Wallpaper.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Wallpaper.Avalonia/LittleBigMouse.Plugin.Wallpaper.Avalonia.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
 	<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Avalonia/LittleBigMouse.Plugins.Avalonia.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Avalonia/LittleBigMouse.Plugins.Avalonia.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
 	<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/LittleBigMouse.Plugins.csproj
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/LittleBigMouse.Plugins.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/LittleBigMouse.Ui.Loader/LittleBigMouse.Ui.Loader.csproj
+++ b/LittleBigMouse.Ui.Loader/LittleBigMouse.Ui.Loader.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LittleBigMouse.Ui.Avalonia.Tests.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LittleBigMouse.Ui.Avalonia.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LittleBigMouse.Ui.Avalonia.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net10.0</TargetFrameworks>
-		<Nullable>enable</Nullable>
 		<Platforms>x64</Platforms>
 		<OutputType>WinExe</OutputType>
 		<ApplicationIcon>Assets\lbm-logo.ico</ApplicationIcon>
-		<LangVersion>preview</LangVersion>
 		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 		<Copyright>Mathieu GRENET</Copyright>
 		<PackageProjectUrl>https://github.com/mgth/LittleBigMouse/wiki</PackageProjectUrl>
@@ -16,25 +14,6 @@
 		<StartupObject>LittleBigMouse.Ui.Avalonia.Program</StartupObject>
 		<Title>Little Big Mouse</Title>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|x64'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|x86'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|x64'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|x86'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<None Remove="Assets\**" />
 	</ItemGroup>
@@ -50,10 +29,12 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="H.Pipes" Version="15.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="8.0.0-preview.7.23375.6" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.8" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.13" />

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Core/LittleBigMouse.Ui.Core.csproj
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Core/LittleBigMouse.Ui.Core.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Audit of the csproj files across the three repositories, removing settings
and dependencies that no longer carry their weight. **No package version
was upgraded** — xUnit, Avalonia and the rest stay exactly where they are.
No reference was removed without first confirming by compilation that
nothing consumed it.

Companion PRs: mgth/HLab.Avalonia#5 and mgth/HLab.Core#7.

> [!IMPORTANT]
> The submodule bump in this PR points at the tips of those two branches.
> mgth/HLab.Avalonia#5 must land with this one: it drops
> `ReactiveUI.Avalonia` and `Avalonia.Fonts.Inter` from
> `HLab.Base.Avalonia`, and this PR is what declares them on the
> application. Once both merge, the pointers need moving again to the
> resulting merge commits.

## Dependencies removed

`LittleBigMouse.Zoning` carried `System.Linq.Expressions` 4.3.0, a
netstandard-era package whose types have shipped in the framework since
.NET Core; `IXmlSerializable.cs` compiles against the in-box ones. The UI
carried `Microsoft.NETCore.Platforms`, a meta-package that does nothing on
a modern target.

## Dependencies moved to their real consumer

Two references were declared by a project that does not use them and were
reaching their actual consumer transitively — same version, just declared
where the code lives:

| Package | From | To | Used by |
| --- | --- | --- | --- |
| `H.Pipes` | `DisplayLayout` | `Ui.Avalonia` | `Remote/LocalIpcClient.cs` |
| `Avalonia` | `HLab.Sys.Argyll` | `HLab.Sys.Windows.MonitorVcp` | `MonitorLevel.cs` |

`Ui.Avalonia` additionally declares `ReactiveUI.Avalonia` and
`Avalonia.Fonts.Inter`, which it calls through `UseReactiveUI` and
`WithInterFont` but was inheriting from `HLab.Base.Avalonia`.

## Dead settings

Six conditional `PropertyGroup`s in the UI set `DebugType=full` for
`Debug|net8.0|x64` and friends. This project targets `net10.0`, so not one
of those conditions could ever be true; they had been dead since the net10
move and would have stayed dead through the next one.

`HLab.Sys.Windows.Monitors` declared a `RootNamespace` identical to the
default, plus three item groups describing files that are not in the tree:
`Properties/Settings.settings`, its generated designer, and a WPF `Page`
entry for `DisplayChangesView.xaml`.

## Language and nullability

`LangVersion preview` pins are removed — `net10.0` defaults to C# 14,
which compiles all of this. The numeric `LangVersion 12` pins in
`HLab.Sys.Windows.API` and `HLab.Sys.Windows.Monitors` are deliberately
**kept**: lifting those would be a language upgrade, not a cleanup.
Per-project `Nullable` pins that merely repeat `Directory.Build.props` are
removed; `HLab.Core` keeps its own, having no `Directory.Build.props` to
inherit from.

## Verification

Full build of `LittleBigMouse-Linux.slnf` at 0 errors and 710 tests
passing, re-run after the submodule pointer bump. Warning count is
unchanged at equal scope (593 before, 592 after, on a clean
non-incremental build).

## Left alone, deliberately

The `ReleaseDebug` configuration is declared by four projects but
referenced by neither the solution, the CI workflow nor any script — worth
a look, but removing a build configuration is a call for the maintainer.
Same for the heterogeneous `ImplicitUsings`, the dead `AvaloniaVersion`
11.1.0 in `HLab.Avalonia/Directory.Build.props`, and the xUnit and
Test.Sdk version spreads, which are upgrades and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)