### PR TITLE
Benchmark the mouse traversal engine

### DIFF
--- a/LittleBigMouse-Hook-Rust/Cargo.lock
+++ b/LittleBigMouse-Hook-Rust/Cargo.lock
@@ -18,6 +18,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "ashpd"
 version = "0.13.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +159,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,16 +229,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "endi"
@@ -397,6 +521,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +552,21 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -452,6 +602,7 @@ name = "littlebigmouse-hook"
 version = "0.1.0"
 dependencies = [
  "ashpd",
+ "criterion",
  "evdev",
  "futures",
  "libc",
@@ -533,10 +684,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ordered-stream"
@@ -546,6 +712,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -628,6 +804,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "regex"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +907,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -831,6 +1041,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -993,6 +1213,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1329,37 @@ checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -1343,6 +1604,32 @@ dependencies = [
  "winnow",
  "zvariant",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"

--- a/LittleBigMouse-Hook-Rust/Cargo.toml
+++ b/LittleBigMouse-Hook-Rust/Cargo.toml
@@ -65,6 +65,24 @@ features = [
     "Win32_System_Power",
 ]
 
+# Benchmarks only. `default-features = false` drops plotters/rayon and the HTML
+# report generator: the baseline this repo keeps is the textual one, and the
+# daemon has no use for a heavier dev tree.
+[dev-dependencies]
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
+
+# The traversal engine's hot path, measured against a fake cursor.
+[[bench]]
+name = "mouse_engine"
+harness = false
+
+# Allocation counts for the same scenarios. A plain binary rather than a
+# criterion harness: allocation counts are deterministic, so they are reported
+# as exact figures instead of being sampled.
+[[bench]]
+name = "alloc_profile"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/LittleBigMouse-Hook-Rust/README.md
+++ b/LittleBigMouse-Hook-Rust/README.md
@@ -42,6 +42,70 @@ cargo test
 cargo clippy --all-targets
 ```
 
+## Benchmarks
+
+```
+cargo bench --bench mouse_engine -- --quick   # timings, short mode (~1 min)
+cargo bench --bench mouse_engine              # timings, full statistics
+cargo bench --bench alloc_profile             # allocation counts
+cargo bench --bench mouse_engine -- --test    # run every scenario once, no timing
+```
+
+`benches/mouse_engine.rs` times the traversal core, `benches/alloc_profile.rs`
+counts its allocations, and `benches/support/` holds the fixtures both share.
+Nothing installs a hook, opens a device or moves the real pointer: the engine
+talks to a `CursorEnv` whose every method is a field read, so what is measured is
+the algorithm and not the OS. Layouts are generated as the XML the C# UI would
+send (2, 6 and 16 monitors, mixed DPI; plus a 4x4 wall), which is why there is no
+16-monitor fixture file in the tree.
+
+Each scenario is a closed loop of mouse events, and `Scenario::verify` replays it
+eight times asserting that every event still takes the branch the benchmark is
+named after — a crossing benchmark that quietly decayed into interior moves would
+fail rather than report a great number.
+
+### Reading the results
+
+**Timings are machine-dependent.** They move with the CPU, the clock governor,
+the allocator and the build flags, so only compare runs made on the same machine,
+ideally back to back — `cargo bench` keeps a baseline per benchmark id under
+`target/criterion/` and prints the change automatically. The figures below are a
+reference point, not a threshold; nothing in the suite fails on a timing.
+
+Measured on an AMD Ryzen 9 9950X, Linux 7.2 (CachyOS), rustc 1.94.0, `--quick`:
+
+| scenario | 2 zones | 6 zones | 16 zones |
+|---|---|---|---|
+| `interior` (Strait / Cross) | 11.7 / 11.5 ns | — | — |
+| `crossing/Strait` | 66 ns | 68 ns | 67 ns |
+| `crossing/Cross` | 91 ns | 253 ns | 660 ns |
+| `no_target/Strait` | 7.0 ns | 7.0 ns | 7.1 ns |
+| `no_target/Cross` | 27 ns | 107 ns | 296 ns |
+| `intersection/cross_4x4_diagonal` | | | 545 ns |
+| `travel_pixels/cached` | 15 ns | 15 ns | 15 ns |
+| `travel_pixels/compute` | | row_16 11 ns | grid_4x4 2.07 µs |
+| `load_layout` | 10.4 µs | 34.2 µs | 93.3 µs |
+
+**Allocation counts are not machine-dependent** — they are exact and identical on
+any host for a given build, which makes them the half of the baseline worth
+diffing:
+
+| scenario | allocations |
+|---|---|
+| `interior`, both algorithms | **0 per event** |
+| `crossing/Strait`, any zone count | 1 per event (the cached travel-path `Vec` clone) |
+| `crossing/Cross` | 1 / 5 / 15 per event at 2 / 6 / 16 zones |
+| `no_target/Cross` | 1 / 5 / 15 per event at 2 / 6 / 16 zones |
+| `travel_pixels/compute/grid_4x4` | 460 per call |
+| `load_layout/16` | 552 per call, 357 kB |
+
+Two shapes fall out of this, both expected from the code rather than surprises:
+Strait resolves one link on one side and is flat in the zone count, while Cross
+scans every zone per event and costs one `Rect::intersect` `Vec` for each.
+Neither is currently a problem — 660 ns leaves a wide margin at a 1 kHz report
+rate — and this task deliberately changed no algorithm; the point is to have the
+numbers before anyone does.
+
 ## The exe name
 
 Cargo rejects a target named with a `.`, so the binary builds as **`lbm-hook.exe`**

--- a/LittleBigMouse-Hook-Rust/benches/alloc_profile.rs
+++ b/LittleBigMouse-Hook-Rust/benches/alloc_profile.rs
@@ -1,0 +1,234 @@
+//! Allocation profile for the same scenarios `mouse_engine` times.
+//!
+//! ```text
+//! cargo bench --bench alloc_profile
+//! ```
+//!
+//! Unlike the timings, these figures are *not* machine-dependent: they are exact
+//! counts, identical on any host for a given build of the code. That makes them
+//! the more useful half of the baseline — a change that starts allocating on the
+//! per-event path shows up here as a whole number, with no statistics to argue
+//! about.
+//!
+//! Why a plain binary instead of a criterion harness: criterion's own sampling,
+//! reporting and `Vec` bookkeeping allocate heavily, and separating its
+//! allocations from the code under test is more machinery than the answer is
+//! worth. A counting [`GlobalAlloc`] over a bare loop gives exact numbers in
+//! twenty lines. It is registered for this bench binary only, so nothing about
+//! the daemon's allocator changes.
+//!
+//! No assertion, no threshold: this records a baseline, and thresholds on
+//! allocation counts would fail on an unrelated `std` change. Read the numbers,
+//! compare them to the README table, investigate a difference.
+
+mod support;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use littlebigmouse_hook::geometry::{Point, Rect, Segment};
+use littlebigmouse_hook::zones::travel::travel;
+use littlebigmouse_hook::zones::ZonesLayout;
+use support::{
+    complex_intersection, crossing, grid_panels, interior, layout_xml, no_target, row_panels, Algo,
+    Scenario,
+};
+
+// --- counting allocator ------------------------------------------------------
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+
+struct Counting;
+
+/// Delegates everything to the system allocator, counting on the way through.
+/// `realloc` and `alloc_zeroed` are forwarded rather than left to the trait's
+/// default implementations so the allocator behaves exactly like the real one —
+/// the defaults would turn every `realloc` into an alloc/copy/free.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(
+            new_size.saturating_sub(layout.size()) as u64,
+            Ordering::Relaxed,
+        );
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+// --- measurement -------------------------------------------------------------
+
+struct Row {
+    label: String,
+    /// Unit of work the counts are divided by — one mouse event, or one call.
+    unit: &'static str,
+    allocs_per_unit: f64,
+    bytes_per_unit: f64,
+}
+
+/// Run `f` `iters` times and attribute the allocations to `units_per_iter`
+/// units of work. The warm-up lap matters: lazily initialised statics (the
+/// travel cache's hash state, stdout's buffer) allocate exactly once and would
+/// otherwise be charged to the first measured iteration.
+fn measure(
+    label: impl Into<String>,
+    unit: &'static str,
+    iters: u64,
+    units_per_iter: u64,
+    mut f: impl FnMut(),
+) -> Row {
+    for _ in 0..16 {
+        f();
+    }
+
+    ALLOCS.store(0, Ordering::Relaxed);
+    BYTES.store(0, Ordering::Relaxed);
+    for _ in 0..iters {
+        f();
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed);
+    let bytes = BYTES.load(Ordering::Relaxed);
+
+    let units = (iters * units_per_iter) as f64;
+    Row {
+        label: label.into(),
+        unit,
+        allocs_per_unit: allocs as f64 / units,
+        bytes_per_unit: bytes as f64 / units,
+    }
+}
+
+/// A verified scenario, measured per mouse event.
+fn measure_scenario(label: impl Into<String>, mut scenario: Scenario, iters: u64) -> Row {
+    scenario.verify();
+    let units = scenario.path.len() as u64;
+    measure(label, "event", iters, units, || scenario.run())
+}
+
+const ZONE_COUNTS: [usize; 3] = [2, 6, 16];
+const ITERS: u64 = 2_000;
+
+fn main() {
+    // Take stdout's one-off buffer allocation before any measurement.
+    println!("Allocation profile — exact counts, identical on every machine.\n");
+
+    let mut rows = Vec::new();
+
+    for algo in [Algo::Strait, Algo::Cross] {
+        rows.push(measure_scenario(
+            format!("interior/{algo:?}"),
+            interior(algo, 2),
+            ITERS,
+        ));
+    }
+    for algo in [Algo::Strait, Algo::Cross] {
+        for zones in ZONE_COUNTS {
+            rows.push(measure_scenario(
+                format!("crossing/{algo:?}/{zones}"),
+                crossing(algo, zones),
+                ITERS,
+            ));
+        }
+    }
+    for algo in [Algo::Strait, Algo::Cross] {
+        for zones in ZONE_COUNTS {
+            rows.push(measure_scenario(
+                format!("no_target/{algo:?}/{zones}"),
+                no_target(algo, zones),
+                ITERS,
+            ));
+        }
+    }
+    rows.push(measure_scenario(
+        "intersection/cross_4x4_diagonal",
+        complex_intersection(),
+        ITERS,
+    ));
+
+    // The geometry primitive the Cross scan calls once per zone.
+    let rect: Rect<f64> = Rect::new(0.0, 0.0, 480.0, 270.0);
+    let diagonal = Segment::new(Point::new(-100.0, -50.0), Point::new(600.0, 400.0)).line();
+    let vertical = Segment::new(Point::new(240.0, -50.0), Point::new(240.0, 400.0)).line();
+    for (name, line) in [
+        ("rect_intersect_line/diagonal", diagonal),
+        ("rect_intersect_line/vertical", vertical),
+    ] {
+        rows.push(measure(name, "call", ITERS, 1, || {
+            std::hint::black_box(rect.intersect(std::hint::black_box(&line)));
+        }));
+    }
+
+    // travel_pixels, cached and uncached.
+    for zones in ZONE_COUNTS {
+        let panels = row_panels(zones);
+        let xml = layout_xml(&panels, Algo::Strait, 200.0, 0.0);
+        let mut layout = ZonesLayout::from_xml(&xml).expect("generated layout must parse");
+        let (first, last) = (layout.zones[0], layout.zones[zones - 1]);
+        layout.travel_pixels(first, last);
+        rows.push(measure(
+            format!("travel_pixels/cached/{zones}"),
+            "call",
+            ITERS,
+            1,
+            || {
+                std::hint::black_box(layout.travel_pixels(first, last));
+            },
+        ));
+    }
+    for (name, panels) in [
+        ("travel_pixels/compute/row_16", row_panels(16)),
+        ("travel_pixels/compute/grid_4x4", grid_panels(4, 4)),
+    ] {
+        let bounds: Vec<Rect<i32>> = panels.iter().map(|p| p.pixels).collect();
+        let (source, target) = (bounds[0], bounds[bounds.len() - 1]);
+        rows.push(measure(name, "call", ITERS, 1, || {
+            std::hint::black_box(travel(source, target, &bounds));
+        }));
+    }
+
+    // Layout load, for scale: this is what a reconfiguration costs.
+    for zones in ZONE_COUNTS {
+        let xml = layout_xml(&row_panels(zones), Algo::Strait, 200.0, 0.0);
+        rows.push(measure(
+            format!("load_layout/{zones}"),
+            "call",
+            200,
+            1,
+            || {
+                std::hint::black_box(ZonesLayout::from_xml(&xml));
+            },
+        ));
+    }
+
+    let width = rows.iter().map(|r| r.label.len()).max().unwrap_or(0);
+    println!(
+        "{:<width$}  {:>12}  {:>12}",
+        "scenario", "allocs/unit", "bytes/unit"
+    );
+    println!("{:-<width$}  {:->12}  {:->12}", "", "", "");
+    for row in &rows {
+        println!(
+            "{:<width$}  {:>12.2}  {:>12.1}   per {}",
+            row.label, row.allocs_per_unit, row.bytes_per_unit, row.unit
+        );
+    }
+}

--- a/LittleBigMouse-Hook-Rust/benches/mouse_engine.rs
+++ b/LittleBigMouse-Hook-Rust/benches/mouse_engine.rs
@@ -1,0 +1,229 @@
+//! Timing baseline for the mouse traversal engine.
+//!
+//! Everything here runs against the fake cursor of `support::BenchCursor`: no
+//! hook is installed, no device is opened, the real pointer never moves. What is
+//! measured is `MouseEngine::on_mouse_move` and the zone/geometry code it calls
+//! — the part of the daemon that runs on every single mouse report, up to 1000
+//! times per second per device.
+//!
+//! ```text
+//! cargo bench --bench mouse_engine              # full run (a few minutes)
+//! cargo bench --bench mouse_engine -- --quick   # short mode, good enough to compare
+//! cargo bench --bench mouse_engine -- --test    # just run each scenario once
+//! cargo bench --bench mouse_engine -- crossing  # filter by name
+//! ```
+//!
+//! Absolute numbers are meaningless across machines — they depend on the CPU,
+//! its clock governor, the allocator and the build flags. Compare runs made on
+//! the same machine, ideally back to back; criterion's own
+//! `target/criterion/<id>/` baselines do this for you. See the README for the
+//! recorded reference environment.
+//!
+//! Every scenario is a *closed loop* of events (replaying it returns the engine
+//! to its starting state) and is checked by [`Scenario::verify`] before being
+//! timed, so a benchmark cannot silently decay into measuring an early return.
+
+mod support;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use littlebigmouse_hook::geometry::{Point, Rect, Segment};
+use littlebigmouse_hook::zones::travel::travel;
+use littlebigmouse_hook::zones::ZonesLayout;
+use support::{
+    complex_intersection, crossing, desktop_bounds, grid_panels, interior, layout_xml, no_target,
+    row_panels, Algo, Scenario,
+};
+
+/// Zone counts to sweep: a laptop plus one screen, a normal multi-monitor desk,
+/// and a wall large enough to make an O(zones) scan visible.
+const ZONE_COUNTS: [usize; 3] = [2, 6, 16];
+
+/// Time a verified scenario, reporting per-event throughput.
+fn bench_scenario(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    id: BenchmarkId,
+    mut scenario: Scenario,
+) {
+    scenario.verify();
+    group.throughput(Throughput::Elements(scenario.path.len() as u64));
+    group.bench_function(id, |b| b.iter(|| scenario.run()));
+}
+
+/// The common case: the pointer moves inside the monitor it is already on. The
+/// engine must decide "nothing to do" as cheaply as possible.
+fn bench_interior(c: &mut Criterion) {
+    let mut group = c.benchmark_group("interior");
+    for algo in [Algo::Strait, Algo::Cross] {
+        bench_scenario(
+            &mut group,
+            BenchmarkId::from_parameter(format!("{algo:?}")),
+            interior(algo, 2),
+        );
+    }
+    group.finish();
+}
+
+/// A border crossing, swept over the zone count. The interesting result is the
+/// *shape*: Strait resolves a link on one side and is flat in the zone count,
+/// while Cross scans every zone for the nearest exit and is not.
+fn bench_crossing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crossing");
+    for algo in [Algo::Strait, Algo::Cross] {
+        for zones in ZONE_COUNTS {
+            bench_scenario(
+                &mut group,
+                BenchmarkId::new(format!("{algo:?}"), zones),
+                crossing(algo, zones),
+            );
+        }
+    }
+    group.finish();
+}
+
+/// Pushing at the outer rim of the desktop. No zone can match, so the search
+/// cannot exit early — the worst case of the scan, and the one a user produces
+/// continuously just by shoving the pointer into a corner.
+fn bench_no_target(c: &mut Criterion) {
+    let mut group = c.benchmark_group("no_target");
+    for algo in [Algo::Strait, Algo::Cross] {
+        for zones in ZONE_COUNTS {
+            bench_scenario(
+                &mut group,
+                BenchmarkId::new(format!("{algo:?}"), zones),
+                no_target(algo, zones),
+            );
+        }
+    }
+    group.finish();
+}
+
+/// A long diagonal trip across a 4x4 wall: many zone rectangles actually
+/// intersect the trip line, so the nearest-exit comparison runs on all of them.
+fn bench_intersection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("intersection");
+    bench_scenario(
+        &mut group,
+        BenchmarkId::from_parameter("cross_4x4_diagonal"),
+        complex_intersection(),
+    );
+    group.finish();
+}
+
+/// The geometry primitive underneath the scan: `Rect::intersect(&Line)`, called
+/// once per zone per Cross event. It returns a freshly allocated `Vec`, which is
+/// why it also shows up in the allocation profile.
+fn bench_rect_intersect(c: &mut Criterion) {
+    let rect: Rect<f64> = Rect::new(0.0, 0.0, 480.0, 270.0);
+    // A diagonal that genuinely cuts two edges, and a vertical one (the
+    // `f64::MAX` slope sentinel), which takes a different branch.
+    let diagonal = Segment::new(Point::new(-100.0, -50.0), Point::new(600.0, 400.0)).line();
+    let vertical = Segment::new(Point::new(240.0, -50.0), Point::new(240.0, 400.0)).line();
+
+    let mut group = c.benchmark_group("rect_intersect_line");
+    group.bench_function("diagonal", |b| {
+        b.iter(|| std::hint::black_box(rect.intersect(std::hint::black_box(&diagonal))))
+    });
+    group.bench_function("vertical", |b| {
+        b.iter(|| std::hint::black_box(rect.intersect(std::hint::black_box(&vertical))))
+    });
+    group.finish();
+}
+
+/// `travel_pixels` — the clip-rect path the cursor is walked along so it cannot
+/// escape the desktop between two monitors.
+///
+/// Two very different costs share the name: the cached lookup the engine
+/// actually pays per crossing (a hash lookup plus a `Vec` clone), and the
+/// backtracking search behind the cache, benchmarked directly through
+/// `zones::travel::travel` because `ZonesLayout` has no way to drop its cache.
+fn bench_travel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("travel_pixels");
+
+    for zones in ZONE_COUNTS {
+        let panels = row_panels(zones);
+        let xml = layout_xml(&panels, Algo::Strait, 200.0, 0.0);
+        let mut layout = ZonesLayout::from_xml(&xml).expect("generated layout must parse");
+        let (first, last) = (layout.zones[0], layout.zones[zones - 1]);
+        // Warm the cache so the loop measures the lookup, not the search.
+        let warm = layout.travel_pixels(first, last);
+        assert!(
+            !warm.is_empty(),
+            "adjacent monitors must have a travel path"
+        );
+
+        group.bench_function(BenchmarkId::new("cached", zones), |b| {
+            b.iter(|| std::hint::black_box(layout.travel_pixels(first, last)))
+        });
+    }
+
+    // Uncached search. A row is the easy shape (the two monitors are directly
+    // reachable, so it returns at once); the grid forces the recursion.
+    for (name, panels) in [
+        ("compute/row_16", row_panels(16)),
+        ("compute/grid_4x4", grid_panels(4, 4)),
+    ] {
+        let bounds: Vec<Rect<i32>> = panels.iter().map(|p| p.pixels).collect();
+        let source = bounds[0];
+        let target = bounds[bounds.len() - 1];
+        assert!(
+            !travel(source, target, &bounds).is_empty(),
+            "{name}: the fixture must have a travel path to measure"
+        );
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                std::hint::black_box(travel(
+                    std::hint::black_box(source),
+                    std::hint::black_box(target),
+                    std::hint::black_box(&bounds),
+                ))
+            })
+        });
+    }
+
+    group.finish();
+}
+
+/// Layout load. Not a hot path — it runs once per reconfiguration — but a 16
+/// monitor layout is a ~40 kB document and the daemon parses it while the
+/// pointer is live, so it is worth a number.
+fn bench_load(c: &mut Criterion) {
+    let mut group = c.benchmark_group("load_layout");
+    for zones in ZONE_COUNTS {
+        let panels = row_panels(zones);
+        let xml = layout_xml(&panels, Algo::Strait, 200.0, 0.0);
+        group.throughput(Throughput::Bytes(xml.len() as u64));
+        group.bench_function(BenchmarkId::from_parameter(zones), |b| {
+            b.iter(|| std::hint::black_box(ZonesLayout::from_xml(std::hint::black_box(&xml))))
+        });
+    }
+    group.finish();
+}
+
+/// Not timed: prints the shape of the fixtures so a run is self-describing and
+/// a surprising number can be traced back to what was actually measured.
+fn describe(_c: &mut Criterion) {
+    for zones in ZONE_COUNTS {
+        let panels = row_panels(zones);
+        let xml = layout_xml(&panels, Algo::Strait, 200.0, 0.0);
+        let desktop = desktop_bounds(&panels);
+        eprintln!(
+            "fixture row_{zones}: desktop {}x{} px, layout xml {} bytes",
+            desktop.width(),
+            desktop.height(),
+            xml.len(),
+        );
+    }
+}
+
+criterion_group!(
+    benches,
+    describe,
+    bench_interior,
+    bench_crossing,
+    bench_no_target,
+    bench_intersection,
+    bench_rect_intersect,
+    bench_travel,
+    bench_load,
+);
+criterion_main!(benches);

--- a/LittleBigMouse-Hook-Rust/benches/support/mod.rs
+++ b/LittleBigMouse-Hook-Rust/benches/support/mod.rs
@@ -1,0 +1,586 @@
+//! Shared fixtures for the engine benchmarks — synthetic layouts and a fake
+//! cursor. Nothing here touches the OS: no hook, no `SetCursorPos`, no device
+//! enumeration. The benchmarks measure the pure traversal core, which is exactly
+//! the part `CursorEnv` was introduced to isolate.
+//!
+//! ## Why the layouts are generated rather than hand-written
+//!
+//! Zone layouts only enter the daemon as XML from the C# UI, and
+//! [`ZonesLayout::from_xml`] is their only constructor. Generating that XML is
+//! therefore the only way to build a 16-monitor fixture without checking in a
+//! 25 kB file. [`layout_xml`] reproduces the shape the real serializer emits
+//! (`tests/border-sections-zones.xml` is a captured sample of it):
+//!
+//! * every side carries a leading catch-all (`From = -f64::MAX`), then the real
+//!   links sorted along the edge, then a trailing catch-all (`To = f64::MAX`),
+//!   so the `at_physical_index` / `at_pixel_index` walk has the same length it
+//!   has in production;
+//! * `From`/`To` are the *target's* physical span along the edge, in absolute
+//!   millimetres;
+//! * `SourceFromPixel`/`SourceToPixel` are the source pixels that map onto that
+//!   span, `TargetFromPixel`/`TargetToPixel` the target's own pixel span.
+//!
+//! Feeding the mixed-DPI numbers of the checked-in fixtures through
+//! [`link_attrs`] reproduces their attributes exactly, which is what makes these
+//! generated layouts credible stand-ins for real ones.
+
+// Each bench target uses a subset of this module; both would otherwise report
+// the other's helpers as dead code.
+#![allow(dead_code)]
+
+use littlebigmouse_hook::engine::cursor::CursorEnv;
+use littlebigmouse_hook::engine::event::MouseEventArg;
+use littlebigmouse_hook::engine::MouseEngine;
+use littlebigmouse_hook::geometry::{Point, Rect};
+use littlebigmouse_hook::zones::{ZoneId, ZonesLayout};
+
+/// `f64::MAX` as the C# `InvariantCulture` round-trip format spells it.
+const F64_MAX: &str = "1.7976931348623157E+308";
+const F64_MIN: &str = "-1.7976931348623157E+308";
+
+// --- fake cursor ------------------------------------------------------------
+
+/// The evdev backend's `EvdevCursor` semantics, minus the device: a virtual
+/// position clamped into the active clip. Every method is a field read, so the
+/// measurement is engine time and not environment time.
+///
+/// `cursor_hidden` and `clip_is_subrect_of_virtual_screen` answer "no" so the
+/// freelook gate stays open — a benchmark that silently fell into freelook would
+/// be measuring an early return.
+pub struct BenchCursor {
+    pos: Point<i32>,
+    clip: Rect<i32>,
+    desktop: Rect<i32>,
+}
+
+impl BenchCursor {
+    pub fn new(desktop: Rect<i32>) -> Self {
+        BenchCursor {
+            pos: Point::new(desktop.left(), desktop.top()),
+            clip: desktop,
+            desktop,
+        }
+    }
+
+    fn clamp(&self, p: Point<i32>) -> Point<i32> {
+        Point::new(
+            p.x().clamp(self.clip.left(), self.clip.right() - 1),
+            p.y().clamp(self.clip.top(), self.clip.bottom() - 1),
+        )
+    }
+}
+
+impl CursorEnv for BenchCursor {
+    fn get_mouse_location(&self) -> Point<i32> {
+        self.clamp(self.pos)
+    }
+    fn set_mouse_location(&mut self, location: Point<i32>) {
+        self.pos = location;
+    }
+    fn get_clip(&self) -> Rect<i32> {
+        self.clip
+    }
+    fn set_clip(&mut self, r: Rect<i32>) {
+        self.clip = if r.is_empty() { self.desktop } else { r };
+    }
+    fn ctrl_down(&self) -> bool {
+        false
+    }
+    fn buttons_down(&self) -> bool {
+        false
+    }
+    fn cursor_hidden(&self) -> bool {
+        false
+    }
+    fn clip_is_subrect_of_virtual_screen(&self) -> bool {
+        false
+    }
+    fn tick_count(&self) -> u64 {
+        0
+    }
+}
+
+// --- panels -----------------------------------------------------------------
+
+/// One monitor: its pixel rect on the virtual desktop and its physical rect in
+/// millimetres. The ratio between the two is the DPI the engine has to correct.
+#[derive(Debug, Clone, Copy)]
+pub struct Panel {
+    pub pixels: Rect<i32>,
+    pub physical: Rect<f64>,
+}
+
+impl Panel {
+    /// The source pixel row/column that maps onto absolute physical `mm` along
+    /// the given axis — the serializer's `SourceFromPixel`/`SourceToPixel`.
+    fn pixel_at_mm(&self, mm: f64, vertical: bool) -> i32 {
+        let (p0, plen, m0, mlen) = if vertical {
+            (
+                self.pixels.top(),
+                self.pixels.height(),
+                self.physical.top(),
+                self.physical.height(),
+            )
+        } else {
+            (
+                self.pixels.left(),
+                self.pixels.width(),
+                self.physical.left(),
+                self.physical.width(),
+            )
+        };
+        p0 + ((mm - m0) * plen as f64 / mlen) as i32
+    }
+}
+
+/// `n` panels side by side, physically centred on a common midline, with
+/// alternating panel sizes so consecutive borders have mismatched DPI — the
+/// case the whole engine exists for. Pixel geometry stays uniform (3840x2160)
+/// because the OS reports a gapless pixel desktop.
+pub fn row_panels(n: usize) -> Vec<Panel> {
+    const PIXEL_W: i32 = 3840;
+    const PIXEL_H: i32 = 2160;
+    // A 32" and a 24" 4K panel: 139 vs 185 dpi.
+    const SIZES: [(f64, f64); 2] = [(698.0, 393.0), (527.0, 296.0)];
+    let tallest = SIZES[0].1;
+
+    let mut panels = Vec::with_capacity(n);
+    let mut mm_x = 0.0;
+    for i in 0..n {
+        let (w, h) = SIZES[i % SIZES.len()];
+        panels.push(Panel {
+            pixels: Rect::new(i as i32 * PIXEL_W, 0, PIXEL_W, PIXEL_H),
+            physical: Rect::new(mm_x, (tallest - h) / 2.0, w, h),
+        });
+        mm_x += w;
+    }
+    panels
+}
+
+/// A `cols` x `rows` wall of identical 1920x1080 / 480x270 mm panels. Uniform
+/// DPI on purpose: what this fixture stresses is the number of zone rectangles
+/// a single trip line has to be intersected against, not the remapping.
+pub fn grid_panels(cols: usize, rows: usize) -> Vec<Panel> {
+    const PIXEL_W: i32 = 1920;
+    const PIXEL_H: i32 = 1080;
+    const MM_W: f64 = 480.0;
+    const MM_H: f64 = 270.0;
+
+    let mut panels = Vec::with_capacity(cols * rows);
+    for r in 0..rows {
+        for c in 0..cols {
+            panels.push(Panel {
+                pixels: Rect::new(c as i32 * PIXEL_W, r as i32 * PIXEL_H, PIXEL_W, PIXEL_H),
+                physical: Rect::new(c as f64 * MM_W, r as f64 * MM_H, MM_W, MM_H),
+            });
+        }
+    }
+    panels
+}
+
+/// The union of every panel's pixel rect — what the backends call the desktop.
+pub fn desktop_bounds(panels: &[Panel]) -> Rect<i32> {
+    let l = panels.iter().map(|p| p.pixels.left()).min().unwrap_or(0);
+    let t = panels.iter().map(|p| p.pixels.top()).min().unwrap_or(0);
+    let r = panels.iter().map(|p| p.pixels.right()).max().unwrap_or(0);
+    let b = panels.iter().map(|p| p.pixels.bottom()).max().unwrap_or(0);
+    Rect::new(l, t, r - l, b - t)
+}
+
+// --- XML generation ---------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Algo {
+    Strait,
+    Cross,
+}
+
+impl Algo {
+    fn as_attr(self) -> &'static str {
+        match self {
+            // The historical spelling, kept because it is part of the wire format.
+            Algo::Strait => "Strait",
+            Algo::Cross => "Cross",
+        }
+    }
+}
+
+/// Which edge of the source panel a link sits on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Edge {
+    Left,
+    Top,
+    Right,
+    Bottom,
+}
+
+impl Edge {
+    fn element(self) -> &'static str {
+        match self {
+            Edge::Left => "LeftLinks",
+            Edge::Top => "TopLinks",
+            Edge::Right => "RightLinks",
+            Edge::Bottom => "BottomLinks",
+        }
+    }
+
+    /// Left/Right edges are walked along y, Top/Bottom along x.
+    fn vertical(self) -> bool {
+        matches!(self, Edge::Left | Edge::Right)
+    }
+
+    /// Whether `b` sits immediately on this edge of `a`, sharing a run of pixels.
+    fn adjacent(self, a: &Panel, b: &Panel) -> bool {
+        let (ap, bp) = (a.pixels, b.pixels);
+        let overlap_y = ap.top().max(bp.top()) < ap.bottom().min(bp.bottom());
+        let overlap_x = ap.left().max(bp.left()) < ap.right().min(bp.right());
+        match self {
+            Edge::Left => ap.left() == bp.right() && overlap_y,
+            Edge::Right => ap.right() == bp.left() && overlap_y,
+            Edge::Top => ap.top() == bp.bottom() && overlap_x,
+            Edge::Bottom => ap.bottom() == bp.top() && overlap_x,
+        }
+    }
+}
+
+/// One `<ZoneLink>`. Named fields rather than eight positional arguments: the
+/// source and target pixel pairs are interchangeable to the compiler, and
+/// swapping them would produce a layout that parses and crosses to the wrong
+/// place.
+struct Link<'a> {
+    /// Physical span along the edge, in absolute millimetres.
+    span_mm: (&'a str, &'a str),
+    /// The source zone's pixels covering that span.
+    source_px: (i32, i32),
+    /// The target zone's pixels the span maps onto.
+    target_px: (i32, i32),
+    resistance: f64,
+    /// Zone `Id` of the target, or `-1` for a catch-all with nothing behind it.
+    target_id: i32,
+}
+
+impl Link<'_> {
+    /// Serialize in the attribute order the C# serializer uses.
+    fn to_xml(&self) -> String {
+        let (from, to) = self.span_mm;
+        let (source_from, source_to) = self.source_px;
+        let (target_from, target_to) = self.target_px;
+        let resistance = self.resistance;
+        let target_id = self.target_id;
+        format!(
+            r#"<ZoneLink From="{from}" To="{to}" SourceFromPixel="{source_from}" SourceToPixel="{source_to}" TargetFromPixel="{target_from}" TargetToPixel="{target_to}" BorderResistance="{resistance}" MoveBlock="False" DragResistance="{resistance}" DragBlock="False" TargetId="{target_id}"></ZoneLink>"#
+        )
+    }
+}
+
+/// The `<XxxLinks>` element for one edge of one panel: leading catch-all, the
+/// real neighbours sorted along the edge, trailing catch-all.
+fn edge_links(panels: &[Panel], index: usize, edge: Edge, resistance: f64) -> String {
+    let a = &panels[index];
+
+    let mut neighbours: Vec<usize> = (0..panels.len())
+        .filter(|&j| j != index && edge.adjacent(a, &panels[j]))
+        .collect();
+    let span = |p: &Panel| {
+        if edge.vertical() {
+            (p.physical.top(), p.physical.bottom())
+        } else {
+            (p.physical.left(), p.physical.right())
+        }
+    };
+    neighbours.sort_by(|&x, &y| span(&panels[x]).0.total_cmp(&span(&panels[y]).0));
+
+    let target_pixel_span = |p: &Panel| {
+        if edge.vertical() {
+            (p.pixels.top(), p.pixels.bottom())
+        } else {
+            (p.pixels.left(), p.pixels.right())
+        }
+    };
+
+    let mut out = String::new();
+    let mut cursor_mm = F64_MIN.to_string();
+    let mut cursor_px = i32::MIN;
+
+    for j in neighbours {
+        let b = &panels[j];
+        let (mm_from, mm_to) = span(b);
+        let (tgt_from, tgt_to) = target_pixel_span(b);
+        let src_from = a.pixel_at_mm(mm_from, edge.vertical());
+        let src_to = a.pixel_at_mm(mm_to, edge.vertical());
+
+        // Catch-all covering the run of edge before this neighbour starts.
+        out.push_str(
+            &Link {
+                span_mm: (&cursor_mm, &fmt_mm(mm_from)),
+                source_px: (cursor_px, src_from),
+                target_px: (i32::MIN, src_from),
+                resistance: 0.0,
+                target_id: -1,
+            }
+            .to_xml(),
+        );
+        out.push_str(
+            &Link {
+                span_mm: (&fmt_mm(mm_from), &fmt_mm(mm_to)),
+                source_px: (src_from, src_to),
+                target_px: (tgt_from, tgt_to),
+                resistance,
+                target_id: j as i32, // zones are emitted in panel order, so index == Id
+            }
+            .to_xml(),
+        );
+        cursor_mm = fmt_mm(mm_to);
+        cursor_px = src_to;
+    }
+
+    // Trailing catch-all: the run past the last neighbour (or the whole edge
+    // when the panel has none, i.e. the outer rim of the desktop).
+    out.push_str(
+        &Link {
+            span_mm: (&cursor_mm, F64_MAX),
+            source_px: (cursor_px, i32::MAX),
+            target_px: (i32::MIN, i32::MAX),
+            resistance: 0.0,
+            target_id: -1,
+        }
+        .to_xml(),
+    );
+
+    format!("<{el}>{out}</{el}>", el = edge.element())
+}
+
+/// C# `InvariantCulture` double formatting, close enough for the values used
+/// here (no exponent, `.` as the decimal separator).
+fn fmt_mm(v: f64) -> String {
+    if v == v.trunc() {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+/// Serialize `panels` into the `<ZonesLayout>` XML the daemon receives.
+///
+/// `resistance` is applied to every real link (0 = free borders, the default a
+/// benchmark wants: a resisted border short-circuits into `no_zone_matches` and
+/// would measure the cheap path instead of the crossing).
+pub fn layout_xml(panels: &[Panel], algo: Algo, max_travel: f64, resistance: f64) -> String {
+    let mut zones = String::new();
+    for (i, panel) in panels.iter().enumerate() {
+        let mut links = String::new();
+        for edge in [Edge::Left, Edge::Top, Edge::Right, Edge::Bottom] {
+            links.push_str(&edge_links(panels, i, edge, resistance));
+        }
+
+        zones.push_str(&format!(
+            concat!(
+                r#"<Zone Id="{id}" Name="M{id}" DeviceId="M{id}">"#,
+                r#"<PixelsBounds><Rect Left="{pl}" Top="{pt}" Width="{pw}" Height="{ph}"></Rect></PixelsBounds>"#,
+                r#"<PhysicalBounds><Rect Left="{ml}" Top="{mt}" Width="{mw}" Height="{mh}"></Rect></PhysicalBounds>"#,
+                r#"{links}</Zone>"#,
+            ),
+            id = i,
+            pl = panel.pixels.left(),
+            pt = panel.pixels.top(),
+            pw = panel.pixels.width(),
+            ph = panel.pixels.height(),
+            ml = fmt_mm(panel.physical.left()),
+            mt = fmt_mm(panel.physical.top()),
+            mw = fmt_mm(panel.physical.width()),
+            mh = fmt_mm(panel.physical.height()),
+            links = links,
+        ));
+    }
+
+    format!(
+        concat!(
+            r#"<ZonesLayout AdjustPointer="False" AdjustSpeed="False" LoopX="False" LoopY="False" "#,
+            r#"Virtual="False" Priority="Normal" PriorityUnhooked="Below" Algorithm="{algo}" "#,
+            r#"MaxTravelDistance="{max_travel}" FreelookCheckInterval="100" FreelookEnabled="True">"#,
+            r#"<MainZones>{zones}</MainZones></ZonesLayout>"#,
+        ),
+        algo = algo.as_attr(),
+        max_travel = fmt_mm(max_travel),
+        zones = zones,
+    )
+}
+
+// --- engine harness ---------------------------------------------------------
+
+/// An engine loaded with `panels`, its fake cursor, and the zone ids in panel
+/// order — already primed so the first benchmarked event takes the steady-state
+/// path rather than `ExtFirst`.
+pub struct Harness {
+    pub engine: MouseEngine,
+    pub env: BenchCursor,
+    pub zones: Vec<ZoneId>,
+}
+
+impl Harness {
+    pub fn new(panels: &[Panel], algo: Algo, max_travel: f64, prime_at: Point<i32>) -> Harness {
+        let xml = layout_xml(panels, algo, max_travel, 0.0);
+        let layout = ZonesLayout::from_xml(&xml).expect("generated layout must parse");
+        assert_eq!(
+            layout.main_zones.len(),
+            panels.len(),
+            "every generated panel must become a main zone"
+        );
+
+        let mut engine = MouseEngine::new();
+        let zones = layout.zones.clone();
+        engine.load(layout);
+
+        let env = BenchCursor::new(desktop_bounds(panels));
+        let mut harness = Harness { engine, env, zones };
+        // Two events: the first only resolves the starting zone (ExtFirst).
+        harness.feed(prime_at);
+        harness.feed(prime_at);
+        harness
+    }
+
+    /// One mouse event through the engine. Returns whether the engine took over
+    /// (repositioned the cursor) — the flag the backends use to swallow the event.
+    pub fn feed(&mut self, p: Point<i32>) -> bool {
+        let mut event = MouseEventArg::new(p);
+        self.engine.on_mouse_move(&mut self.env, &mut event);
+        event.handled
+    }
+
+    pub fn pixels_of(&self, zone: usize) -> Rect<i32> {
+        self.engine.layout.arena[self.zones[zone]].pixels_bounds()
+    }
+}
+
+// --- scenarios --------------------------------------------------------------
+
+/// A closed loop of mouse events: replaying it leaves the engine in the state it
+/// started from, so a benchmark can iterate it without a per-iteration reset.
+pub struct Scenario {
+    pub name: &'static str,
+    pub harness: Harness,
+    pub path: Vec<Point<i32>>,
+    /// What `handled` must be for every event of the path. Asserted by
+    /// [`Scenario::verify`], which is how the suite proves each benchmark
+    /// exercises the branch its name claims.
+    pub expect_handled: bool,
+}
+
+impl Scenario {
+    /// Run the path once.
+    #[inline]
+    pub fn run(&mut self) {
+        for i in 0..self.path.len() {
+            let p = self.path[i];
+            std::hint::black_box(self.harness.feed(p));
+        }
+    }
+
+    /// Replay the loop and check that it really is one: every event must take
+    /// the expected branch, on every lap. A path that decayed into interior
+    /// moves after the first lap would otherwise benchmark nothing.
+    pub fn verify(&mut self) {
+        for lap in 0..8 {
+            for (i, &p) in self.path.clone().iter().enumerate() {
+                let handled = self.harness.feed(p);
+                assert_eq!(
+                    handled,
+                    self.expect_handled,
+                    "{}: event {i} of lap {lap} at ({}, {}) was handled={handled}",
+                    self.name,
+                    p.x(),
+                    p.y(),
+                );
+            }
+        }
+    }
+}
+
+/// Motion that never leaves the current zone — the overwhelmingly common event,
+/// and the one whose cost the daemon pays on every single mouse report.
+pub fn interior(algo: Algo, zones: usize) -> Scenario {
+    let panels = row_panels(zones);
+    let bounds = panels[0].pixels;
+    let (cx, cy) = (
+        bounds.left() + bounds.width() / 2,
+        bounds.top() + bounds.height() / 2,
+    );
+    let harness = Harness::new(&panels, algo, 200.0, Point::new(cx, cy));
+    Scenario {
+        name: "interior",
+        harness,
+        // A small square well away from the edge columns, so no border is even
+        // a candidate and the resistance re-arm guard is exercised.
+        path: vec![
+            Point::new(cx + 8, cy),
+            Point::new(cx + 8, cy + 8),
+            Point::new(cx, cy + 8),
+            Point::new(cx, cy),
+        ],
+        expect_handled: false,
+    }
+}
+
+/// Crossing the border between the first two zones, back and forth. Every event
+/// resolves a link, drains resistance, walks the travel rects and repositions
+/// the cursor.
+pub fn crossing(algo: Algo, zones: usize) -> Scenario {
+    let panels = row_panels(zones);
+    let border = panels[0].pixels.right();
+    let y = panels[0].pixels.top() + panels[0].pixels.height() / 2;
+    let harness = Harness::new(
+        &panels,
+        algo,
+        200.0,
+        Point::new(panels[0].pixels.left() + 100, y),
+    );
+    Scenario {
+        name: "crossing",
+        harness,
+        // One pixel past the border in each direction: the minimal overshoot a
+        // real mouse report produces, and the one that must not ping-pong.
+        path: vec![Point::new(border, y), Point::new(border - 1, y)],
+        expect_handled: true,
+    }
+}
+
+/// Pushing against the outer rim of the desktop: the search scans every zone,
+/// matches none, and the cursor is clipped back. This is the worst case of
+/// `find_target_zone` — no early exit is possible, so its cost is the full
+/// zone count.
+pub fn no_target(algo: Algo, zones: usize) -> Scenario {
+    let panels = row_panels(zones);
+    let last = panels[zones - 1].pixels;
+    let y = last.top() + last.height() / 2;
+    let harness = Harness::new(&panels, algo, 200.0, Point::new(last.right() - 100, y));
+    Scenario {
+        name: "no_target",
+        harness,
+        // Past the rightmost edge, where there is nothing to cross into.
+        // `no_zone_matches` leaves `old_point` untouched, so one event is
+        // already a closed loop.
+        path: vec![Point::new(last.right(), y)],
+        expect_handled: false,
+    }
+}
+
+/// A long diagonal trip across a monitor wall: the trip line is intersected
+/// against every zone rectangle, most of those intersections are real, and the
+/// nearest-exit comparison has to run on all of them. `MaxTravelDistance` is
+/// deliberately large so nothing is rejected early.
+pub fn complex_intersection() -> Scenario {
+    let panels = grid_panels(4, 4);
+    let first = panels[0].pixels;
+    let start = Point::new(first.left() + 40, first.top() + 40);
+    let harness = Harness::new(&panels, Algo::Cross, 4000.0, start);
+    let far = panels[panels.len() - 1].pixels;
+    Scenario {
+        name: "complex_intersection",
+        harness,
+        path: vec![
+            Point::new(far.right() - 40, far.bottom() - 40),
+            Point::new(first.left() + 40, first.top() + 40),
+        ],
+        expect_handled: true,
+    }
+}


### PR DESCRIPTION
GEN-22. Adds a reproducible measurement baseline for the engine's hot path. **No production algorithm is touched** — this task is deliberately measurement-only.

## What is here

| file | role |
|---|---|
| `benches/support/mod.rs` | fixtures: fake `CursorEnv` + synthetic layout generator |
| `benches/mouse_engine.rs` | timings (criterion) |
| `benches/alloc_profile.rs` | allocation counts (counting `GlobalAlloc`) |

Nothing installs a hook, opens a device or moves the real pointer. The engine talks to a `CursorEnv` whose every method is a field read, so what is measured is the algorithm and not the OS.

Coverage: interior move, crossing at 2/6/16 zones, no-target search, complex intersection (4x4 wall, long diagonal), `Rect::intersect`, `travel_pixels` cached and uncached, and layout load.

## The fixtures are not guesswork

Layouts only enter the daemon as XML from the C# UI, and `ZonesLayout::from_xml` is their only constructor — so a 16-monitor fixture means either a 37 kB file in the tree or a generator. This is the generator, and its link layout is derived from the captured serializer output in `tests/border-sections-zones.xml`: leading catch-all, real links sorted along the edge, trailing catch-all, `From`/`To` as the target's physical span in absolute mm.

Its formulas reproduce the attributes of both checked-in fixtures exactly, mixed-DPI pairs included — feeding the `ZonesLayout` fixture's numbers through it yields the same `SourceFromPixel="-225" SourceToPixel="2642"`.

## Each benchmark proves it measures what it claims

Every scenario is a *closed loop* of events, and `Scenario::verify` replays it eight times asserting each event still takes the branch the benchmark is named after. A crossing benchmark that quietly decayed into interior moves now fails instead of reporting a great number. `cargo bench -- --test` runs all of this in seconds.

## Results

Allocation counts are exact and identical on any host — the half of the baseline worth diffing:

| scenario | allocs/event |
|---|---|
| `interior`, both algorithms | **0** |
| `crossing/Strait`, any zone count | 1 (the cached travel-path `Vec` clone) |
| `crossing/Cross` @ 2 / 6 / 16 zones | 1 / 5 / 15 |
| `no_target/Cross` @ 2 / 6 / 16 zones | 1 / 5 / 15 |

Timings (Ryzen 9 9950X, `--quick`, machine-dependent): interior 11.7 ns; `crossing/Strait` flat at ~66 ns across all zone counts; `crossing/Cross` 91 → 253 → 660 ns.

Two shapes fall out, both predicted by the code rather than surprises: Strait resolves one link on one side and is flat in the zone count, while Cross scans every zone per event and pays one `Rect::intersect` `Vec` for each. Neither is a problem today — 660 ns leaves wide margin at a 1 kHz report rate — and the point is to have the numbers before anyone starts optimising.

## Documentation and thresholds

The README records the commands, the reference environment, and the fact that timings (unlike allocation counts) are machine-dependent and only comparable back-to-back on one machine. **No thresholds**: nothing in the suite fails on a timing.

`criterion` is a dev-dependency with `default-features = false` — no plotters, rayon or HTML reporter.

## Verification

- `cargo test` — 96 passed, 0 failed
- `cargo clippy --all-targets --all-features` — no errors, **zero warnings from the new targets** (the 15 lib + 1 `lbm-pattern` warnings are pre-existing on `master`)
- `cargo bench -- --test`, `-- --quick` and the allocation profile all run clean

One thing to flag: `cargo fmt --check` does not pass on `master`, over two test assertions in `src/engine/mod.rs`. That is pre-existing and unrelated; `cargo fmt` wanted to reformat them and I reverted it to keep this diff measurement-only. The new bench files are rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
