### PR TITLE
Make the hook crate rustfmt-clean

### DIFF
--- a/LittleBigMouse-Hook-Rust/src/engine/mod.rs
+++ b/LittleBigMouse-Hook-Rust/src/engine/mod.rs
@@ -1044,7 +1044,10 @@ mod tests {
         env.clip = game_clip;
         eng.restore_managed_clip(&mut env);
 
-        assert_eq!(env.clip, game_clip, "LBM must not overwrite a newer game clip");
+        assert_eq!(
+            env.clip, game_clip,
+            "LBM must not overwrite a newer game clip"
+        );
         assert!(eng.old_clip_rect.is_empty());
         assert!(eng.managed_clip_rect.is_empty());
     }
@@ -1059,7 +1062,10 @@ mod tests {
         env.clip = Rect::new(700, 300, 1920, 1080);
         env.clipped_sub = true;
 
-        assert_eq!(eng.freelook_reason(&env), Some(FreelookReason::ExternalClip));
+        assert_eq!(
+            eng.freelook_reason(&env),
+            Some(FreelookReason::ExternalClip)
+        );
     }
 
     #[test]


### PR DESCRIPTION
`cargo fmt --check` currently fails on a bare clone of `master`, over two test assertions in `LittleBigMouse-Hook-Rust/src/engine/mod.rs`. Running `cargo fmt` produces exactly those two hunks and nothing else, so this makes the check pass.

Whitespace only — no assertion, message or test behaviour changes.

Split out of #584 on purpose: that PR is measurement-only and should not carry an unrelated reformat of production code.

Worth having before GEN-07 (the `.editorconfig` / analysis-policy task), which will want `cargo fmt --check` green as a starting point.

## Verification

- `cargo fmt --check` — clean
- `cargo test` — 96 passed, 0 failed
- `cargo clippy --all-targets --all-features` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
