### PR TITLE
run-lbm.sh: wait for the UI to die before killing the daemon

### DIFF
--- a/run-lbm.sh
+++ b/run-lbm.sh
@@ -77,15 +77,74 @@ warn() { echo -e "${Y}!!  $*${N}"; }
 #    of them and the old instance survives, the relaunch dies on the
 #    single-instance lock, and you are left looking at the stale app with an empty
 #    log. EVIOCGRAB releases on process exit, so this also frees any grabbed mice.
+#
+#    ORDER AND WAITING BOTH MATTER, and for the same reason: the UI relaunches the
+#    daemon whenever it loses the connection. That contract is only suspended for a
+#    clean tray Exit (`_quitting`, see "Stop relaunching the daemon the UI is
+#    quitting"); a signal does not go through QuitAsync, so a SIGTERM'd UI keeps its
+#    reconnect loop running while it winds down. Kill the daemon while any UI is
+#    still breathing and it spawns a REPLACEMENT, which survives into the launch
+#    below still holding the mice — and with a different PID, so it reads as a kill
+#    that failed rather than a spawn that should not have happened.
+#
+#    pkill only delivers the signal, it does not wait. So: signal the UI, wait for
+#    it to actually be gone, and only then take the daemon.
 step "Stopping running instance(s)"
-UI_STOPPED=0
-pkill -f "LittleBigMouse.Ui.Avalonia.dl[l]" 2>/dev/null && UI_STOPPED=1
-pkill -f "LittleBigMouse.Ui.Avaloni[a]$" 2>/dev/null && UI_STOPPED=1
-# Anchored: /usr/lib/littlebigmouse/lbm-hook must stay for the daemon pkill below.
-pkill -f "littlebigmous[e]$" 2>/dev/null && UI_STOPPED=1
-[[ "$UI_STOPPED" -eq 1 ]] && note "UI stopped" || note "no UI running"
-pkill -x lbm-hook 2>/dev/null && note "daemon stopped" || note "no daemon running"
-sleep 1
+
+# Anchored patterns: /usr/lib/littlebigmouse/lbm-hook must survive these and be left
+# to the daemon pkill below. The bracketed letter keeps pkill off its own command line.
+UI_PATTERNS=(
+    "LittleBigMouse.Ui.Avalonia.dl[l]"
+    "LittleBigMouse.Ui.Avaloni[a]$"
+    "littlebigmous[e]$"
+)
+
+ui_running() {
+    local pattern
+    for pattern in "${UI_PATTERNS[@]}"; do
+        pgrep -f "$pattern" >/dev/null 2>&1 && return 0
+    done
+    return 1
+}
+
+wait_gone() {  # wait_gone <deciseconds> <predicate>
+    local tries="$1" predicate="$2"
+    while (( tries-- > 0 )); do
+        "$predicate" || return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+if ui_running; then
+    for pattern in "${UI_PATTERNS[@]}"; do pkill -f "$pattern" 2>/dev/null; done
+    if wait_gone 50 ui_running; then
+        note "UI stopped"
+    else
+        warn "UI still up 5s after SIGTERM — forcing"
+        for pattern in "${UI_PATTERNS[@]}"; do pkill -9 -f "$pattern" 2>/dev/null; done
+        wait_gone 20 ui_running || warn "UI survived SIGKILL — it may respawn the daemon below"
+    fi
+else
+    note "no UI running"
+fi
+
+# Nothing is left to respawn it now.
+hook_running() { pgrep -x lbm-hook >/dev/null 2>&1; }
+if hook_running; then
+    pkill -x lbm-hook 2>/dev/null
+    wait_gone 30 hook_running && note "daemon stopped" || warn "daemon did not exit"
+else
+    note "no daemon running"
+fi
+
+# A daemon back from the dead means something outside this script relaunched it.
+# Say so loudly: it is holding the mice, and building on top of it is how you end up
+# debugging the previous build's grab.
+sleep 0.5
+if hook_running; then
+    warn "a daemon reappeared after the kill (pid $(pgrep -x lbm-hook | tr '\n' ' ')) — it holds the mice"
+fi
 
 # 2. build the Rust daemon (non-fatal: stage whatever already exists on failure).
 if [[ "$NO_BUILD" -eq 0 && "$SKIP_DAEMON" -eq 0 ]]; then


### PR DESCRIPTION
## The bug

Stopping an instance could leave a daemon behind **holding the mice** — with a PID different from the one that was killed, so it read as a kill that failed rather than a spawn that should not have happened.

The order in the script was already correct: UI first, daemon second. What was missing is that **`pkill` only delivers the signal, it does not wait.**

The UI relaunches the daemon whenever it loses the connection. That contract is only suspended for a clean tray Exit (`_quitting`, from 6192462 "Stop relaunching the daemon the UI is quitting") — a signal does not go through `QuitAsync`. So a SIGTERM'd UI keeps its reconnect loop running the whole time it winds down:

1. `pkill` signals the UI; it starts shutting down but is still alive.
2. `pkill -x lbm-hook` kills the daemon.
3. The dying UI's listener takes the disconnect, fires `ConnectionFailed`, and launches a **replacement daemon**.
4. That successor survives into the build and launch below, still grabbing `/dev/input`.

## The fix

Signal the UI, **wait for it to actually be gone** (SIGKILL and say so if it outlasts five seconds), and only then take the daemon. Then check once more: a daemon reappearing after that point came from something outside this script, and building on top of a process holding the mice is how you end up debugging the previous build's grab.

## Verified

Against a **real hooked instance**, which is the case that matters — not just the idle path:

```
=== before stop ===
UI:     370459
daemon: 370502
grabs:  4

=== stop path ===
    UI stopped
    daemon stopped

=== after stop ===
UI:          []
daemon:      []
grabs input: 0
uinput:      0
virtuels:    0
```

No successor, no uinput handle, no virtual devices left. The idle path still reports `no UI running / no daemon running`, and `bash -n` is clean.

## Not affected

`run-lbm.ps1` uses `Stop-Process -Force`, which terminates immediately, so the UI never gets a shutdown window in which to relaunch anything. It is the graceful SIGTERM that opens this race — the bug is Linux-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)