### PR TITLE
Centralise KDE detection in LinuxDesktopEnvironment

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LinuxDesktopEnvironmentTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LinuxDesktopEnvironmentTests.cs
@@ -1,0 +1,69 @@
+using LittleBigMouse.Platform.Linux;
+using Xunit;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// The KScreen/Plasma code paths gate on <see cref="LinuxDesktopEnvironment.IsKde"/>.
+/// These pin the interpretation of the freedesktop variables: colon-separated priority
+/// lists, case-insensitivity, the "plasma" spelling, and the absent case that non-KDE
+/// sessions rely on to fall back to xrandr / skip the wallpaper and gap code.
+/// </summary>
+public class LinuxDesktopEnvironmentTests
+{
+    [Theory]
+    // Absent / empty: not KDE (non-KDE sessions must keep their xrandr fallback).
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    // Canonical KDE value, as reported by a Plasma session.
+    [InlineData("KDE", true)]
+    // The "plasma" spelling some setups use.
+    [InlineData("plasma", true)]
+    // Case variations.
+    [InlineData("kde", true)]
+    [InlineData("Kde", true)]
+    [InlineData("Plasma", true)]
+    [InlineData("PLASMA", true)]
+    // Colon-separated priority list: KDE present anywhere in the list.
+    [InlineData("ubuntu:KDE", true)]
+    [InlineData("KDE:X-Generic", true)]
+    [InlineData("foo:plasma:bar", true)]
+    // Non-KDE desktops stay non-KDE.
+    [InlineData("GNOME", false)]
+    [InlineData("ubuntu:GNOME", false)]
+    [InlineData("XFCE", false)]
+    [InlineData("sway", false)]
+    public void IsKde_from_xdg_current_desktop(string? xdgCurrentDesktop, bool expected)
+    {
+        var env = new LinuxDesktopEnvironment(xdgCurrentDesktop);
+        Assert.Equal(expected, env.IsKde);
+    }
+
+    [Fact]
+    public void DesktopSession_is_used_as_fallback_when_xdg_absent()
+    {
+        Assert.True(new LinuxDesktopEnvironment(null, "plasmawayland").IsKde);
+        Assert.True(new LinuxDesktopEnvironment(null, "plasma").IsKde);
+        Assert.False(new LinuxDesktopEnvironment(null, "gnome").IsKde);
+        Assert.False(new LinuxDesktopEnvironment(null, null).IsKde);
+    }
+
+    [Fact]
+    public void XdgCurrentDesktop_is_authoritative_when_present()
+    {
+        // A KDE XDG value stays KDE regardless of DESKTOP_SESSION.
+        Assert.True(new LinuxDesktopEnvironment("KDE", "gnome").IsKde);
+        // The DESKTOP_SESSION fallback only fires when XDG is absent: a present
+        // non-KDE XDG value is authoritative and is NOT overridden by the session.
+        Assert.False(new LinuxDesktopEnvironment("GNOME", "plasma").IsKde);
+        // An empty XDG (not just null) also falls through to the session.
+        Assert.True(new LinuxDesktopEnvironment("", "plasma").IsKde);
+    }
+
+    [Fact]
+    public void Current_reads_the_live_environment_without_throwing()
+    {
+        // Smoke test: the static accessor must be usable from the platform code.
+        _ = LinuxDesktopEnvironment.Current.IsKde;
+    }
+}

--- a/LittleBigMouse.Platform.Linux/KScreenGapGuard.cs
+++ b/LittleBigMouse.Platform.Linux/KScreenGapGuard.cs
@@ -30,7 +30,7 @@ public static class KScreenGapGuard
     // Gaps only matter for the Wayland portal backend: under X11 the daemon emulates
     // ClipCursor directly (no barriers), and without kscreen there is nothing to drive.
     static bool IsWaylandKde
-        => Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP")?.Contains("KDE", StringComparison.OrdinalIgnoreCase) == true
+        => LinuxDesktopEnvironment.Current.IsKde
            && (Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") == "wayland"
                || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY")));
 

--- a/LittleBigMouse.Platform.Linux/KScreenMonitorSource.cs
+++ b/LittleBigMouse.Platform.Linux/KScreenMonitorSource.cs
@@ -19,7 +19,7 @@ public class KScreenMonitorSource : ILinuxMonitorSource
     public string Name => "kscreen";
 
     public bool IsAvailable()
-        => Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP")?.Contains("KDE", StringComparison.OrdinalIgnoreCase) == true
+        => LinuxDesktopEnvironment.Current.IsKde
            && RunKScreenDoctor() != null;
 
     public List<LinuxMonitor> Query()

--- a/LittleBigMouse.Platform.Linux/LinuxDesktopEnvironment.cs
+++ b/LittleBigMouse.Platform.Linux/LinuxDesktopEnvironment.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+
+namespace LittleBigMouse.Platform.Linux;
+
+/// <summary>
+/// Interprets the freedesktop environment variables that tell us which desktop shell
+/// is running. Every KScreen/Plasma-specific code path used to inline the same
+/// <c>XDG_CURRENT_DESKTOP.Contains("KDE")</c> check; this type centralises that so the
+/// spelling of the check lives in one place and can be substituted in tests.
+///
+/// <para><c>XDG_CURRENT_DESKTOP</c> is, per the freedesktop spec, a colon-separated
+/// list of names in priority order (e.g. <c>"ubuntu:GNOME"</c>). We treat the session as
+/// KDE when any element names KDE or Plasma, case-insensitively. When that variable is
+/// absent we fall back to <c>DESKTOP_SESSION</c>, which display managers set to the
+/// session file name (e.g. <c>"plasma"</c>, <c>"plasmawayland"</c>).</para>
+///
+/// This is deliberately narrow: it is not a general cross-platform abstraction, only the
+/// one signal the Linux platform code needs.
+/// </summary>
+public sealed class LinuxDesktopEnvironment
+{
+    readonly string? _xdgCurrentDesktop;
+    readonly string? _desktopSession;
+
+    /// <param name="xdgCurrentDesktop">Raw value of <c>XDG_CURRENT_DESKTOP</c> (may be null).</param>
+    /// <param name="desktopSession">Raw value of <c>DESKTOP_SESSION</c> (may be null).</param>
+    public LinuxDesktopEnvironment(string? xdgCurrentDesktop, string? desktopSession = null)
+    {
+        _xdgCurrentDesktop = xdgCurrentDesktop;
+        _desktopSession = desktopSession;
+    }
+
+    /// <summary>The live process environment.</summary>
+    public static LinuxDesktopEnvironment Current { get; } = new(
+        Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP"),
+        Environment.GetEnvironmentVariable("DESKTOP_SESSION"));
+
+    /// <summary>
+    /// True when the current session is KDE Plasma. Matches the historical behaviour
+    /// (a "KDE" substring in <c>XDG_CURRENT_DESKTOP</c>) and additionally recognises the
+    /// "plasma" spelling and the <c>DESKTOP_SESSION</c> fallback.
+    /// </summary>
+    public bool IsKde
+        => string.IsNullOrEmpty(_xdgCurrentDesktop)
+            ? NamesKde(_desktopSession)   // XDG unset: fall back to the session file name
+            : NamesKde(_xdgCurrentDesktop);
+
+    static bool NamesKde(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+
+        // XDG_CURRENT_DESKTOP is a colon-separated priority list.
+        foreach (var token in value.Split(':', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Contains("KDE", StringComparison.OrdinalIgnoreCase)
+                || token.Contains("plasma", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/LittleBigMouse.Platform.Linux/LinuxDisplayController.cs
+++ b/LittleBigMouse.Platform.Linux/LinuxDisplayController.cs
@@ -57,8 +57,7 @@ public class LinuxDisplayController : IDisplayController
             _factory.NotifyDisplayChanged();
     }
 
-    static bool UseKScreen
-        => Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP")?.Contains("KDE", StringComparison.OrdinalIgnoreCase) == true;
+    static bool UseKScreen => LinuxDesktopEnvironment.Current.IsKde;
 
     public bool SetPrimary(DisplaySource source)
         => Notify(UseKScreen

--- a/LittleBigMouse.Platform.Linux/PlasmaWallpaperService.cs
+++ b/LittleBigMouse.Platform.Linux/PlasmaWallpaperService.cs
@@ -20,7 +20,7 @@ public class PlasmaWallpaperService : IWallpaperService
     bool? _isSupported;
 
     public bool IsSupported => _isSupported ??=
-        Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP")?.Contains("KDE", StringComparison.OrdinalIgnoreCase) == true
+        LinuxDesktopEnvironment.Current.IsKde
         && PlasmaWallpaper.EvaluateScript("print(\"ok\")") == "ok";
 
     public Task ApplyAsync(IReadOnlyList<ScreenWallpaper> screens)


### PR DESCRIPTION
LNX-03. The four ad-hoc `XDG_CURRENT_DESKTOP` checks (KScreenGapGuard, KScreenMonitorSource, LinuxDisplayController, PlasmaWallpaperService) collapse into one injectable `LinuxDesktopEnvironment`. Parses the colon-separated list case-insensitively per the freedesktop spec, recognises `KDE`/`plasma`, and falls back to `DESKTOP_SESSION` only when XDG is absent — a strict superset of the old substring match, identical on any real KDE session. 18 tests (absent/empty values, case variants, lists, XDG authority over the fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)