### PR TITLE
Extract calibration chart building into CalibrationChartModel

### DIFF
--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/CalibrationChartModelTests.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia.Tests/CalibrationChartModelTests.cs
@@ -1,0 +1,163 @@
+using HLab.Sys.Windows.MonitorVcp;
+using LittleBigMouse.Plugin.Vcp.Avalonia.Calibration;
+using LiveChartsCore;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.Effects;
+using SkiaSharp;
+using Xunit;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Tests;
+
+/// <summary>
+/// Locks the projection of calibration data onto the LiveCharts series and axes.
+/// These exercise the pure presentation factory extracted from the view model:
+/// no UI, no hardware, no async work — just the mapping of a <see cref="Tune"/>
+/// onto chart coordinates and the fixed colours/labels/limits of the axes.
+/// </summary>
+public class CalibrationChartModelTests
+{
+   static SKColor StrokeColor(ISeries series)
+      => ((SolidColorPaint)((LineSeries<Tune>)series).Stroke!).Color;
+
+   static Coordinate Map(ISeries series, Tune tune)
+      => ((LineSeries<Tune>)series).Mapping!(tune, 0);
+
+   static readonly Tune Sample = new()
+   {
+      Brightness = 42,
+      Y = 120,
+      Red = 200,
+      Green = 210,
+      Blue = 220,
+      DeltaE = 1.5,
+   };
+
+   [Fact]
+   public void BuildSeries_ProducesFiveLineSeriesInOrder()
+   {
+      var series = CalibrationChartModel.BuildSeries(null);
+
+      Assert.Equal(5, series.Length);
+      Assert.All(series, s => Assert.IsType<LineSeries<Tune>>(s));
+   }
+
+   [Fact]
+   public void BuildSeries_UsesTheExpectedStrokeColours()
+   {
+      var series = CalibrationChartModel.BuildSeries(null);
+
+      Assert.Equal(SKColors.White, StrokeColor(series[0]));
+      Assert.Equal(SKColors.Red, StrokeColor(series[1]));
+      Assert.Equal(SKColors.Green, StrokeColor(series[2]));
+      Assert.Equal(SKColors.Blue, StrokeColor(series[3]));
+      Assert.Equal(SKColors.Orange, StrokeColor(series[4]));
+   }
+
+   [Fact]
+   public void BuildSeries_MapsEachChannelToBrightnessAndItsValue()
+   {
+      var series = CalibrationChartModel.BuildSeries(null);
+
+      // X (secondary) is always the brightness step
+      Assert.All(series, s => Assert.Equal(Sample.Brightness, Map(s, Sample).SecondaryValue));
+
+      // Y (primary) is the channel this series charts
+      Assert.Equal(Sample.Y, Map(series[0], Sample).PrimaryValue);       // luminance / white
+      Assert.Equal(Sample.Red, Map(series[1], Sample).PrimaryValue);     // red gain
+      Assert.Equal(Sample.Green, Map(series[2], Sample).PrimaryValue);   // green gain
+      Assert.Equal(Sample.Blue, Map(series[3], Sample).PrimaryValue);    // blue gain
+      Assert.Equal(Sample.DeltaE, Map(series[4], Sample).PrimaryValue);  // ΔE00 marker
+   }
+
+   [Fact]
+   public void BuildSeries_AssignsSeriesToTheCorrectYAxis()
+   {
+      var series = CalibrationChartModel.BuildSeries(null).Cast<LineSeries<Tune>>().ToArray();
+
+      Assert.Equal(0, series[0].ScalesYAt); // nits
+      Assert.Equal(1, series[1].ScalesYAt); // gain
+      Assert.Equal(1, series[2].ScalesYAt); // gain
+      Assert.Equal(1, series[3].ScalesYAt); // gain
+      Assert.Equal(2, series[4].ScalesYAt); // ΔE00
+   }
+
+   [Fact]
+   public void BuildSeries_OnlyTheDeltaESeriesShowsAMarker()
+   {
+      var series = CalibrationChartModel.BuildSeries(null).Cast<LineSeries<Tune>>().ToArray();
+
+      // the four curves are strokes only, no geometry fill
+      Assert.All(series.Take(4), s =>
+      {
+         Assert.Null(s.GeometryFill);
+         Assert.Null(s.GeometryStroke);
+         Assert.Null(s.Fill);
+      });
+
+      var deltaE = series[4];
+      var geometryFill = Assert.IsType<SolidColorPaint>(deltaE.GeometryFill);
+      Assert.Equal(SKColors.Orange, geometryFill.Color);
+      Assert.Equal(6, deltaE.GeometrySize);
+      Assert.Null(deltaE.Fill);
+   }
+
+   [Fact]
+   public void BuildSeries_WithNullLutLeavesValuesUnset()
+   {
+      var series = CalibrationChartModel.BuildSeries(null).Cast<LineSeries<Tune>>().ToArray();
+
+      Assert.All(series, s => Assert.Null(s.Values));
+   }
+
+   [Fact]
+   public void BuildXAxes_IsASingleBrightnessAxis()
+   {
+      var axes = CalibrationChartModel.BuildXAxes(null);
+
+      var axis = Assert.Single(axes);
+      Assert.Equal("Brightness", axis.Name);
+      Assert.Equal(SKColors.Black, ((SolidColorPaint)axis.NamePaint!).Color);
+      Assert.Equal(SKColors.Blue, ((SolidColorPaint)axis.LabelsPaint!).Color);
+      Assert.Equal(10, axis.TextSize);
+      Assert.Equal(0, axis.MinLimit);
+      Assert.Null(axis.MaxLimit); // autoscales with the points
+   }
+
+   [Fact]
+   public void BuildYAxes_ProducesNitsGainAndDeltaEAxes()
+   {
+      var axes = CalibrationChartModel.BuildYAxes(null);
+
+      Assert.Equal(3, axes.Length);
+
+      var nits = axes[0];
+      Assert.Equal("nits", nits.Name);
+      Assert.Equal(SKColors.Red, ((SolidColorPaint)nits.NamePaint!).Color);
+      Assert.Equal(SKColors.Green, ((SolidColorPaint)nits.LabelsPaint!).Color);
+      Assert.Equal(20, nits.TextSize);
+      Assert.Equal(0, nits.MinLimit);
+      Assert.Null(nits.MaxLimit);
+      // dashed separators on the primary (left) axis
+      var nitsSeparators = Assert.IsType<SolidColorPaint>(nits.SeparatorsPaint);
+      Assert.IsType<DashEffect>(nitsSeparators.PathEffect);
+
+      var gain = axes[1];
+      Assert.Equal("Gain", gain.Name);
+      Assert.Equal(SKColors.Black, ((SolidColorPaint)gain.NamePaint!).Color);
+      Assert.Equal(SKColors.Blue, ((SolidColorPaint)gain.LabelsPaint!).Color);
+      Assert.Equal(10, gain.TextSize);
+      Assert.Equal(LiveChartsCore.Measure.AxisPosition.End, gain.Position);
+      Assert.Null(gain.MinLimit); // autoscale, no fixed limits
+
+      var deltaE = axes[2];
+      Assert.Equal("ΔE00", deltaE.Name);
+      Assert.Equal(SKColors.Orange, ((SolidColorPaint)deltaE.NamePaint!).Color);
+      Assert.Equal(SKColors.Orange, ((SolidColorPaint)deltaE.LabelsPaint!).Color);
+      Assert.Equal(10, deltaE.TextSize);
+      Assert.Equal(0, deltaE.MinLimit);
+      Assert.Equal(LiveChartsCore.Measure.AxisPosition.End, deltaE.Position);
+      Assert.Null(deltaE.SeparatorsPaint);
+   }
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/Calibration/CalibrationChartModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/Calibration/CalibrationChartModel.cs
@@ -1,0 +1,187 @@
+/*
+  LittleBigMouse.Plugin.Vcp.Avalonia
+  Copyright (c) 2021 Mathieu GRENET.  All right reserved.
+
+  This file is part of LittleBigMouse.Plugin.Vcp.Avalonia.
+
+    LittleBigMouse.Plugin.Vcp.Avalonia is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    LittleBigMouse.Plugin.Vcp.Avalonia is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with MouseControl.  If not, see <http://www.gnu.org/licenses/>.
+
+	  mailto:mathieu@mgth.fr
+	  http://www.mgth.fr
+*/
+
+using HLab.Sys.Windows.MonitorVcp;
+using LiveChartsCore;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.Effects;
+using SkiaSharp;
+
+namespace LittleBigMouse.Plugin.Vcp.Avalonia.Calibration;
+
+/// <summary>
+/// Pure presentation factory turning a <see cref="ProbeLut"/> into the LiveCharts
+/// series and axes used by the calibration curve. It knows nothing about the
+/// calibration algorithm, the DDC/CI hardware or the smart-TV clients, and never
+/// starts asynchronous work: given a lut, it produces the exact same series,
+/// colours, labels and axis settings the view model used to build inline.
+/// </summary>
+public static class CalibrationChartModel
+{
+   /// <summary>
+   /// Builds the calibration curve series for <paramref name="lut"/>.
+   /// The white/red/green/blue lines follow the smoothed lut; the ΔE00 marker
+   /// series follows the raw sorted lut. A null lut yields empty (null-valued)
+   /// series, exactly as the previous inline construction did.
+   /// </summary>
+   public static ISeries[] BuildSeries(ProbeLut? lut) =>
+   [
+      new LineSeries<Tune>
+      {
+            Values = lut?.SmoothLut,
+            Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Y),
+
+            Stroke = new SolidColorPaint(SKColors.White),
+            GeometryStroke = null,
+            GeometryFill = null,
+            Fill = null,
+
+      },
+
+      new LineSeries<Tune>
+      {
+            Values = lut?.SmoothLut,
+            Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Red),
+
+            Stroke = new SolidColorPaint(SKColors.Red),
+            GeometryStroke = null,
+            GeometryFill = null,
+            Fill = null,
+            ScalesYAt = 1
+      },
+      new LineSeries<Tune>
+      {
+            Values = lut?.SmoothLut,
+            Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Green),
+
+            Stroke = new SolidColorPaint(SKColors.Green),
+            GeometryStroke = null,
+            GeometryFill = null,
+            Fill = null,
+            ScalesYAt = 1
+      },
+      new LineSeries<Tune>
+      {
+            Values = lut?.SmoothLut,
+            Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Blue),
+
+            Stroke = new SolidColorPaint(SKColors.Blue),
+            GeometryStroke = null,
+            GeometryFill = null,
+            Fill = null,
+            ScalesYAt = 1
+      },
+
+      // measured ΔE00 after tuning, one point per brightness step
+      new LineSeries<Tune>
+      {
+            Values = lut?.SortedLut,
+            Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.DeltaE),
+
+            Stroke = new SolidColorPaint(SKColors.Orange),
+            GeometryStroke = null,
+            GeometryFill = new SolidColorPaint(SKColors.Orange),
+            GeometrySize = 6,
+            Fill = null,
+            ScalesYAt = 2
+      },
+
+   ];
+
+   /// <summary>
+   /// Builds the single horizontal (brightness) axis. The <paramref name="lut"/>
+   /// argument is kept for parity with the previous binding, which recomputed the
+   /// axes whenever the lut changed; the axis itself autoscales to the points.
+   /// </summary>
+   public static Axis[] BuildXAxes(ProbeLut? lut) =>
+   [
+      new Axis
+      {
+         Name = "Brightness",
+         NamePaint = new SolidColorPaint(SKColors.Black),
+
+         LabelsPaint = new SolidColorPaint(SKColors.Blue),
+         TextSize = 10,
+
+         SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray) { StrokeThickness = 2 }  ,
+         // no MaxLimit: autoscale follows the points as they land
+         MinLimit = 0,
+
+      },
+   ];
+
+   /// <summary>
+   /// Builds the three vertical axes: nits (left), gain (right), ΔE00 (right).
+   /// </summary>
+   public static Axis[] BuildYAxes(ProbeLut? lut) =>
+   [
+      new Axis
+      {
+         Name = "nits",
+         NamePaint = new SolidColorPaint(SKColors.Red),
+
+         LabelsPaint = new SolidColorPaint(SKColors.Green),
+         TextSize = 20,
+
+         SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray)
+         {
+            StrokeThickness = 2,
+            PathEffect = new DashEffect([3, 3])
+         }            ,
+         // no MaxLimit: autoscale follows the points as they land
+         MinLimit = 0,
+
+
+      },
+
+      new Axis
+      {
+         Name = "Gain",
+         NamePaint = new SolidColorPaint(SKColors.Black),
+
+         LabelsPaint = new SolidColorPaint(SKColors.Blue),
+         TextSize = 10,
+
+         SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray) { StrokeThickness = 2 }  ,
+         // autoscale: fixed limits computed at bind time went stale
+         // (and threw on an empty lut) once live measurements landed
+         Position = LiveChartsCore.Measure.AxisPosition.End
+      },
+
+      new Axis
+      {
+         Name = "ΔE00",
+         NamePaint = new SolidColorPaint(SKColors.Orange),
+
+         LabelsPaint = new SolidColorPaint(SKColors.Orange),
+         TextSize = 10,
+
+         SeparatorsPaint = null,
+         MinLimit = 0,
+         Position = LiveChartsCore.Measure.AxisPosition.End
+      }
+
+   ];
+}

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugin.Vcp.Avalonia/VcpScreenViewModel.cs
@@ -43,12 +43,8 @@ using LittleBigMouse.Plugin.Vcp.Avalonia.SamsungTizen;
 using LittleBigMouse.Plugin.Vcp.Avalonia.HisenseVidaa;
 using LittleBigMouse.Plugin.Vcp.Calibration;
 using LiveChartsCore;
-using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView;
-using LiveChartsCore.SkiaSharpView.Painting;
-using LiveChartsCore.SkiaSharpView.Painting.Effects;
 using ReactiveUI;
-using SkiaSharp;
 
 namespace LittleBigMouse.Plugin.Vcp.Avalonia;
 
@@ -329,148 +325,24 @@ public class VcpScreenViewModel : ViewModel<PhysicalMonitor>
           .DisposeWith(this);
 
 
+      // series and axes construction lives in CalibrationChartModel: a pure
+      // presentation factory that preserves the exact colours, labels, mappings
+      // and axis settings. The view model only wires the reactive bindings.
       _series = this.WhenAnyValue(
             e => e.ProbeLut)
-            .Select(lut => new ISeries[]
-            {
-               new LineSeries<Tune>
-               {
-                     Values = lut?.SmoothLut,
-                     Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Y),
-
-                     Stroke = new SolidColorPaint(SKColors.White),
-                     GeometryStroke = null,
-                     GeometryFill = null,
-                     Fill = null,
-
-               },
-
-               new LineSeries<Tune>
-               {
-                     Values = lut?.SmoothLut,
-                     Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Red),
-
-                     Stroke = new SolidColorPaint(SKColors.Red),
-                     GeometryStroke = null,
-                     GeometryFill = null,
-                     Fill = null,
-                     ScalesYAt = 1
-               },
-               new LineSeries<Tune>
-               {
-                     Values = lut?.SmoothLut,
-                     Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Green),
-
-                     Stroke = new SolidColorPaint(SKColors.Green),
-                     GeometryStroke = null,
-                     GeometryFill = null,
-                     Fill = null,
-                     ScalesYAt = 1
-               },
-               new LineSeries<Tune>
-               {
-                     Values = lut?.SmoothLut,
-                     Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.Blue),
-
-                     Stroke = new SolidColorPaint(SKColors.Blue),
-                     GeometryStroke = null,
-                     GeometryFill = null,
-                     Fill = null,
-                     ScalesYAt = 1
-               },
-
-               // measured ΔE00 after tuning, one point per brightness step
-               new LineSeries<Tune>
-               {
-                     Values = lut?.SortedLut,
-                     Mapping = (tune, index) => new Coordinate(tune.Brightness, tune.DeltaE),
-
-                     Stroke = new SolidColorPaint(SKColors.Orange),
-                     GeometryStroke = null,
-                     GeometryFill = new SolidColorPaint(SKColors.Orange),
-                     GeometrySize = 6,
-                     Fill = null,
-                     ScalesYAt = 2
-               },
-
-            })
+            .Select(CalibrationChartModel.BuildSeries)
             .ToProperty(this, e => e.Series)
             .DisposeWith(this);
 
       _xAxes = this.WhenAnyValue(
-            e => e.ProbeLut,
-            selector: e => e?.SortedLut)
-            .Select(lut => new Axis[]
-            {
-               new Axis
-               {
-                  Name = "Brightness",
-                  NamePaint = new SolidColorPaint(SKColors.Black),
-
-                  LabelsPaint = new SolidColorPaint(SKColors.Blue),
-                  TextSize = 10,
-
-                  SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray) { StrokeThickness = 2 }  ,
-                  // no MaxLimit: autoscale follows the points as they land
-                  MinLimit = 0,
-
-               },
-            })
+            e => e.ProbeLut)
+            .Select(CalibrationChartModel.BuildXAxes)
             .ToProperty(this, e => e.XAxes)
             .DisposeWith(this);
 
       _yAxes = this.WhenAnyValue(
-            e => e.ProbeLut,
-            selector: e => e?.SortedLut)
-            .Select(lut => new Axis[]
-            {
-               new Axis
-               {
-                  Name = "nits",
-                  NamePaint = new SolidColorPaint(SKColors.Red), 
-
-                  LabelsPaint = new SolidColorPaint(SKColors.Green), 
-                  TextSize = 20,
-
-                  SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray)
-                  {
-                     StrokeThickness = 2,
-                     PathEffect = new DashEffect([3, 3])
-                  }            ,
-                  // no MaxLimit: autoscale follows the points as they land
-                  MinLimit = 0,
-
-
-               },
-
-               new Axis
-               {
-                  Name = "Gain",
-                  NamePaint = new SolidColorPaint(SKColors.Black), 
-
-                  LabelsPaint = new SolidColorPaint(SKColors.Blue), 
-                  TextSize = 10,
-
-                  SeparatorsPaint = new SolidColorPaint(SKColors.LightSlateGray) { StrokeThickness = 2 }  ,
-                  // autoscale: fixed limits computed at bind time went stale
-                  // (and threw on an empty lut) once live measurements landed
-                  Position = LiveChartsCore.Measure.AxisPosition.End
-               },
-
-               new Axis
-               {
-                  Name = "ΔE00",
-                  NamePaint = new SolidColorPaint(SKColors.Orange),
-
-                  LabelsPaint = new SolidColorPaint(SKColors.Orange),
-                  TextSize = 10,
-
-                  SeparatorsPaint = null,
-                  MinLimit = 0,
-                  Position = LiveChartsCore.Measure.AxisPosition.End
-               }
-
-            })
+            e => e.ProbeLut)
+            .Select(CalibrationChartModel.BuildYAxes)
             .ToProperty(this, e => e.YAxes)
             .DisposeWith(this);
    }


### PR DESCRIPTION
GEN-05. The LiveCharts axes/series construction leaves `VcpScreenViewModel` (~140 inline lines) for a pure static presentation factory, `Calibration/CalibrationChartModel` (`BuildSeries`/`BuildXAxes`/`BuildYAxes` from a `ProbeLut?`). Rendering preserved verbatim — series order, colours, mappings, `ScalesYAt`, axis names/limits/positions, dashed nit separators. The view model keeps its three OAPHs as Avalonia binding points and just delegates. The new type knows nothing of Samsung/Hisense and starts no async work. 8 projection/axis tests, no real UI needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)