### PR TITLE
Split daemon process and recovery state out of LittleBigMouseClientService

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DaemonProcessManagerTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/DaemonProcessManagerTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The daemon <em>process</em> lifecycle, driven through a simulated process host and file seams so
+/// no real daemon is ever spawned (spawning one would capture the machine's mice) and no test
+/// touches the real per-user data directory. Covers the four things this manager is responsible
+/// for: launching at most one, not launching over a live one, force-stopping only what it owns, and
+/// releasing its handle on disposal without killing the daemon.
+/// </summary>
+public sealed class DaemonProcessManagerTests
+{
+    /// <summary>A simulated process. Never touches the OS.</summary>
+    sealed class FakeProcess(string name, int id, int sessionId) : IDaemonProcess
+    {
+        public bool HasExited { get; set; }
+        public int SessionId { get; } = sessionId;
+        public int Id { get; } = id;
+        public string ProcessName { get; } = name;
+
+        public bool StopRefused { get; set; }
+        public int StopCalls { get; private set; }
+        public bool Disposed { get; private set; }
+
+        public bool TryStop()
+        {
+            StopCalls++;
+            if (StopRefused) return false;
+            HasExited = true;
+            return true;
+        }
+
+        public void Dispose() => Disposed = true;
+    }
+
+    sealed class FakeProcessHost : IProcessHost
+    {
+        public int CurrentSessionId { get; set; } = 1;
+
+        /// <summary>Processes visible to enumeration.</summary>
+        public List<FakeProcess> Running { get; } = [];
+
+        /// <summary>Every handle enumeration has handed out — to assert they get disposed.</summary>
+        public List<FakeProcess> Handed { get; } = [];
+
+        public List<FakeProcess> Launched { get; } = [];
+        public Func<string, FakeProcess>? LaunchFactory { get; set; }
+        public Exception? LaunchThrows { get; set; }
+
+        public IEnumerable<IDaemonProcess> Enumerate(IEnumerable<string> processNames)
+        {
+            var names = processNames.ToHashSet();
+            // Snapshot so a TryStop that flips HasExited mid-iteration is fine.
+            foreach (var process in Running.Where(p => names.Contains(p.ProcessName)).ToList())
+            {
+                Handed.Add(process);
+                yield return process;
+            }
+        }
+
+        public IDaemonProcess Launch(string path)
+        {
+            if (LaunchThrows is not null) throw LaunchThrows;
+            var process = LaunchFactory?.Invoke(path)
+                          ?? new FakeProcess("lbm-hook", 1000 + Launched.Count, CurrentSessionId);
+            Launched.Add(process);
+            Running.Add(process);
+            return process;
+        }
+    }
+
+    /// <summary>A manager wired to fakes: a fixed hook path and a no-op exclusion-file seed.</summary>
+    static DaemonProcessManager Manager(FakeProcessHost host, string? hookPath = "/fake/lbm-hook")
+        => new(host, seedExcludedFile: () => { }, resolveHookPath: () => hookPath);
+
+    [Fact]
+    public void ADaemonIsLaunchedWhenNoneIsRunning()
+    {
+        var host = new FakeProcessHost();
+        var manager = Manager(host);
+
+        manager.LaunchDaemon();
+
+        Assert.Single(host.Launched);
+    }
+
+    [Fact]
+    public void TheExclusionFileIsSeededBeforeLaunch()
+    {
+        var host = new FakeProcessHost();
+        var seeded = false;
+        var manager = new DaemonProcessManager(host,
+            seedExcludedFile: () => seeded = true, resolveHookPath: () => "/fake/lbm-hook");
+
+        manager.LaunchDaemon();
+
+        Assert.True(seeded);
+        Assert.Single(host.Launched);
+    }
+
+    [Fact]
+    public void ASeedFailureDoesNotAbortTheLaunch()
+    {
+        // Seeding the exclusion file is best-effort; the daemon must still start.
+        var host = new FakeProcessHost();
+        var manager = new DaemonProcessManager(host,
+            seedExcludedFile: () => throw new System.IO.IOException("disk full"),
+            resolveHookPath: () => "/fake/lbm-hook");
+
+        manager.LaunchDaemon();
+
+        Assert.Single(host.Launched);
+    }
+
+    [Fact]
+    public void NothingLaunchesWhenTheHookExecutableCannotBeFound()
+    {
+        var host = new FakeProcessHost();
+        var manager = Manager(host, hookPath: null);
+
+        manager.LaunchDaemon();
+
+        Assert.Empty(host.Launched);
+    }
+
+    [Fact]
+    public void ADaemonAlreadyRunningIsNotLaunchedAgain()
+    {
+        var host = new FakeProcessHost();
+        host.Running.Add(new FakeProcess("lbm-hook", 42, host.CurrentSessionId));
+        var manager = Manager(host);
+
+        manager.LaunchDaemon();
+
+        Assert.Empty(host.Launched);
+    }
+
+    [Fact]
+    public void AnAlreadyRunningCheckDisposesEveryEnumeratedHandle()
+    {
+        // Enumerated handles are short-lived: the manager must dispose each one it inspects.
+        var host = new FakeProcessHost();
+        var live = new FakeProcess("lbm-hook", 42, host.CurrentSessionId);
+        host.Running.Add(live);
+        var manager = Manager(host);
+
+        manager.LaunchDaemon();
+
+        Assert.True(live.Disposed);
+    }
+
+    [Fact]
+    public void AnExitedProcessDoesNotBlockARelaunch()
+    {
+        var host = new FakeProcessHost();
+        host.Running.Add(new FakeProcess("lbm-hook", 42, host.CurrentSessionId) { HasExited = true });
+        var manager = Manager(host);
+
+        manager.LaunchDaemon();
+
+        Assert.Single(host.Launched);
+        Assert.All(host.Handed, p => Assert.True(p.Disposed));
+    }
+
+    [Fact]
+    public void ReplacingTheLaunchedHandleDisposesThePreviousOne()
+    {
+        var host = new FakeProcessHost();
+        var manager = Manager(host);
+
+        manager.LaunchDaemon();
+        var first = host.Launched.Single();
+        // The first handle stays visible-but-exited so the second launch's guard lets it through.
+        first.HasExited = true;
+
+        manager.LaunchDaemon();
+
+        Assert.Equal(2, host.Launched.Count);
+        Assert.True(first.Disposed);
+    }
+
+    [Fact]
+    public void OnUnixStopKillsOnlyTheLaunchedInstance()
+    {
+        if (OperatingSystem.IsWindows()) return; // Unix-only ownership rule.
+
+        var host = new FakeProcessHost();
+        var mine = new FakeProcess("lbm-hook", 1000, host.CurrentSessionId);
+        host.LaunchFactory = _ => mine;
+        var manager = Manager(host);
+        manager.LaunchDaemon();
+
+        // A foreign daemon this UI never launched appears afterwards — must be left alone: the
+        // Unix path stops only the owned handle and never enumerates.
+        var foreign = new FakeProcess("lbm-hook", 7, sessionId: 2);
+        host.Running.Add(foreign);
+
+        var stopped = manager.StopCurrentSessionDaemons();
+
+        Assert.True(stopped);
+        Assert.Equal(1, mine.StopCalls);
+        Assert.Equal(0, foreign.StopCalls); // never touched
+    }
+
+    [Fact]
+    public void OnUnixWithNothingLaunchedStopReportsClearOnlyWhenNoDaemonLingers()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var host = new FakeProcessHost();
+        var manager = Manager(host);
+
+        // No launched instance and no lbm-hook in the table → nothing lingers → "stopped".
+        Assert.True(manager.StopCurrentSessionDaemons());
+
+        // A live foreign daemon means the field is not clear (but it is not ours to kill).
+        host.Running.Add(new FakeProcess("lbm-hook", 7, 2));
+        Assert.False(manager.StopCurrentSessionDaemons());
+    }
+
+    [Fact]
+    public void StopReportsFailureWhenTheProcessRefusesToDie()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var host = new FakeProcessHost();
+        var mine = new FakeProcess("lbm-hook", 1000, host.CurrentSessionId) { StopRefused = true };
+        host.LaunchFactory = _ => mine;
+        var manager = Manager(host);
+        manager.LaunchDaemon();
+
+        Assert.False(manager.StopCurrentSessionDaemons());
+        Assert.Equal(1, mine.StopCalls);
+    }
+
+    [Fact]
+    public void DisposeReleasesTheOwnedHandleWithoutKillingTheDaemon()
+    {
+        var host = new FakeProcessHost();
+        var mine = new FakeProcess("lbm-hook", 1000, host.CurrentSessionId);
+        host.LaunchFactory = _ => mine;
+        var manager = Manager(host);
+        manager.LaunchDaemon();
+
+        manager.Dispose();
+
+        Assert.True(mine.Disposed);      // handle released
+        Assert.Equal(0, mine.StopCalls); // but NOT force-stopped
+        Assert.False(mine.HasExited);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RecoveryStateStoreTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/RecoveryStateStoreTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using LittleBigMouse.Ui.Avalonia.Remote;
+using LittleBigMouse.Zoning;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// What gets written to the crash-recovery / autostart file, and when. The daemon replays this
+/// file at boot with no UI reachable, so the decision of "remember this / don't / strip the Run
+/// line" is the whole safety contract — a client's foreign geometry replayed over the local
+/// desktop, or a stopped layout that re-hooks the mouse, both start here.
+/// </summary>
+public sealed class RecoveryStateStoreTests
+{
+    /// <summary>A recovery writer that records instead of touching disk, and can be told to fail.</summary>
+    sealed class FakeWriter : IRecoveryFileWriter
+    {
+        public string? WrittenPath { get; private set; }
+        public string? WrittenContent { get; private set; }
+        public int Writes { get; private set; }
+        public int MarkStoppedCalls { get; private set; }
+
+        public Exception? WriteThrows { get; set; }
+        public Exception? MarkStoppedThrows { get; set; }
+
+        public Task WriteAsync(string path, string content, CancellationToken token)
+        {
+            if (WriteThrows is not null) throw WriteThrows;
+            Writes++;
+            WrittenPath = path;
+            WrittenContent = content;
+            return Task.CompletedTask;
+        }
+
+        public Task MarkStoppedAsync(string path, CancellationToken token)
+        {
+            if (MarkStoppedThrows is not null) throw MarkStoppedThrows;
+            MarkStoppedCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    const string Path = "/fake/Current.xml";
+
+    static RecoveryStateStore Store(FakeWriter writer) => new(writer, Path);
+
+    static CommandMessage Load(bool virtualLayout = false)
+        => new(LittleBigMouseCommand.Load, new ZonesLayout { Virtual = virtualLayout });
+
+    static CommandMessage Run() => new(LittleBigMouseCommand.Run);
+    static CommandMessage Stop() => new(LittleBigMouseCommand.Stop, (ZonesLayout?)null);
+
+    [Fact]
+    public async Task ARealLoadIsWrittenToTheRecoveryFile()
+    {
+        var writer = new FakeWriter();
+
+        var failure = await Store(writer).PersistAsync([Load(), Run()], persist: true);
+
+        Assert.Null(failure);
+        Assert.Equal(1, writer.Writes);
+        Assert.Equal(Path, writer.WrittenPath);
+        // Both lines land, newline-terminated: the daemon reads it back line by line.
+        Assert.Contains("Command=\"Load\"", writer.WrittenContent);
+        Assert.Contains("Command=\"Run\"", writer.WrittenContent);
+        Assert.EndsWith("\n", writer.WrittenContent);
+    }
+
+    [Fact]
+    public async Task AVirtualLoadIsNeverPersisted()
+    {
+        // A standalone daemon must not replay a client's geometry over the local desktop.
+        var writer = new FakeWriter();
+
+        var failure = await Store(writer).PersistAsync([Load(virtualLayout: true), Run()], persist: true);
+
+        Assert.Null(failure);
+        Assert.Equal(0, writer.Writes);
+        Assert.Equal(0, writer.MarkStoppedCalls);
+    }
+
+    [Fact]
+    public async Task ANonPersistingSendWritesNothing()
+    {
+        // Live preview: the recovery file keeps describing the last applied layout.
+        var writer = new FakeWriter();
+
+        var failure = await Store(writer).PersistAsync([Load(), Run()], persist: false);
+
+        Assert.Null(failure);
+        Assert.Equal(0, writer.Writes);
+    }
+
+    [Fact]
+    public async Task AStopStripsTheRunLineFromTheExistingFile()
+    {
+        var writer = new FakeWriter();
+
+        var failure = await Store(writer).PersistAsync([Stop()], persist: true);
+
+        Assert.Null(failure);
+        Assert.Equal(0, writer.Writes);
+        Assert.Equal(1, writer.MarkStoppedCalls);
+    }
+
+    [Fact]
+    public async Task AFailedLoadWriteIsReturnedSoTheCallerCanSurfaceIt()
+    {
+        // The live layout was applied but recovery is stale: the caller turns this into the
+        // "settings could not be saved" warning.
+        var writer = new FakeWriter { WriteThrows = new IOException("disk full") };
+
+        var failure = await Store(writer).PersistAsync([Load(), Run()], persist: true);
+
+        Assert.IsType<IOException>(failure);
+    }
+
+    [Fact]
+    public async Task AnXmlFailureOnLoadIsAlsoReturned()
+    {
+        var writer = new FakeWriter { WriteThrows = new XmlException("bad") };
+
+        var failure = await Store(writer).PersistAsync([Load(), Run()], persist: true);
+
+        Assert.IsType<XmlException>(failure);
+    }
+
+    [Fact]
+    public async Task AFailedStopIsSwallowedNeverReturned()
+    {
+        // Stop is a safety operation: a persistence failure must never fault it.
+        var writer = new FakeWriter { MarkStoppedThrows = new UnauthorizedAccessException() };
+
+        var failure = await Store(writer).PersistAsync([Stop()], persist: true);
+
+        Assert.Null(failure);
+    }
+
+    [Fact]
+    public async Task ALoadTakesPrecedenceOverAStopInTheSameBatch()
+    {
+        // A batch with both a real Load and a Stop is a Start-shaped send: write, don't strip.
+        var writer = new FakeWriter();
+
+        var failure = await Store(writer).PersistAsync([Load(), Stop()], persist: true);
+
+        Assert.Null(failure);
+        Assert.Equal(1, writer.Writes);
+        Assert.Equal(0, writer.MarkStoppedCalls);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/DaemonProcessManager.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/DaemonProcessManager.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugins;
+
+namespace LittleBigMouse.Ui.Avalonia.Remote;
+
+/// <summary>
+/// Owns the hook daemon <em>process</em>: locating its executable, launching it (at most one),
+/// force-stopping the one this UI started, and seeding the exclusion file the daemon reads.
+/// Pulled out of <see cref="LittleBigMouseClientService"/> so the process ownership rules and the
+/// stop/relaunch behaviour live in one testable place — the IPC transport and the recovery file
+/// are separate concerns (<see cref="LocalIpcClient"/>, <see cref="RecoveryStateStore"/>).
+/// <para>
+/// <b>Process ownership.</b> The single daemon this manager launches is held in
+/// <see cref="_daemonProcess"/> and owned for the manager's lifetime: it is disposed either when
+/// replaced by a newer launch or when the manager itself is disposed. Handles obtained by
+/// <see cref="IProcessHost.Enumerate"/> (foreign or otherwise) are short-lived and disposed as
+/// soon as they are inspected — never retained. On Unix the manager will only ever stop the
+/// instance it launched (enumerating every <c>lbm-hook</c> could target another user's process,
+/// especially if the UI runs as root); on Windows it may stop any hook image in its own logon
+/// session as a last resort.
+/// </para>
+/// <para>
+/// <b>Disposal.</b> <see cref="Dispose"/> releases the owned launch handle only. It does NOT kill
+/// the daemon: a Stop/Quit is an explicit user action routed through <see cref="StopCurrentSessionDaemons"/>,
+/// and simply disposing the UI must leave a running daemon alone (autostart owns it thereafter).
+/// </para>
+/// </summary>
+public sealed class DaemonProcessManager : IDisposable
+{
+    readonly IProcessHost _host;
+    readonly Action _seedExcludedFile;
+    readonly Func<string?> _resolveHookPath;
+    readonly object _launchGate = new();
+    IDaemonProcess? _daemonProcess;
+
+    public DaemonProcessManager() : this(new SystemProcessHost())
+    {
+    }
+
+    /// <param name="host">The OS process seam.</param>
+    /// <param name="seedExcludedFile">
+    /// Seeds the exclusion file the daemon reads (see <see cref="CreateExcludedFile"/>). Injectable
+    /// so tests can supply a no-op and stay off the real per-user data directory; defaults to the
+    /// production writer.
+    /// </param>
+    /// <param name="resolveHookPath">
+    /// Locates the hook executable (see <see cref="FindHookPath"/>). Injectable so tests can return
+    /// a fixed path without the daemon binary being present; defaults to the real probe.
+    /// </param>
+    public DaemonProcessManager(IProcessHost host, Action? seedExcludedFile = null,
+        Func<string?>? resolveHookPath = null)
+    {
+        _host = host;
+        _seedExcludedFile = seedExcludedFile ?? CreateExcludedFile;
+        _resolveHookPath = resolveHookPath ?? FindHookPath;
+    }
+
+    /// <summary>
+    /// Launch the daemon unless one is already running (in this session, on Windows). The
+    /// check-and-launch sequence is atomic: the IPC listener and a foreground command can both
+    /// observe a missing endpoint, and must not start two daemons.
+    /// </summary>
+    public void LaunchDaemon()
+    {
+        lock (_launchGate)
+        {
+            if (IsDaemonRunning()) return;
+
+            var path = _resolveHookPath();
+            if (path is null)
+            {
+                Debug.WriteLine($"Not found : {HookExeName}");
+                return;
+            }
+
+            // Must not abort the daemon launch if the exclusion file can't be written.
+            try { _seedExcludedFile(); }
+            catch (Exception ex) { Debug.WriteLine($"CreateExcludedFile failed: {ex.Message}"); }
+
+            try
+            {
+                var process = _host.Launch(path);
+                _daemonProcess?.Dispose();
+                _daemonProcess = process;
+                Debug.WriteLine($"Started : {process.ProcessName} {process.Id}");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"LaunchDaemon failed: {ex}");
+            }
+        }
+    }
+
+    bool IsDaemonRunning()
+    {
+        foreach (var process in _host.Enumerate(HookProcessNames))
+        {
+            using (process)
+            {
+                if (process.HasExited) continue;
+                if (OperatingSystem.IsWindows()
+                    && process.SessionId != _host.CurrentSessionId) continue;
+                Debug.WriteLine($"Already running : {process.ProcessName} {process.Id}");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Force-stop the daemon as a last resort when IPC could not deliver a clean Stop.
+    /// </summary>
+    /// <returns>True if no hook daemon is left running afterwards.</returns>
+    public bool StopCurrentSessionDaemons()
+    {
+        // On Unix, process names are not scoped to a Windows-style logon session. Only terminate
+        // the daemon instance this UI actually launched; enumerating every "lbm-hook" could
+        // otherwise target another user's process (especially if the UI itself is running as root).
+        if (!OperatingSystem.IsWindows())
+        {
+            if (_daemonProcess is not null) return _daemonProcess.TryStop();
+
+            var daemonFound = false;
+            foreach (var process in _host.Enumerate([HookProcessNames[0]]))
+            {
+                using (process)
+                    daemonFound |= !process.HasExited;
+            }
+            return !daemonFound;
+        }
+
+        var stopped = true;
+        var session = _host.CurrentSessionId;
+        foreach (var process in _host.Enumerate(HookProcessNames))
+        {
+            using (process)
+            {
+                if (process.HasExited || process.SessionId != session) continue;
+                if (!process.TryStop()) stopped = false;
+            }
+        }
+        return stopped;
+    }
+
+    /// <summary>
+    /// Last-resort seed of the exclusion list, right before the daemon starts reading it.
+    /// <see cref="LittleBigMouse.Plugins.Persistence.ExcludedListPersistence"/> normally gets
+    /// there first (loading a layout precedes launching the daemon) and writes the same content,
+    /// header included; this stays as the guard for any path that reaches the daemon without a
+    /// load, where the alternative is a daemon running with no exclusions at all. Both must keep
+    /// writing the same thing.
+    /// </summary>
+    static void CreateExcludedFile()
+    {
+        var dir = LbmPaths.DataDir;
+        var file = Path.Combine(dir, "Excluded.txt");
+        if (File.Exists(file)) return;
+
+        Directory.CreateDirectory(dir);
+        // Self-heal: a buggy earlier version created "Excluded.txt" as a *directory*.
+        if (Directory.Exists(file)) Directory.Delete(file, true);
+        var lines = new[] { ExcludedProcessDefaults.Header }.Concat(ExcludedProcessDefaults.All);
+        File.WriteAllText(file, string.Join("\n", lines) + "\n");
+    }
+
+    // Deployed Windows builds keep the historical staging name (CI renames the Rust binary to it);
+    // a dev-tree Rust daemon runs under its cargo binary name on every platform.
+    static string HookExeName => OperatingSystem.IsWindows() ? "LittleBigMouse.Hook.exe" : "lbm-hook";
+
+    static string[] HookProcessNames => OperatingSystem.IsWindows()
+        ? ["LittleBigMouse.Hook", "lbm-hook"]
+        : ["lbm-hook"];
+
+    /// <summary>
+    /// Locate the hook daemon without depending on the .NET target framework folder
+    /// (net8.0, net9.0, net10.0, ...). Deployed builds keep the hook next to the UI; in the dev
+    /// tree the Rust hook is built under LittleBigMouse-Hook-Rust/target.
+    /// Resistant to .NET version, platform (AnyCPU/x64) and configuration (Debug/Release) changes.
+    /// </summary>
+    static string? FindHookPath()
+    {
+        var uiDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        // 1. Deployed / published build: the hook sits right next to the UI.
+        var sibling = Path.Combine(uiDir, HookExeName);
+        if (File.Exists(sibling)) return sibling;
+
+        // 2. Dev tree: find the hook build output and search it.
+        try
+        {
+            var projectSegment = Path.Combine("LittleBigMouse.Ui", "LittleBigMouse.Ui.Avalonia");
+            var i = uiDir.IndexOf(projectSegment, StringComparison.OrdinalIgnoreCase);
+            if (i < 0) return null;
+            var root = uiDir[..i];
+
+            // Prefer the build matching the UI's current configuration.
+            var sep = Path.DirectorySeparatorChar;
+            var config = uiDir.Contains($"{sep}Debug{sep}", StringComparison.OrdinalIgnoreCase) ? "Debug" : "Release";
+
+            // Rust daemon first: LittleBigMouse-Hook-Rust/target/{debug,release}/lbm-hook[.exe].
+            var rustExe = OperatingSystem.IsWindows() ? "lbm-hook.exe" : "lbm-hook";
+            var target = Path.Combine(root, "LittleBigMouse-Hook-Rust", "target");
+            var rust = new[]
+                {
+                    Path.Combine(target, config.ToLowerInvariant(), rustExe),
+                    Path.Combine(target, "release", rustExe),
+                    Path.Combine(target, "debug", rustExe),
+                }
+                .FirstOrDefault(File.Exists);
+            return rust;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Release the owned launch handle. Does not stop the daemon — see the type remarks.
+    /// </summary>
+    public void Dispose()
+    {
+        _daemonProcess?.Dispose();
+        _daemonProcess = null;
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/IProcessHost.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/IProcessHost.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace LittleBigMouse.Ui.Avalonia.Remote;
+
+/// <summary>
+/// The operating-system process operations <see cref="DaemonProcessManager"/> needs, isolated
+/// behind a seam so its ownership and stop/relaunch logic can be tested without spawning real
+/// daemons. Production is <see cref="SystemProcessHost"/>, a thin wrapper over
+/// <see cref="System.Diagnostics.Process"/>.
+/// </summary>
+public interface IProcessHost
+{
+    /// <summary>The session this UI runs in — used only on Windows to scope hook enumeration.</summary>
+    int CurrentSessionId { get; }
+
+    /// <summary>Every live-or-dead process currently matching one of the given image names.</summary>
+    IEnumerable<IDaemonProcess> Enumerate(IEnumerable<string> processNames);
+
+    /// <summary>
+    /// Start the daemon executable at <paramref name="path"/>. Returns the owned handle. Throws on
+    /// launch failure; the caller decides how loudly to fail.
+    /// </summary>
+    IDaemonProcess Launch(string path);
+}
+
+/// <summary>
+/// A handle to a (possibly foreign) daemon process. Enumerated handles are owned by the caller and
+/// must be disposed; the one returned by <see cref="IProcessHost.Launch"/> is owned by
+/// <see cref="DaemonProcessManager"/> for the lifetime of the service.
+/// </summary>
+public interface IDaemonProcess : System.IDisposable
+{
+    bool HasExited { get; }
+    int SessionId { get; }
+    int Id { get; }
+    string ProcessName { get; }
+
+    /// <summary>Force-stop the process tree and wait briefly. True if it is gone afterwards.</summary>
+    bool TryStop();
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/LittleBigMouseClientService.cs
@@ -1,26 +1,35 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using LittleBigMouse.Plugins;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using Avalonia.Threading;
 using LittleBigMouse.DisplayLayout.Monitors;
 using LittleBigMouse.Zoning;
 
 namespace LittleBigMouse.Ui.Avalonia.Remote;
 
+/// <summary>
+/// Turns the UI's Start/Stop/live-preview intentions into daemon commands. It coordinates three
+/// concerns, each owned by its own component:
+/// <list type="bullet">
+/// <item><see cref="LocalIpcClient"/> — the named-pipe / socket transport and reconnect loop.</item>
+/// <item><see cref="DaemonProcessManager"/> — launching and force-stopping the hook process.</item>
+/// <item><see cref="RecoveryStateStore"/> — the crash-recovery / autostart file.</item>
+/// </list>
+/// This class keeps the policy that ties them together: what a Start sends, when the topology
+/// prologue runs, and how a lost-IPC Stop falls back to killing the process.
+/// </summary>
 public class LittleBigMouseClientService : ILittleBigMouseClientService, IDisposable
 {
     public event EventHandler<LittleBigMouseServiceEventArgs>? DaemonEventReceived;
     readonly LocalIpcClient _client;
-
-
+    readonly DaemonProcessManager _processManager;
+    readonly RecoveryStateStore _recovery;
 
     protected void OnStateChanged(LittleBigMouseEvent evt, string payload = "")
     {
@@ -35,9 +44,17 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
     readonly ILayoutOptions _options;
 
     public LittleBigMouseClientService(ILayoutOptions options, IDisplayController displayController)
+        : this(options, displayController, new DaemonProcessManager(), new RecoveryStateStore())
+    {
+    }
+
+    internal LittleBigMouseClientService(ILayoutOptions options, IDisplayController displayController,
+        DaemonProcessManager processManager, RecoveryStateStore recovery)
     {
         _displayController = displayController;
         _options = options;
+        _processManager = processManager;
+        _recovery = recovery;
         _client = new LocalIpcClient();
 
         _client.ConnectionFailed += (sender, args) =>
@@ -136,7 +153,7 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
             // Stop is a safety operation: losing IPC must not leave the input
             // hook active or fault ReactiveCommand's observable pipeline. Kill
             // only known hook images in this logon session as the last resort.
-            var stopped = ForceStopCurrentSessionDaemons();
+            var stopped = _processManager.StopCurrentSessionDaemons();
             Debug.WriteLine($"Stop IPC failed; daemon fallback stopped={stopped}: {error}");
             OnStateChanged(stopped ? LittleBigMouseEvent.Stopped : LittleBigMouseEvent.Dead);
         }
@@ -149,192 +166,7 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
         await Task.Run(_displayController.RestoreAfterEngine, token);
     }
 
-    readonly object _daemonLaunchGate = new();
-    Process? _daemonProcess;
-
-    bool ForceStopCurrentSessionDaemons()
-    {
-        // On Unix, process names are not scoped to a Windows-style logon session.
-        // Only terminate the daemon instance this UI actually launched; enumerating
-        // every "lbm-hook" could otherwise target another user's process (especially
-        // if the UI itself is running as root).
-        if (!OperatingSystem.IsWindows())
-        {
-            if (_daemonProcess is not null) return TryStopProcess(_daemonProcess);
-
-            var daemonFound = false;
-            foreach (var process in Process.GetProcessesByName(HookProcessNames[0]))
-            {
-                using (process)
-                    daemonFound |= !process.HasExited;
-            }
-            return !daemonFound;
-        }
-
-        var stopped = true;
-        var session = Process.GetCurrentProcess().SessionId;
-        foreach (var name in HookProcessNames)
-        foreach (var process in Process.GetProcessesByName(name))
-        {
-            using (process)
-            {
-                if (process.HasExited || process.SessionId != session) continue;
-                if (!TryStopProcess(process)) stopped = false;
-            }
-        }
-        return stopped;
-    }
-
-    static bool TryStopProcess(Process process)
-    {
-        try
-        {
-            if (process.HasExited) return true;
-            process.Kill(entireProcessTree: true);
-            return process.WaitForExit(2000);
-        }
-        catch (Exception error) when (error is InvalidOperationException
-                                      or System.ComponentModel.Win32Exception
-                                      or NotSupportedException)
-        {
-            Debug.WriteLine($"Could not force-stop {process.ProcessName}: {error.Message}");
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Last-resort seed of the exclusion list, right before the daemon starts reading it.
-    /// <see cref="LittleBigMouse.Plugins.Persistence.ExcludedListPersistence"/> normally
-    /// gets there first (loading a layout precedes launching the daemon) and writes the
-    /// same content, header included; this stays as the guard for any path that reaches
-    /// the daemon without a load, where the alternative is a daemon running with no
-    /// exclusions at all. Both must keep writing the same thing.
-    /// </summary>
-    void CreateExcludedFile()
-    {
-        var dir = LbmPaths.DataDir;
-        var file = Path.Combine(dir,"Excluded.txt");
-        if(File.Exists(file)) return;
-
-        Directory.CreateDirectory(dir);
-        // Self-heal: a buggy earlier version created "Excluded.txt" as a *directory*.
-        if (Directory.Exists(file)) Directory.Delete(file, true);
-        var lines = new[] { ExcludedProcessDefaults.Header }.Concat(ExcludedProcessDefaults.All);
-        File.WriteAllText(file, string.Join("\n", lines) + "\n");
-    }
-
-    public void LaunchDaemon()
-    {
-        // The listener and a foreground command can both observe a missing endpoint.
-        // Keep their check-and-launch sequence atomic so they cannot start two daemons.
-        lock (_daemonLaunchGate)
-        {
-            foreach (var name in HookProcessNames)
-            foreach (var process in Process.GetProcessesByName(name))
-            {
-                using (process)
-                {
-                    if(process.HasExited) continue;
-                    if (OperatingSystem.IsWindows()
-                        && process.SessionId != Process.GetCurrentProcess().SessionId) continue;
-                    Debug.WriteLine($"Already running : {process.ProcessName} {process.Id}");
-                    return;
-                }
-            }
-
-            var path = FindHookPath();
-            if (path is null)
-            {
-                Debug.WriteLine($"Not found : {HookExeName}");
-                return;
-            }
-
-            // Must not abort the daemon launch if the exclusion file can't be written.
-            try { CreateExcludedFile(); }
-            catch (Exception ex) { Debug.WriteLine($"CreateExcludedFile failed: {ex.Message}"); }
-
-            try
-            {
-                // Elevation model (#512): the UI itself runs elevated when the user
-                // opted in, so the daemon inherits that level — no runas here.
-                var startInfo = new ProcessStartInfo
-                {
-                    FileName = path,
-#if DEBUG
-                    UseShellExecute = true,
-#else
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-#endif
-                };
-
-                var process = new Process { StartInfo = startInfo};
-
-                process.Start();
-
-                _daemonProcess?.Dispose();
-                _daemonProcess = process;
-
-                Debug.WriteLine($"Started : {process.ProcessName} {process.Id}");
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"LaunchDaemon failed: {ex}");
-            }
-        }
-    }
-
-    // Deployed Windows builds keep the historical staging name (CI renames the Rust
-    // binary to it); a dev-tree Rust daemon runs under its cargo binary name on
-    // every platform.
-    static string HookExeName => OperatingSystem.IsWindows() ? "LittleBigMouse.Hook.exe" : "lbm-hook";
-    static string[] HookProcessNames => OperatingSystem.IsWindows()
-        ? ["LittleBigMouse.Hook", "lbm-hook"]
-        : ["lbm-hook"];
-
-    /// <summary>
-    /// Locate the hook daemon without depending on the .NET target framework folder
-    /// (net8.0, net9.0, net10.0, ...). Deployed builds keep the hook next to the UI; in the
-    /// dev tree the Rust hook is built under LittleBigMouse-Hook-Rust/target.
-    /// Resistant to .NET version, platform (AnyCPU/x64) and configuration (Debug/Release) changes.
-    /// </summary>
-    static string? FindHookPath()
-    {
-        var uiDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        // 1. Deployed / published build: the hook sits right next to the UI.
-        var sibling = Path.Combine(uiDir, HookExeName);
-        if (File.Exists(sibling)) return sibling;
-
-        // 2. Dev tree: find the hook build output and search it.
-        try
-        {
-            var projectSegment = Path.Combine("LittleBigMouse.Ui", "LittleBigMouse.Ui.Avalonia");
-            var i = uiDir.IndexOf(projectSegment, StringComparison.OrdinalIgnoreCase);
-            if (i < 0) return null;
-            var root = uiDir[..i];
-
-            // Prefer the build matching the UI's current configuration.
-            var sep = Path.DirectorySeparatorChar;
-            var config = uiDir.Contains($"{sep}Debug{sep}", StringComparison.OrdinalIgnoreCase) ? "Debug" : "Release";
-
-            // Rust daemon first: LittleBigMouse-Hook-Rust/target/{debug,release}/lbm-hook[.exe].
-            var rustExe = OperatingSystem.IsWindows() ? "lbm-hook.exe" : "lbm-hook";
-            var target = Path.Combine(root, "LittleBigMouse-Hook-Rust", "target");
-            var rust = new[]
-                {
-                    Path.Combine(target, config.ToLowerInvariant(), rustExe),
-                    Path.Combine(target, "release", rustExe),
-                    Path.Combine(target, "debug", rustExe),
-                }
-                .FirstOrDefault(File.Exists);
-            return rust;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+    public void LaunchDaemon() => _processManager.LaunchDaemon();
 
     async Task StopDaemon(CancellationToken token = default)
     {
@@ -369,44 +201,7 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
         var commands = messages.ToList();
         var wireXml = $"<Messages>{string.Concat(commands.Select(command => command.Serialize()))}</Messages>";
 
-        // The daemon reads this file back on startup: LbmPaths must match its side
-        // (%LOCALAPPDATA%\Mgth\LittleBigMouse on Windows, ~/.local/share/LittleBigMouse on
-        // Linux). The former literal @"Mgth\LittleBigMouse\Current.xml" produced a file
-        // NAMED with backslashes on Linux.
-        var path = Path.Combine(LbmPaths.DataDir, "Current.xml");
-
-        Exception? persistenceFailure = null;
-        // Virtual (foreign) layouts are sent to the daemon for inspection but must never
-        // become the crash-recovery/autostart state: a standalone daemon would replay a
-        // client's geometry over the local desktop at the next boot.
-        if (persist && commands.Any(command => command.Command == LittleBigMouseCommand.Load
-                                    && command.Payload?.Virtual != true))
-        {
-            var recoveryXml = string.Join("\n", commands.Select(command => command.Serialize())) + "\n";
-            try
-            {
-                await AtomicRecoveryFile.WriteAsync(path, recoveryXml, token);
-            }
-            catch (Exception error) when (error is IOException or UnauthorizedAccessException or XmlException)
-            {
-                persistenceFailure = error;
-            }
-        }
-        else if (persist && commands.Any(command => command.Command == LittleBigMouseCommand.Stop))
-        {
-            // A user Stop must survive a restart: strip the Run line so a
-            // standalone daemon replays the layout stopped instead of re-hooking
-            // the mouse at the next boot. Stop is a safety operation — a
-            // persistence failure must never fault it.
-            try
-            {
-                await AtomicRecoveryFile.MarkStoppedAsync(path, token);
-            }
-            catch (Exception error) when (error is IOException or UnauthorizedAccessException or XmlException)
-            {
-                Debug.WriteLine($"Could not persist the stopped state: {error.Message}");
-            }
-        }
+        var persistenceFailure = await _recovery.PersistAsync(commands, persist, token);
 
         await _client.SendMessageAsync(wireXml, TimeSpan.FromMilliseconds(timeout), token);
         if (persistenceFailure is not null)
@@ -418,7 +213,7 @@ public class LittleBigMouseClientService : ILittleBigMouseClientService, IDispos
     public void Dispose()
     {
         _client.Dispose();
-        _daemonProcess?.Dispose();
+        _processManager.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/RecoveryStateStore.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/RecoveryStateStore.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using LittleBigMouse.Plugins;
+using LittleBigMouse.Zoning;
+
+namespace LittleBigMouse.Ui.Avalonia.Remote;
+
+/// <summary>
+/// Owns the crash-recovery / autostart file (<c>Current.xml</c>) that a standalone daemon
+/// reads back at boot. This is the persistence half of a send, pulled out of
+/// <see cref="LittleBigMouseClientService"/> so the file format, path and "what counts as a
+/// change worth remembering" decision live in one place.
+/// <para>
+/// The daemon reads this file back on startup: the path must match its side
+/// (<c>%LOCALAPPDATA%\Mgth\LittleBigMouse</c> on Windows, <c>~/.local/share/LittleBigMouse</c>
+/// on Linux — <see cref="LbmPaths.DataDir"/>). The former literal
+/// <c>@"Mgth\LittleBigMouse\Current.xml"</c> produced a file NAMED with backslashes on Linux.
+/// </para>
+/// <para>
+/// The two file operations are seams (<see cref="IRecoveryFileWriter"/>) so tests can drive the
+/// persistence decisions without touching a real disk; production uses
+/// <see cref="AtomicRecoveryFileWriter"/>, a thin pass-through to <see cref="AtomicRecoveryFile"/>.
+/// </para>
+/// </summary>
+public sealed class RecoveryStateStore
+{
+    readonly IRecoveryFileWriter _writer;
+    readonly string _path;
+
+    public RecoveryStateStore() : this(new AtomicRecoveryFileWriter(),
+        Path.Combine(LbmPaths.DataDir, "Current.xml"))
+    {
+    }
+
+    internal RecoveryStateStore(IRecoveryFileWriter writer, string path)
+    {
+        _writer = writer;
+        _path = path;
+    }
+
+    /// <summary>
+    /// Fold the crash-recovery consequence of a batch of commands into the file, then report
+    /// whether it succeeded. A Load of a real layout is written verbatim (one command per line);
+    /// a Stop strips the Run line from what is already there so the daemon replays stopped.
+    /// Nothing else touches the file.
+    /// </summary>
+    /// <param name="commands">The batch about to be sent to the daemon.</param>
+    /// <param name="persist">
+    /// False for a send the daemon should run but not remember (live preview): the recovery file
+    /// keeps describing the last applied layout. Serializing a layout is the expensive half of a
+    /// send, so the recovery copy is only built when it is actually going to be written.
+    /// </param>
+    /// <returns>
+    /// Null when nothing was persisted or a Load was persisted successfully. A non-null exception
+    /// when a Load could not be written — the live configuration was applied but recovery is stale,
+    /// which the caller surfaces. A failed Stop is swallowed here (Stop is a safety operation) and
+    /// never returned.
+    /// </returns>
+    public async Task<Exception?> PersistAsync(IReadOnlyList<CommandMessage> commands,
+        bool persist, CancellationToken token = default)
+    {
+        if (!persist) return null;
+
+        // Virtual (foreign) layouts are sent to the daemon for inspection but must never become
+        // the crash-recovery/autostart state: a standalone daemon would replay a client's geometry
+        // over the local desktop at the next boot.
+        if (commands.Any(command => command.Command == LittleBigMouseCommand.Load
+                                    && command.Payload?.Virtual != true))
+        {
+            var recoveryXml = string.Join("\n", commands.Select(command => command.Serialize())) + "\n";
+            try
+            {
+                await _writer.WriteAsync(_path, recoveryXml, token);
+                return null;
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or XmlException)
+            {
+                return error;
+            }
+        }
+
+        if (commands.Any(command => command.Command == LittleBigMouseCommand.Stop))
+        {
+            // A user Stop must survive a restart: strip the Run line so a standalone daemon
+            // replays the layout stopped instead of re-hooking the mouse at the next boot. Stop is
+            // a safety operation — a persistence failure must never fault it.
+            try
+            {
+                await _writer.MarkStoppedAsync(_path, token);
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException or XmlException)
+            {
+                System.Diagnostics.Debug.WriteLine($"Could not persist the stopped state: {error.Message}");
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// The two file operations <see cref="RecoveryStateStore"/> needs, as a seam for tests. The
+/// production implementation is <see cref="AtomicRecoveryFileWriter"/>.
+/// </summary>
+public interface IRecoveryFileWriter
+{
+    Task WriteAsync(string path, string content, CancellationToken token);
+    Task MarkStoppedAsync(string path, CancellationToken token);
+}
+
+/// <summary>Production writer: a thin pass-through to <see cref="AtomicRecoveryFile"/>.</summary>
+public sealed class AtomicRecoveryFileWriter : IRecoveryFileWriter
+{
+    public Task WriteAsync(string path, string content, CancellationToken token)
+        => AtomicRecoveryFile.WriteAsync(path, content, token);
+
+    public Task MarkStoppedAsync(string path, CancellationToken token)
+        => AtomicRecoveryFile.MarkStoppedAsync(path, token);
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/SystemProcessHost.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Remote/SystemProcessHost.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace LittleBigMouse.Ui.Avalonia.Remote;
+
+/// <summary>
+/// Production <see cref="IProcessHost"/>: a thin wrapper over <see cref="Process"/>. All the real
+/// OS calls live here so <see cref="DaemonProcessManager"/> stays testable.
+/// </summary>
+public sealed class SystemProcessHost : IProcessHost
+{
+    public int CurrentSessionId
+    {
+        get
+        {
+            using var self = Process.GetCurrentProcess();
+            return self.SessionId;
+        }
+    }
+
+    public IEnumerable<IDaemonProcess> Enumerate(IEnumerable<string> processNames)
+    {
+        foreach (var name in processNames)
+        foreach (var process in Process.GetProcessesByName(name))
+            yield return new SystemDaemonProcess(process);
+    }
+
+    public IDaemonProcess Launch(string path)
+    {
+        // Elevation model (#512): the UI itself runs elevated when the user opted in, so the daemon
+        // inherits that level — no runas here.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = path,
+#if DEBUG
+            UseShellExecute = true,
+#else
+            UseShellExecute = false,
+            CreateNoWindow = true,
+#endif
+        };
+
+        var process = new Process { StartInfo = startInfo };
+        process.Start();
+        return new SystemDaemonProcess(process);
+    }
+}
+
+/// <summary>Owns one real <see cref="Process"/> handle.</summary>
+sealed class SystemDaemonProcess(Process process) : IDaemonProcess
+{
+    public bool HasExited => process.HasExited;
+    public int SessionId => process.SessionId;
+    public int Id => process.Id;
+    public string ProcessName => process.ProcessName;
+
+    public bool TryStop()
+    {
+        try
+        {
+            if (process.HasExited) return true;
+            process.Kill(entireProcessTree: true);
+            return process.WaitForExit(2000);
+        }
+        catch (Exception error) when (error is InvalidOperationException
+                                      or System.ComponentModel.Win32Exception
+                                      or NotSupportedException)
+        {
+            Debug.WriteLine($"Could not force-stop {process.ProcessName}: {error.Message}");
+            return false;
+        }
+    }
+
+    public void Dispose() => process.Dispose();
+}


### PR DESCRIPTION
GEN-11, continuing #573. `LittleBigMouseClientService` keeps the Start/Stop/Quit policy, topology prologue/epilogue and the lost-IPC Stop fallback; the process concern moves to `DaemonProcessManager` (locate, launch-at-most-once, force-stop owned/session instances, exclusion-file seed) behind an `IProcessHost` seam, and the `Current.xml` decisions move to `RecoveryStateStore` behind `IRecoveryFileWriter`. Timeouts, paths, recovery format and reconnection behaviour carried over verbatim; no IPC change. Ownership documented: `Dispose` releases the handle but never kills the daemon — stopping stays an explicit user action. 20 tests with simulated process host and file writer (start, already-present, failure, recovery, stop/dispose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)