### PR TITLE
Route all four mouse backends through the hot_path core

### DIFF
--- a/LittleBigMouse-Hook-Rust/src/hook/hot_path.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/hot_path.rs
@@ -1,19 +1,40 @@
 //! Platform-neutral core of the mouse-hook hot path.
 //!
 //! Every backend's per-report callback (`hook/windows/mouse.rs`,
-//! `hook/linux/x11.rs`, `hook/linux/evdev.rs`, `hook/linux/portal.rs`) is built
-//! from the same three moving parts: **dedup** the report against the last
-//! location, take the engine under a **non-blocking `try_lock`** (a contended
-//! lock — a `Load` swapping the layout — passes the event straight through), and
-//! **dispatch** it to `MouseEngine::on_mouse_move`. That shape runs up to
-//! 1000×/s per device with the user's input captured, so it must never block and
-//! must not allocate or log on the ordinary (no-crossing) path.
+//! `hook/linux/x11.rs`, `hook/linux/evdev/router.rs`, `hook/linux/portal.rs`)
+//! is built from the same moving parts: **dedup** the report against the last
+//! location (where positions repeat at all), take the engine under a
+//! **non-blocking `try_lock`** (a contended lock — a `Load` swapping the layout
+//! — passes the event straight through), and **dispatch** it to
+//! `MouseEngine::on_mouse_move`. That shape runs up to 1000×/s per device with
+//! the user's input captured, so it must never block and must not allocate or
+//! log on the ordinary (no-crossing) path.
 //!
 //! Those parts are extracted here, free of any Win32 / evdev / X11 type, for two
 //! reasons: the Windows callback that cannot compile off Windows is reduced to a
 //! thin `unsafe` shim over code that can, and that same code is then exercised
 //! directly by `benches/mouse_hook.rs` and by the tests below on any host — no
 //! hook installed, no device opened, the real pointer never touched.
+//!
+//! The lock-and-dispatch decision ([`route_move`]) is byte-for-byte the same in
+//! all four backends. What differs around it is deliberate, and each variant is
+//! an explicit choice at the call site, not an accident to be flattened:
+//!
+//! | backend | dedup                       | after a crossing        | contended report          |
+//! |---------|-----------------------------|-------------------------|---------------------------|
+//! | Windows | [`MoveDedup`] on OS reports | dedup kept (C++ parity) | counted, passed to the OS |
+//! | X11     | [`MoveDedup`] on polled `QueryPointer` | [`MoveDedup::reset`]    | counted, cursor already moved |
+//! | evdev   | none — relative deltas, empty frames skipped upstream | nothing to resync | **not counted**; backend commits the clamped candidate itself |
+//! | portal  | none — zero-delta frames skipped upstream | capture released at the warp target | counted, treated as not-handled |
+//!
+//! The crossing column: on Windows the `SetCursorPos` warp re-enters the hook
+//! with its own event, so the stale `prev` (the swallowed position) resolves
+//! itself — and when the warp lands exactly on the swallowed pixel (adjacent
+//! same-DPI border at distance 1) dropping that synthetic event is correct, the
+//! cursor is already there. X11 observes the warp by *polling*, not by an event,
+//! so it resets the dedup to guarantee the next polled position reaches the
+//! engine. The two absolute-position backends own their cursor outright and
+//! never see a repeated position to begin with.
 
 use std::sync::Mutex;
 
@@ -30,9 +51,10 @@ use crate::hook::{CROSSINGS, MOUSE_EVENTS};
 /// reaches the engine — otherwise a stationary pointer would burn a lock and a
 /// full traversal pass on every timer tick.
 ///
-/// Not itself thread-safe: each backend owns one from the single thread its
-/// callback runs on (the Windows pump keeps it in a `thread_local`). Splitting it
-/// out of that `thread_local` is what makes the dedup decision testable.
+/// Not itself thread-safe: the backends that see repeatable positions (Windows,
+/// X11) each own one from the single thread their callback runs on (the Windows
+/// pump keeps it in a `thread_local`). Splitting it out of that `thread_local`
+/// is what makes the dedup decision testable.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MoveDedup {
     prev: Option<(i32, i32)>,
@@ -74,9 +96,11 @@ pub enum Routed {
     /// The engine ran and left the cursor where it was — an interior move. The
     /// backend forwards the event.
     Passed,
-    /// The engine repositioned the cursor across a border. The backend swallows
-    /// the event (Win32 `LRESULT(1)`) and should reset its dedup, since the warp
-    /// it just performed is itself a position change.
+    /// The engine repositioned the cursor across a border. What the backend does
+    /// next is its own, documented in the module-level variants table: Windows
+    /// swallows the OS event (`LRESULT(1)`) and keeps its dedup, X11 resets its
+    /// dedup, portal releases the capture at the warp target, evdev emits the
+    /// engine-written position.
     Crossed,
 }
 
@@ -130,7 +154,9 @@ pub fn route_move<E: CursorEnv>(
 
 /// Count one accepted (deduped) report. Kept next to [`route_move`] so a backend
 /// pairs the two and the "event seen" counter means the same thing everywhere:
-/// every report that survived dedup, contended or not.
+/// every report that survived dedup, contended or not. (evdev is the documented
+/// exception — see the module-level variants table: its contended arm commits a
+/// position itself and has always left that frame uncounted.)
 #[inline]
 pub fn count_event() {
     MOUSE_EVENTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/LittleBigMouse-Hook-Rust/src/hook/linux/evdev/router.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/linux/evdev/router.rs
@@ -20,6 +20,7 @@ use evdev::{uinput::VirtualDevice, EventType};
 use crate::engine::cursor::CursorEnv;
 use crate::engine::event::MouseEventArg;
 use crate::geometry::Point;
+use crate::hook::hot_path::{count_event, route_move, Routed};
 use crate::hook::linux::accel::{AccelConfig, PointerAccel};
 use crate::ipc::protocol;
 use crate::shared::Shared;
@@ -486,25 +487,25 @@ impl Router {
             // drains border resistance. Only the committed position gets clamped.
             let candidate = Point::new(old.x().saturating_add(dx), old.y().saturating_add(dy));
 
-            let mut engine = match shared.engine.try_lock() {
-                Ok(g) => g,
-                Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
-                Err(std::sync::TryLockError::WouldBlock) => {
+            // The evdev variants around the shared route (see the table in
+            // `hot_path`): the cursor is authoritative, so someone must always
+            // commit a position — the engine's verdict on a crossing, our own
+            // clamp otherwise. A contended route therefore cannot just pass: it
+            // commits the clamped candidate and emits right here (and that frame
+            // has never been counted as an event — the early return skips the
+            // pending keyboard frame too, exactly as before).
+            let routed = route_move(&shared.engine, &mut self.env, candidate);
+            match routed {
+                Routed::Contended => {
                     self.env.virtual_pos = self.env.clamp(candidate);
                     self.emit_absolute();
                     return;
                 }
-            };
-            let mut e = MouseEventArg::new(candidate);
-            engine.on_mouse_move(&mut self.env, &mut e);
-            drop(engine);
-
-            if !e.handled {
-                self.env.virtual_pos = self.env.clamp(candidate);
-            }
-            crate::hook::MOUSE_EVENTS.fetch_add(1, Ordering::Relaxed);
-            if e.handled {
-                crate::hook::CROSSINGS.fetch_add(1, Ordering::Relaxed);
+                Routed::Passed => {
+                    self.env.virtual_pos = self.env.clamp(candidate);
+                    count_event();
+                }
+                Routed::Crossed => count_event(),
             }
             if self.debug {
                 // Per-frame trace: raw delta, engine input, emitted position. The
@@ -512,7 +513,7 @@ impl Router {
                 // sent it" investigation (compare against what KWin displays).
                 eprintln!("[LittleBigMouse.Hook] evdev: frame d=({dx},{dy}) cand=({},{}) -> emit ({},{}){}{}",
                     candidate.x(), candidate.y(), self.env.virtual_pos.x(), self.env.virtual_pos.y(),
-                    if e.handled { " CROSS" } else { "" },
+                    if routed.handled() { " CROSS" } else { "" },
                     if self.env.ctrl_down() { " ctrl" } else { "" });
             }
         }

--- a/LittleBigMouse-Hook-Rust/src/hook/linux/portal.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/linux/portal.rs
@@ -33,6 +33,7 @@ use reis::event::{DeviceCapability, EiEvent};
 use crate::engine::cursor::CursorEnv;
 use crate::engine::event::MouseEventArg;
 use crate::geometry::{Point, Rect};
+use crate::hook::hot_path::{count_event, route_move};
 use crate::ipc::protocol;
 use crate::shared::Shared;
 
@@ -241,7 +242,6 @@ async fn run_async(shared: &'static Shared) -> bool {
                 // barrier at its own (uncorrected) position, so deferring the warp
                 // to the next motion frame is the "correction one pixel too late".
                 if let Some(target) = env.pending_warp.take() {
-                    crate::hook::CROSSINGS.fetch_add(1, Ordering::Relaxed);
                     eprintln!("[LittleBigMouse.Hook] portal: crossing on activation -> release at ({},{})",
                         target.x(), target.y());
                     if let Some(c) = capture.take() {
@@ -309,7 +309,7 @@ async fn run_async(shared: &'static Shared) -> bool {
                         let position = Point::new(env.virtual_pos.x() + dx, env.virtual_pos.y() + dy);
                         env.virtual_pos = position;
 
-                        crate::hook::MOUSE_EVENTS.fetch_add(1, Ordering::Relaxed);
+                        count_event();
                         let handled = feed_engine(shared, &mut env, position);
 
                         // Re-pin into the emulated clip: the next frame's delta must
@@ -321,7 +321,6 @@ async fn run_async(shared: &'static Shared) -> bool {
                         if let Some(target) = env.pending_warp.take() {
                             // The engine crossed: release the capture, placing the
                             // cursor at the computed target — this is the warp.
-                            crate::hook::CROSSINGS.fetch_add(1, Ordering::Relaxed);
                             eprintln!("[LittleBigMouse.Hook] portal: crossing -> release at ({},{})", target.x(), target.y());
                             let c = capture.take().unwrap();
                             release(&input_capture, &session, c.activation_id, Some(target)).await;
@@ -482,15 +481,14 @@ fn layout_barriers(
     barriers
 }
 
+/// One report through the shared non-blocking route (contended → not handled).
+/// `Routed::Crossed` — counted as a crossing by the core — coincides exactly
+/// with `env.pending_warp` being set: the engine's only cursor write
+/// (`move_cursor`) sets `handled` and calls `set_mouse_location` together, so
+/// the callers keep reading the warp *target* from `pending_warp` while the
+/// *counting* lives in `hot_path` like every other backend.
 fn feed_engine(shared: &Shared, env: &mut PortalCursor, position: Point<i32>) -> bool {
-    let mut engine = match shared.engine.try_lock() {
-        Ok(g) => g,
-        Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
-        Err(std::sync::TryLockError::WouldBlock) => return false,
-    };
-    let mut e = MouseEventArg::new(position);
-    engine.on_mouse_move(env, &mut e);
-    e.handled
+    route_move(&shared.engine, env, position).handled()
 }
 
 /// The main zone whose bounds are closest to `position` (squared distance to the

--- a/LittleBigMouse-Hook-Rust/src/hook/linux/x11.rs
+++ b/LittleBigMouse-Hook-Rust/src/hook/linux/x11.rs
@@ -28,6 +28,7 @@ use x11rb::rust_connection::RustConnection;
 use crate::engine::cursor::CursorEnv;
 use crate::engine::event::MouseEventArg;
 use crate::geometry::{Point, Rect};
+use crate::hook::hot_path::{count_event, route_move, MoveDedup, Routed};
 use crate::ipc::protocol;
 use crate::shared::Shared;
 
@@ -61,7 +62,7 @@ pub fn run(shared: &'static Shared) {
     };
 
     let mut selected = false;
-    let mut prev: Option<(i32, i32)> = None;
+    let mut dedup = MoveDedup::new();
 
     eprintln!("[LittleBigMouse.Hook] x11 backend running");
 
@@ -86,7 +87,7 @@ pub fn run(shared: &'static Shared) {
                     engine.on_mouse_move(&mut env, &mut e);
                     drop(engine);
                     env.clip = None;
-                    prev = None;
+                    dedup.reset();
                     crate::platform::set_process_priority(crate::priority::Priority::from_u8(
                         shared.priority_unhooked.load(Ordering::SeqCst),
                     ));
@@ -128,22 +129,14 @@ pub fn run(shared: &'static Shared) {
                 }
             }
 
-            let loc = (pos.x(), pos.y());
-            if prev != Some(loc) {
-                prev = Some(loc);
-                crate::hook::MOUSE_EVENTS.fetch_add(1, Ordering::Relaxed);
-
-                let mut engine = match shared.engine.try_lock() {
-                    Ok(g) => g,
-                    Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
-                    Err(std::sync::TryLockError::WouldBlock) => continue,
-                };
-                let mut e = MouseEventArg::new(pos);
-                engine.on_mouse_move(&mut env, &mut e);
-                if e.handled {
-                    crate::hook::CROSSINGS.fetch_add(1, Ordering::Relaxed);
-                    // The engine warped the cursor: resync the dedup state.
-                    prev = None;
+            if dedup.accept((pos.x(), pos.y())) {
+                count_event();
+                if route_move(&shared.engine, &mut env, pos) == Routed::Crossed {
+                    // The engine warped the cursor, and the warp is observed by
+                    // the next QueryPointer poll — not by a hook re-entry of its
+                    // own as on Windows. Resync so the next polled position
+                    // always reaches the engine (variants table in `hot_path`).
+                    dedup.reset();
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #596. **Merge after #596** (built on the `hook::hot_path` module it introduces).

Consolidates the Windows, X11, evdev and portal backends on `hot_path::route_move`/`MoveDedup`, keeping each backend's semantics as explicit, documented options rather than flattening them — the variant table lives in the `hot_path` module doc: Windows keeps its dedup across crossings (C++ hook parity), X11 resets it (QueryPointer-probed position), evdev has no positional dedup, uncounted contention and commits the clamped candidate, portal targets the warp via `pending_warp`. 104 lib tests green, `mouse_hook` bench still asserts 0 allocations on the ordinary paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)