### PR TITLE
fix(ui): sever LocationControlViewModel's roots on disposal

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LocationControlViewModelTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LocationControlViewModelTests.cs
@@ -1,0 +1,150 @@
+using HLab.Sys.Windows.API;
+using HLab.Sys.Windows.Monitors;
+using LittleBigMouse.DisplayLayout.Monitors;
+using LittleBigMouse.Plugins;
+using LittleBigMouse.Ui.Avalonia.Controls;
+using LittleBigMouse.Ui.Avalonia.Main;
+using LittleBigMouse.Zoning;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The location control's view model lives as long as its view: HLab.Mvvm disposes it when
+/// the view leaves the logical tree (window close), and a new one is built on the next open.
+/// What these tests pin down is that disposal actually severs everything reaching beyond the
+/// view model — the daemon client and the layout are process-lifetime residents, so anything
+/// they still hold after Dispose is a generation of the UI that can never be collected.
+/// <para>
+/// Built through the internal constructor: the UI-thread seams run inline and the live
+/// ticker is a recording fake, so no test touches Avalonia's dispatcher — without a platform
+/// it belongs to whichever thread reaches it first, and a blocking Invoke from any other
+/// thread waits forever on a loop nobody pumps.
+/// </para>
+/// </summary>
+public sealed class LocationControlViewModelTests
+{
+    sealed class FakeMainService : IMainService
+    {
+        public IMonitorsLayout MonitorsLayout { get; set; } =
+            MainServiceFakes.NewLayout(new ILayoutOptions.Design());
+
+        public bool LivePreview { get; set; }
+
+        public void UpdateLayout() { }
+        public void ReloadSystemLayout() { }
+        public Task StartNotifierAsync() => Task.CompletedTask;
+        public Task ShowControlAsync() => Task.CompletedTask;
+        public void AddControlPlugin(Action<IMainPluginsViewModel>? action) { }
+    }
+
+    sealed class FakeMonitorsService : ISystemMonitorsService
+    {
+        // Only ExportConfig walks Root, and only on Windows; no test comes near it.
+        public DisplayDevice Root => null!;
+        public DesktopWallpaperPosition WallpaperPosition => default;
+    }
+
+    sealed class FakeTicker : ILiveTicker
+    {
+        public bool Running { get; private set; }
+        public void Start() => Running = true;
+        public void Stop() => Running = false;
+    }
+
+    sealed class Fixture
+    {
+        public FakeDaemon Daemon { get; } = new();
+        public FakePersistence Persistence { get; } = new();
+        public FakeMainService Main { get; } = new();
+        public FakeTicker Ticker { get; } = new();
+        public LocationControlViewModel Vm { get; }
+
+        public Fixture()
+        {
+            Vm = new LocationControlViewModel(
+                Daemon,
+                Main,
+                new FakeMonitorsService(),
+                Persistence,
+                new EngineController(Daemon, Persistence, () => Vm?.Model),
+                onUiThread: run => run(),
+                postToUi: post => post(),
+                liveTicker: _ => Ticker);
+        }
+    }
+
+    [Fact]
+    public void BuildingTheViewModelSubscribesToTheDaemon()
+    {
+        var f = new Fixture();
+
+        Assert.True(f.Daemon.HasSubscribers);
+    }
+
+    [Fact]
+    public void DisposingTheViewModelGivesTheDaemonSubscriptionBack()
+    {
+        var f = new Fixture();
+
+        f.Vm.Dispose();
+
+        Assert.False(f.Daemon.HasSubscribers);
+    }
+
+    /// <summary>Positive control: gives the negative test below its meaning.</summary>
+    [Fact]
+    public void ADaemonEventReachesTheViewModelWhileItLives()
+    {
+        var f = new Fixture();
+
+        f.Daemon.Raise(LittleBigMouseEvent.Running);
+
+        Assert.True(f.Vm.Running);
+    }
+
+    [Fact]
+    public void AfterDisposalADaemonEventNoLongerReachesTheViewModel()
+    {
+        var f = new Fixture();
+        f.Vm.Dispose();
+
+        f.Daemon.Raise(LittleBigMouseEvent.Running);
+
+        Assert.False(f.Vm.Running);
+    }
+
+    [Fact]
+    public void DisposalEndsALivePreview()
+    {
+        // Closing the window while previewing: without this, the ticker keeps feeding the
+        // daemon a layout nobody can see or stop, and the dispatcher roots the running timer.
+        var f = new Fixture();
+        f.Vm.LiveUpdate = true;
+        Assert.True(f.Main.LivePreview);
+        Assert.True(f.Ticker.Running);
+
+        f.Vm.Dispose();
+
+        Assert.False(f.Main.LivePreview);
+        Assert.False(f.Ticker.Running);
+    }
+
+    [Fact]
+    public void AfterDisposalTheLayoutNoLongerReachesTheViewModel()
+    {
+        // The WhenAnyValue chains watching Model.Saved subscribe to the layout itself,
+        // which lives on MainService: Dispose must let go of the model to unhook them.
+        var f = new Fixture();
+        var layout = MainServiceFakes.NewLayout(new LbmOptions());
+        f.Vm.Model = layout;
+
+        f.Vm.Dispose();
+        Assert.Null(f.Vm.Model);
+
+        f.Vm.Saved = true;
+        layout.Saved = false;
+
+        Assert.True(f.Vm.Saved);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Controls/LocationControlViewModel.cs
@@ -55,20 +55,38 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     readonly EngineController _engine;
 
     readonly ILittleBigMouseClientService _service;
+    readonly Action<Action> _postToUi;
 
     public LocationControlViewModel(ILittleBigMouseClientService service,IMainService main, ISystemMonitorsService monitorsService, ILayoutPersistence persistence, EngineController engine)
+        : this(service, main, monitorsService, persistence, engine,
+            run => Dispatcher.UIThread.Invoke(run),
+            post => Dispatcher.UIThread.Post(() => post()),
+            tick => new DispatcherLiveTicker(tick))
+    {
+    }
+
+    /// <summary>
+    /// The dispatcher seams, injectable for the same reason <see cref="DaemonStatusTracker"/>
+    /// takes its <c>onUiThread</c>: tests have no UI thread, and without a platform Avalonia's
+    /// dispatcher belongs to whichever thread reaches it first — a blocking Invoke from any
+    /// other one waits forever on a loop nobody pumps.
+    /// </summary>
+    internal LocationControlViewModel(ILittleBigMouseClientService service, IMainService main,
+        ISystemMonitorsService monitorsService, ILayoutPersistence persistence, EngineController engine,
+        Action<Action> onUiThread, Action<Action> postToUi, Func<Func<Task>, ILiveTicker> liveTicker)
     {
         _service = service;
         _mainService = main;
         _persistence = persistence;
         _engine = engine;
+        _postToUi = postToUi;
 
         _monitorsService = monitorsService;
 
         // What the daemon says about itself — see DaemonStatusTracker. Built before the commands
         // below, whose canExecute reads Running and Dead through the helpers wired here.
         _status = new DaemonStatusTracker(
-            run => Dispatcher.UIThread.Invoke(run),
+            onUiThread,
             () => LiveUpdate,
             wasPreviewing =>
             {
@@ -185,8 +203,7 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
             () => Model?.ComputeZones(),
             (zones, token) => _service.SendLiveAsync(zones, token));
 
-        _liveTimer = new DispatcherTimer { Interval = LiveLayoutUpdater.Interval };
-        _liveTimer.Tick += async (_, _) => await _live.TickAsync();
+        _liveTimer = liveTicker(() => _live.TickAsync());
 
         this.WhenAnyValue(e => e.LiveUpdate).Subscribe(live =>
         {
@@ -207,8 +224,30 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
 
         this.UnsavedOn(e => e.Model);
 
-        service.DaemonEventReceived += (_, e) => _status.Apply(e);
+        // The service is a process-lifetime singleton: a bare += would keep every
+        // generation of this view model alive for as long as the app runs. Disposal
+        // happens when the owning view leaves the logical tree (HLab.Mvvm's LinkDispose).
+        OwnedSubscription.Create<EventHandler<LittleBigMouseServiceEventArgs>>(
+                (_, e) => _status.Apply(e),
+                h => service.DaemonEventReceived += h,
+                h => service.DaemonEventReceived -= h)
+            .DisposeWith(this);
+
         _status.Apply(new LittleBigMouseServiceEventArgs(service.State, ""));
+    }
+
+    public override void OnDispose()
+    {
+        // Ends a live preview with its owner: LivePreview goes back to the service and
+        // the timer stops — a running DispatcherTimer is rooted by the dispatcher, and
+        // its tick reaches the daemon through this view model.
+        LiveUpdate = false;
+        _liveTimer.Stop();
+
+        // Every WhenAnyValue chain watching through Model (command canExecute, UnsavedOn)
+        // is subscribed to the layout itself, which lives on MainService: letting go of
+        // the model is what unhooks them.
+        Model = null;
     }
 
     readonly DaemonStatusTracker _status;
@@ -217,7 +256,7 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     {
         // The last Load outcome belongs to the previous layout generation. Runs before the
         // field is assigned on the very first model, where there is nothing to forget.
-        Dispatcher.UIThread.Post(() => _status?.ForgetLayoutInfo());
+        _postToUi?.Invoke(() => _status?.ForgetLayoutInfo());
 
         // A rebuild (display change, refresh, virtual layout opened) goes through
         // MainService, which feeds the daemon itself: what we believe it holds no longer
@@ -371,7 +410,7 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
     public ReactiveCommand<Unit, Unit> LiveUpdateCommand { get; }
 
     readonly LiveLayoutUpdater _live;
-    readonly DispatcherTimer _liveTimer;
+    readonly ILiveTicker _liveTimer;
 
     /// <summary>
     /// Last Load outcome reported by the daemon ("3 zones (3 main), virtual" / a failure
@@ -401,4 +440,30 @@ public class LocationControlViewModel : ViewModel<MonitorsLayout>, ISavable
       set => this.RaiseAndSetIfChanged(ref _saved, value);
    }
    bool _saved;
+}
+
+/// <summary>The live pump's clock, started and stopped with the preview switch.</summary>
+internal interface ILiveTicker
+{
+    void Start();
+    void Stop();
+}
+
+/// <summary>
+/// The production clock: a <see cref="DispatcherTimer"/>, built and driven on the UI thread.
+/// While running it is rooted by the dispatcher — one more reason stopping it belongs to the
+/// view model's disposal.
+/// </summary>
+sealed class DispatcherLiveTicker : ILiveTicker
+{
+    readonly DispatcherTimer _timer;
+
+    public DispatcherLiveTicker(Func<Task> tick)
+    {
+        _timer = new DispatcherTimer { Interval = LiveLayoutUpdater.Interval };
+        _timer.Tick += async (_, _) => await tick();
+    }
+
+    public void Start() => _timer.Start();
+    public void Stop() => _timer.Stop();
 }


### PR DESCRIPTION
## Problem

`LocationControlViewModel` subscribed to the singleton daemon client (`DaemonEventReceived`) with an anonymous lambda and armed a `DispatcherTimer`, with no way back out. Every generation of the location control — one per window open — stayed reachable for the life of the process, ticking timer included. This is the lifecycle risk documented (out of scope) by the WIN-05 audit.

## Fix

The disposal machinery already existed: HLab.Mvvm disposes the DataContext when its view leaves the logical tree, and `ReactiveModel` carries the `Disposer`. The view model just never registered anything with it.

- The daemon subscription now goes through `OwnedSubscription.Create(...).DisposeWith(this)`.
- `OnDispose` ends a live preview (`LiveUpdate = false`, so `MainService.LivePreview` follows), stops the ticker — a running `DispatcherTimer` is rooted by the dispatcher — and lets go of the model: the `WhenAnyValue` chains watching through `Model.Saved` (command canExecute, `UnsavedOn`) subscribe to the layout itself, which lives on `MainService` and would otherwise keep every dead view model reachable.

## Testability

The dispatcher seams (UI marshalling, live timer) are injectable through an internal constructor, `DaemonStatusTracker`-style, with production defaults on the public constructor DI keeps using. Without a platform, Avalonia's dispatcher belongs to whichever thread reaches it first, and a blocking `Invoke` from any other thread waits forever on a loop nobody pumps — under xunit's parallel scheduling that made any dispatcher-touching test a lottery (all tests green, then the testhost never exits).

Six new tests pin the contract: subscription handed back on dispose, daemon events inert after dispose, live preview and ticker ended, layout released. Full UI suite: 332/332, stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)