### PR TITLE
chore: pin the Rust toolchain to the validated version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+# The version the hook's test suite is validated against. CI runners ship
+# whatever stable is current; without this pin the hook builds with a
+# different compiler than the one used for local validation.
+channel = "1.94.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
CI runners build the hook with whatever stable Rust toolchain they ship, which silently drifts from the compiler the test suite was validated against. This pins `1.94.0` (minimal profile, with clippy and rustfmt) at the repo root so CI and local builds agree.

The idea is salvaged from the closed #513 review — repinned from 1.95.0 to 1.94.0, the version the hook's current test suite (131 tests) actually ran on. `cargo check` verified locally against the pin. Note for CI timing: the Windows runner will now install the pinned toolchain instead of using the preinstalled stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)