### PR TITLE
fix: cap the layout store key so nine monitors no longer break startup (#589)

### DIFF
--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/JsonLayoutStoreTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/JsonLayoutStoreTests.cs
@@ -190,6 +190,20 @@ public class JsonLayoutStoreTests : IDisposable
     }
 
     [Fact]
+    public void WriteThenRead_NineMonitorId_RoundTrips()
+    {
+        // #589: nine monitor ids join into a name longer than a file name may be (255
+        // bytes). WriteJson swallows the IOException, so this silently stored nothing.
+        var id = LayoutStoreKeyTests.LayoutId(9);
+        Assert.True(id.Length > 255);
+
+        var store = new JsonLayoutStore(_dir);
+        store.WriteLayout(id, new LayoutDto { Options = new LayoutOptionsDto { Enabled = true } });
+
+        Assert.True(store.Read(id, []).Layout!.Options!.Enabled);
+    }
+
+    [Fact]
     public void WriteModels_UpsertsWithoutDroppingOthers()
     {
         var store = new JsonLayoutStore(_dir);

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutPersistenceTests.cs
@@ -39,6 +39,25 @@ public class LayoutPersistenceTests
         }
     }
 
+    /// <summary>
+    /// The #589 store: the id-based operations throw, as the registry did on a key name
+    /// over 255 characters.
+    /// </summary>
+    sealed class ThrowingStore : ILayoutStore
+    {
+        const string Message = "Registry key names should not be greater than 255 characters.";
+
+        public LayoutStoreData Read(string layoutId, IReadOnlyCollection<string> pnpCodes)
+            => throw new ArgumentException(Message);
+
+        public void WriteGlobalOptions(GlobalOptionsDto options) { }
+
+        public void WriteLayout(string layoutId, LayoutDto layout)
+            => throw new ArgumentException(Message);
+
+        public void WriteModels(IReadOnlyDictionary<string, ModelDto> models) { }
+    }
+
     sealed class TestPersistence(ILayoutStore store, string excludedFile) : LayoutPersistence(store)
     {
         protected override string ExcludedListFile() => excludedFile;
@@ -115,6 +134,22 @@ public class LayoutPersistenceTests
         Assert.True(restoredMonitor.Placed);
         Assert.True(restoredMonitor.Saved);
         Assert.True(restored.Saved);
+    }
+
+    [Fact]
+    public void Load_StoreReadFailure_DoesNotThrowAndLoadsAsAFirstRun()
+    {
+        // #589: nine monitors made the layout id longer than a registry key name may be,
+        // the read threw through Load, and the UI never booted. Whatever the store does,
+        // Load has to come back with a usable layout, marked saved as on a first run.
+        var persistence = new TestPersistence(new ThrowingStore(), TempExcludedFile());
+        var layout = NewLayout(out var monitor, out _);
+
+        persistence.Load(layout);
+
+        Assert.True(layout.Saved);
+        Assert.True(monitor.Saved);
+        Assert.False(persistence.IsLoading);
     }
 
     [Fact]

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutStoreKeyTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/LayoutStoreKeyTests.cs
@@ -1,0 +1,74 @@
+using LittleBigMouse.Plugins.Persistence;
+
+namespace LittleBigMouse.DisplayLayout.Tests;
+
+/// <summary>
+/// The store name of a layout (#589). Nine monitor ids join into a layout id longer than a
+/// registry key name may be; the read threw and the UI never booted, which read as an
+/// "8-monitor limit". A short id must keep its historical key; a long one must fit, stay
+/// stable, and stay distinct from its neighbors.
+/// </summary>
+public class LayoutStoreKeyTests
+{
+    /// <summary>One Windows monitor id: PnP code, EDID serial, week, year, checksum — 29 chars.</summary>
+    public static string MonitorId(int i) => $"GSM5B09{i:D2}NTMX5X567_0C_07E5_A{i % 10}";
+
+    /// <summary>The layout id of that many monitors, as ComputeId joins them.</summary>
+    public static string LayoutId(int monitors)
+        => string.Join("+", Enumerable.Range(1, monitors).Select(MonitorId));
+
+    [Fact]
+    public void EightMonitors_KeepTheirHistoricalKey()
+    {
+        var id = LayoutId(8);
+
+        Assert.True(id.Length <= LayoutStoreKey.MaxLength);
+        Assert.Equal(id, LayoutStoreKey.For(id));
+    }
+
+    [Fact]
+    public void NineMonitors_FitTheLimit()
+    {
+        // The reporter's configuration: the ninth monitor is the one that went over.
+        var id = LayoutId(9);
+        Assert.True(id.Length > LayoutStoreKey.MaxLength);
+
+        Assert.True(LayoutStoreKey.For(id).Length <= LayoutStoreKey.MaxLength);
+    }
+
+    [Fact]
+    public void LongId_KeepsAReadableHead()
+        => Assert.StartsWith(MonitorId(1) + "+" + MonitorId(2), LayoutStoreKey.For(LayoutId(9)));
+
+    [Fact]
+    public void LongId_IsStable()
+        => Assert.Equal(LayoutStoreKey.For(LayoutId(9)), LayoutStoreKey.For(LayoutId(9)));
+
+    [Fact]
+    public void LongIds_SharingTheirHead_GetDistinctKeys()
+    {
+        var a = LayoutId(9);
+        // Differs in its last character only, far past the readable head.
+        var b = a[..^1] + "F";
+
+        Assert.NotEqual(LayoutStoreKey.For(a), LayoutStoreKey.For(b));
+    }
+
+    [Fact]
+    public void Key_UsesOnlyStoreSafeCharacters()
+        => Assert.Matches("^[A-Za-z0-9+_~]+$", LayoutStoreKey.For(LayoutId(12)));
+
+    [Fact]
+    public void ShorterCap_IsHonored()
+    {
+        // What the JSON store passes: the file name cap minus its extension.
+        var key = LayoutStoreKey.For(LayoutId(9), 250);
+
+        Assert.True(key.Length <= 250);
+        Assert.NotEqual(LayoutStoreKey.For(LayoutId(9)), key);
+    }
+
+    [Fact]
+    public void CapWithNoRoomForTheDigest_IsRefused()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => LayoutStoreKey.For(LayoutId(9), 40));
+}

--- a/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/RegistryLayoutStoreTests.cs
+++ b/LittleBigMouse.Core/LittleBigMouse.DisplayLayout.Tests/RegistryLayoutStoreTests.cs
@@ -107,6 +107,19 @@ public class RegistryLayoutStoreTests : IDisposable
     }
 
     [WindowsFact]
+    public void WriteThenRead_NineMonitorId_RoundTrips()
+    {
+        // #589: the joined id of nine monitors exceeds the 255-character registry key
+        // name limit; OpenSubKey threw ArgumentException and the UI never booted.
+        var id = LayoutStoreKeyTests.LayoutId(9);
+        Assert.True(id.Length > 255);
+
+        Store.WriteLayout(id, new LayoutDto { Options = new LayoutOptionsDto { Enabled = true } });
+
+        Assert.True(Store.Read(id, []).Layout!.Options!.Enabled);
+    }
+
+    [WindowsFact]
     public void Model_RoundTripsSizeBordersAndName()
     {
         var borders = Filled<BordersDto>();

--- a/LittleBigMouse.Platform.Linux/JsonLayoutStore.cs
+++ b/LittleBigMouse.Platform.Linux/JsonLayoutStore.cs
@@ -33,10 +33,15 @@ public class JsonLayoutStore : ILayoutStore
     string OptionsPath => Path.Combine(_configDir, "options.json");
     string ModelsPath => Path.Combine(_configDir, "models.json");
 
+    const string LayoutExtension = ".json";
+
     string LayoutPath(string layoutId)
     {
         var id = string.Join("_", layoutId.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries));
-        return Path.Combine(_configDir, "layouts", $"{id}.json");
+        // A file name is capped at 255 bytes on every common filesystem, extension
+        // included, and a nine-monitor id is longer (#589): same rule as the registry.
+        var name = LayoutStoreKey.For(id, LayoutStoreKey.MaxLength - LayoutExtension.Length);
+        return Path.Combine(_configDir, "layouts", name + LayoutExtension);
     }
 
     public LayoutStoreData Read(string layoutId, IReadOnlyCollection<string> pnpCodes) => new()
@@ -76,7 +81,9 @@ public class JsonLayoutStore : ILayoutStore
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            var temp = path + ".tmp";
+            // Same length as the final name, not longer: a layout name may already sit at
+            // the 255-byte cap, and a longer temp twin fails right here (#589).
+            var temp = Path.ChangeExtension(path, ".tmp");
             File.WriteAllText(temp, JsonSerializer.Serialize(value, JsonOptions));
             File.Move(temp, path, overwrite: true);
         }

--- a/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
+++ b/LittleBigMouse.Platform.Windows/RegistryLayoutStore.cs
@@ -33,6 +33,12 @@ public class RegistryLayoutStore : ILayoutStore
     RegistryKey? OpenRoot(bool create)
         => create ? Registry.CurrentUser.CreateSubKey(_rootKey) : Registry.CurrentUser.OpenSubKey(_rootKey);
 
+    /// <summary>
+    /// A registry key name is capped at 255 characters and a nine-monitor id is longer
+    /// (#589): the key is derived from the id, and is the id itself whenever it fits.
+    /// </summary>
+    static string LayoutKeyPath(string layoutId) => @$"Layouts\{LayoutStoreKey.For(layoutId)}";
+
     //==================//
     // Read             //
     //==================//
@@ -44,7 +50,7 @@ public class RegistryLayoutStore : ILayoutStore
         using var root = OpenRoot(create: false);
         if (root == null) return data;
 
-        using var layoutKey = root.OpenSubKey(@$"Layouts\{layoutId}");
+        using var layoutKey = root.OpenSubKey(LayoutKeyPath(layoutId));
 
         data.GlobalOptions = ReadGlobalOptions(root, layoutKey);
         if (layoutKey != null) data.Layout = ReadLayout(layoutKey);
@@ -282,7 +288,7 @@ public class RegistryLayoutStore : ILayoutStore
     public void WriteLayout(string layoutId, LayoutDto layout)
     {
         using var root = OpenRoot(create: true);
-        using var key = root?.CreateSubKey(@$"Layouts\{layoutId}");
+        using var key = root?.CreateSubKey(LayoutKeyPath(layoutId));
         if (key == null) return;
 
         if (layout.Options is { } o)

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutPersistence.cs
@@ -96,9 +96,7 @@ public abstract class LayoutPersistence : ILayoutPersistence
         IsLoading = true;
         try
         {
-            var data = _store.Read(
-                layout.Id,
-                layout.PhysicalMonitors.Select(m => m.Model.PnpCode).Distinct().ToList());
+            var data = ReadStore(layout);
 
             layout.Options.LoadAtStartup = IsAutostartScheduled(layout);
             layout.Options.Elevated = IsElevated;
@@ -171,6 +169,28 @@ public abstract class LayoutPersistence : ILayoutPersistence
         }
 
         monitor.Saved = true;
+    }
+
+    /// <summary>
+    /// The store read, with its failure contained: a store that cannot be read must not
+    /// keep the app from starting. Nine monitors made a layout id longer than a registry
+    /// key name may be, the read threw through Load, and the UI never came up (#589). The
+    /// layout then loads as on a first run — placed from the system configuration, nothing
+    /// saved — and the failure is in ui.log.
+    /// </summary>
+    LayoutStoreData ReadStore(MonitorsLayout layout)
+    {
+        try
+        {
+            return _store.Read(
+                layout.Id,
+                layout.PhysicalMonitors.Select(m => m.Model.PnpCode).Distinct().ToList());
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine($"[LittleBigMouse] Layout store read failed for '{layout.Id}': {error}");
+            return new LayoutStoreData();
+        }
     }
 
     //==================//

--- a/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutStoreKey.cs
+++ b/LittleBigMouse.Plugins/LittleBigMouse.Plugins.Core/Persistence/LayoutStoreKey.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LittleBigMouse.Plugins.Persistence;
+
+/// <summary>
+/// The name a layout is stored under, derived from its id.
+/// <para>
+/// A layout id is the "+"-joined list of its monitor ids (<c>LayoutIdExtensions.ComputeId</c>):
+/// 26 to 31 characters per monitor on Windows, more on Linux. Both backends cap a name —
+/// Windows refuses a registry key name over 255 characters, the common Linux filesystems a
+/// file name over 255 bytes — and nine monitors are enough to go over. The registry then
+/// threw at the first read and the UI never came up, which read as an "8-monitor limit" (#589).
+/// </para>
+/// <para>
+/// An id that fits is stored as-is, so every existing configuration keeps its key. A longer
+/// one keeps a readable head and ends with the SHA-256 of the whole id: two setups sharing
+/// their first monitors still get distinct entries, and one setup always maps to the same.
+/// </para>
+/// </summary>
+public static class LayoutStoreKey
+{
+    /// <summary>Longest name the backends accept, registry key names and file names alike.</summary>
+    public const int MaxLength = 255;
+
+    /// <summary>Between the readable head and the digest; never part of an id.</summary>
+    const char Separator = '~';
+
+    /// <param name="layoutId">The layout id, as computed from the monitor set.</param>
+    /// <param name="maxLength">
+    /// The backend's cap. A file store passes the cap minus its extension.
+    /// </param>
+    public static string For(string layoutId, int maxLength = MaxLength)
+    {
+        ArgumentNullException.ThrowIfNull(layoutId);
+        if (layoutId.Length <= maxLength) return layoutId;
+
+        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(layoutId)));
+
+        var head = maxLength - digest.Length - 1;
+        if (head < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength,
+                $"A store key needs room for the {digest.Length}-character digest and its separator.");
+
+        // Ids are ASCII in practice; never cut a surrogate pair should one show up.
+        if (head > 0 && char.IsHighSurrogate(layoutId[head - 1])) head--;
+
+        return $"{layoutId[..head]}{Separator}{digest}";
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/MainService.cs
@@ -378,8 +378,10 @@ public class MainService : ReactiveModel, IMainService
         }
         catch (Exception error)
         {
-            // One failed notification must not stop later daemon events.
-            Debug.WriteLine($"Daemon event handler failed: {error}");
+            // One failed notification must not stop later daemon events — but its reason
+            // has to reach ui.log: a layout rebuild throwing on hot-plug (#589) was
+            // invisible in Release, Debug.WriteLine being compiled out.
+            Console.Error.WriteLine($"Daemon event handler failed: {error}");
         }
     }
 }


### PR DESCRIPTION
Fixes #589.

## Root cause

The reporter's `ui.log` ends with:

```
Boot failed: System.ArgumentException: Registry key names should not be greater than 255 characters. (Parameter 'name')
   at Microsoft.Win32.RegistryKey.OpenSubKey(String name, Boolean writable)
   at LittleBigMouse.Platform.Windows.RegistryLayoutStore.Read(String layoutId, IReadOnlyCollection`1 pnpCodes)
   at LittleBigMouse.Plugins.Persistence.LayoutPersistence.Load(MonitorsLayout layout)
```

`LayoutIdExtensions.ComputeId` joins every monitor id with `+`. A Windows monitor id is `{PnP}{EDID serial}_{week}_{year}_{checksum}`, 26 to 31 characters. `RegistryKey.ValidateKeyName` refuses any path segment over 255 characters, which is also the native Windows limit on a key name.

| Monitors | Layout id length | |
|---|---|---|
| 8 × ~29 chars | ~240 | fits |
| 9 × ~29 chars | ~269 | over 255, `ArgumentException` |

So the "8-monitor limit" is a 255-character limit on the layout key, reached at nine monitors with ordinary EDID serials. Rotation suffixes and the generic-serial de-duplication suffix make an id longer still, so smaller setups can hit it too.

The same read runs on every display change: the rebuild threw on hot-plug and `MainService` swallowed it in a `Debug.WriteLine`, which is compiled out in Release. And `JsonLayoutStore` had the same latent limit: a file name is capped at 255 bytes on every common Linux filesystem, and `WriteJson` swallows the `IOException`, so a nine-monitor layout would have silently never been saved.

## Change

- **`LayoutStoreKey`** (Plugins.Core): the name a layout is stored under. An id that fits is the key itself, so every existing configuration keeps its key. A longer id keeps a readable head and ends with the SHA-256 of the whole id: stable, and distinct between setups that share their first monitors.
- **`RegistryLayoutStore`** derives `Layouts\{key}` from it; **`JsonLayoutStore`** derives the file name with the cap minus `.json`, and its temp twin now has the same length as the final name instead of `.json.tmp` (that one was the first thing to fail at the cap).
- **`LayoutPersistence.Load`** contains a store read failure: the layout loads as on a first run, placed from the system configuration, and the failure is written to `ui.log`. A store that cannot be read must not keep the app from starting.
- **`MainService`** writes a failed daemon-event handler to `Console.Error`, i.e. `ui.log`, instead of `Debug.WriteLine`.

## Tests

- `LayoutStoreKeyTests`: eight monitors keep the historical key, nine fit the cap, readable head, stability, distinct keys for ids differing past the head, store-safe characters, shorter cap honored.
- `JsonLayoutStoreTests.WriteThenRead_NineMonitorId_RoundTrips`: fails before the change (nothing stored), passes after.
- `RegistryLayoutStoreTests.WriteThenRead_NineMonitorId_RoundTrips` (`[WindowsFact]`, runs on `windows-latest` in CI): the exact #589 call, `OpenSubKey` on a nine-monitor id.
- `LayoutPersistenceTests.Load_StoreReadFailure_DoesNotThrowAndLoadsAsAFirstRun`.

Run on Linux: DisplayLayout tests 317 passed, 19 skipped (Windows-only); UI tests 332 passed; `LittleBigMouse.Ui.Avalonia` builds with 0 errors. The registry round-trip is for CI to confirm.

## Not in this PR

- A failed boot still leaves the process alive with no window and no tray icon (`Program.cs` only logs the faulted bootloader task). That is the "process is running in Task Manager" of the report, and deserves its own change.
- `ui.log` keeps a single previous run, so the reporter's two relaunches overwrote the log of the hot-plug failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
