### PR TITLE
fix: a failed boot tells the user and exits instead of lingering (#589)

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BootFailureHandlerTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/BootFailureHandlerTests.cs
@@ -1,0 +1,82 @@
+using LittleBigMouse.Ui.Avalonia.Main;
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// A failed boot must end the process, not park it: the parked process had no window, no
+/// tray icon, and held the single-instance lock, so every relaunch exited silently (#589).
+/// The handler's three steps are log, show, shut down — and the last one has to happen no
+/// matter what the two before it did.
+/// </summary>
+public sealed class BootFailureHandlerTests
+{
+    static readonly Exception Boom =
+        new ArgumentException("Registry key names should not be greater than 255 characters.");
+
+    sealed class Recorder
+    {
+        public readonly List<string> Log = [];
+        public readonly List<string> Steps = [];
+        public Exception? Shown;
+        public int LogLinesWhenShown = -1;
+        public bool DialogThrows;
+        public bool ShutdownThrows;
+
+        public BootFailureHandler Handler => new(
+            log: Log.Add,
+            showAsync: error =>
+            {
+                Shown = error;
+                LogLinesWhenShown = Log.Count;
+                Steps.Add("show");
+                return DialogThrows
+                    ? Task.FromException(new InvalidOperationException("no dispatcher"))
+                    : Task.CompletedTask;
+            },
+            shutdown: () =>
+            {
+                Steps.Add("shutdown");
+                if (ShutdownThrows) throw new InvalidOperationException("already shut down");
+            });
+    }
+
+    [Fact]
+    public async Task LogsThenShowsThenShutsDown()
+    {
+        var recorder = new Recorder();
+
+        await recorder.Handler.HandleAsync(Boom);
+
+        Assert.Equal(["show", "shutdown"], recorder.Steps);
+        Assert.Same(Boom, recorder.Shown);
+
+        // The log line is the one thing that survives the dialog being closed unread:
+        // written first, with the exception in full.
+        var line = Assert.Single(recorder.Log);
+        Assert.StartsWith("Boot failed: ", line);
+        Assert.Contains(Boom.Message, line);
+        Assert.Equal(1, recorder.LogLinesWhenShown);
+    }
+
+    [Fact]
+    public async Task ShutsDownWhenTheDialogCannotBeShown()
+    {
+        var recorder = new Recorder { DialogThrows = true };
+
+        await recorder.Handler.HandleAsync(Boom);
+
+        Assert.Equal("shutdown", recorder.Steps.Last());
+        Assert.Contains(recorder.Log, l => l.StartsWith("Boot failure could not be shown: "));
+    }
+
+    [Fact]
+    public async Task AShutdownFailureIsLoggedNotThrown()
+    {
+        var recorder = new Recorder { ShutdownThrows = true };
+
+        await recorder.Handler.HandleAsync(Boom);
+
+        Assert.Contains(recorder.Log, l => l.StartsWith("Shutdown after boot failure failed: "));
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureHandler.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureHandler.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// What happens when the bootstrapper faults.
+/// <para>
+/// Nothing observed a failed boot while the app was alive: the boot task was only awaited
+/// after app.Run returned, so the process sat there with no window, no tray icon (the tray
+/// is wired after the layout is built) and the single-instance lock held — every relaunch
+/// signaled it and exited. That is "the GUI will no longer launch" next to "the process is
+/// running in Task Manager" (#589, a registry key over 255 characters thrown by the first
+/// layout load), and the only way out was Task Manager.
+/// </para>
+/// <para>
+/// Three steps, each surviving the previous one's failure: log it (ui.log on Windows), show
+/// it, shut the app down. The daemon is left alone on purpose, as on every other way the UI
+/// goes away without the user choosing Exit: whatever it was doing before this failed start
+/// is not this run's to undo, and the next successful start reconnects to it.
+/// </para>
+/// </summary>
+internal sealed class BootFailureHandler(
+    Action<string> log,
+    Func<Exception, Task> showAsync,
+    Action shutdown)
+{
+    public async Task HandleAsync(Exception error)
+    {
+        log($"Boot failed: {error}");
+
+        try
+        {
+            await showAsync(error);
+        }
+        catch (Exception dialogError)
+        {
+            log($"Boot failure could not be shown: {dialogError}");
+        }
+
+        try
+        {
+            shutdown();
+        }
+        catch (Exception shutdownError)
+        {
+            log($"Shutdown after boot failure failed: {shutdownError}");
+        }
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureView.axaml
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureView.axaml
@@ -1,0 +1,54 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="LittleBigMouse.Ui.Avalonia.Main.BootFailureView"
+        Title="LittleBigMouse could not start"
+        Width="620"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="True"
+        WindowStartupLocation="CenterScreen"
+        Background="{DynamicResource Lbm.Brushes.Pane.Background}">
+
+	<StackPanel Margin="24,20" Spacing="14">
+
+		<StackPanel Orientation="Horizontal" Spacing="12">
+			<Path Data="{StaticResource Lbm.Icon.Warning}"
+			      Fill="#E0A030" Width="26" Height="26" Stretch="Uniform"
+			      VerticalAlignment="Center"/>
+			<TextBlock Text="LittleBigMouse could not start"
+			           FontSize="16" FontWeight="SemiBold"
+			           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+			           VerticalAlignment="Center" TextWrapping="Wrap"/>
+		</StackPanel>
+
+		<TextBlock TextWrapping="Wrap" FontSize="13"
+		           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"
+		           Text="An error stopped LittleBigMouse while it was starting. It will close when you dismiss this window. Your saved layouts are untouched."/>
+
+		<Border Background="{DynamicResource Lbm.Brushes.Card.Background}"
+		        BorderBrush="{DynamicResource Lbm.Brushes.Card.Border}"
+		        BorderThickness="1" CornerRadius="6" Padding="14,10">
+			<StackPanel Spacing="6">
+				<TextBlock Text="Details" FontSize="13" FontWeight="SemiBold"
+				           Foreground="{DynamicResource Lbm.Brushes.Text.Primary}"/>
+				<TextBox x:Name="DetailsText" IsReadOnly="True" AcceptsReturn="True"
+				         TextWrapping="Wrap" FontFamily="Consolas, Courier New, monospace" FontSize="11"
+				         MaxHeight="220"/>
+			</StackPanel>
+		</Border>
+
+		<TextBlock x:Name="LogText" TextWrapping="Wrap" FontSize="12"
+		           Foreground="{DynamicResource Lbm.Brushes.Text.Secondary}"/>
+
+		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+			<Button x:Name="CopyButton" MinWidth="110" HorizontalContentAlignment="Center"
+			        Click="OnCopyClick" Content="Copy details"/>
+			<Button x:Name="OpenLogButton" MinWidth="110" HorizontalContentAlignment="Center"
+			        Click="OnOpenLogClick" Content="Open log folder"/>
+			<Button x:Name="CloseButton" IsDefault="True" IsCancel="True"
+			        MinWidth="90" HorizontalContentAlignment="Center"
+			        Click="OnCloseClick" Content="Close"/>
+		</StackPanel>
+
+	</StackPanel>
+</Window>

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureView.axaml.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Main/BootFailureView.axaml.cs
@@ -1,0 +1,81 @@
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace LittleBigMouse.Ui.Avalonia.Main;
+
+/// <summary>
+/// The window a failed start puts up (see <see cref="BootFailureHandler"/>): the exception
+/// as text, ready to be copied into an issue, and where the log went. Nothing else of the
+/// app is on screen at that point, hence a top-level window centered on the screen with a
+/// taskbar entry — it must be findable, it is the only sign the app gives.
+/// </summary>
+public partial class BootFailureView : Window
+{
+    readonly string _details;
+    readonly string? _logFile;
+
+    /// <summary>For the XAML previewer only.</summary>
+    public BootFailureView() : this(new InvalidOperationException("Preview"), null) { }
+
+    public BootFailureView(Exception error, string? logFile)
+    {
+        InitializeComponent();
+
+        _details = error.ToString();
+        _logFile = logFile;
+
+        DetailsText.Text = _details;
+        LogText.Text = logFile is null
+            ? "This report was also written to the standard error output."
+            : $"This report was also written to {logFile}.";
+        OpenLogButton.IsVisible = logFile is not null;
+    }
+
+    /// <summary>Show, and complete once the user has closed it.</summary>
+    public static Task ShowAsync(Exception error, string? logFile)
+    {
+        var view = new BootFailureView(error, logFile);
+        var closed = new TaskCompletionSource();
+        view.Closed += (_, _) => closed.TrySetResult();
+        view.Show();
+        return closed.Task;
+    }
+
+    async void OnCopyClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard is null) return;
+
+            var data = new DataTransfer();
+            data.Add(DataTransferItem.CreateText(_details));
+            await clipboard.SetDataAsync(data);
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine($"Copying the boot failure details failed: {error}");
+        }
+    }
+
+    void OnOpenLogClick(object? sender, RoutedEventArgs e)
+    {
+        if (Path.GetDirectoryName(_logFile) is not { } folder) return;
+        try
+        {
+            Process.Start(new ProcessStartInfo(folder) { UseShellExecute = true });
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine($"Opening the log folder failed: {error}");
+        }
+    }
+
+    void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/Program.cs
@@ -283,11 +283,20 @@ internal class Program
 
             var task = boot.BootAsync();
 
-            // A bootloader failure would otherwise stay invisible until shutdown (the task is
-            // only awaited after app.Run returns) — leaving the app alive with no window and
-            // no tray icon, and nothing to diagnose it with.
+            // A bootloader failure is only awaited after app.Run returns, i.e. never while the
+            // app lives. Logging it was not enough: the process stayed up with no window, no
+            // tray icon (wired after the layout is built) and the single-instance lock held,
+            // so every relaunch signaled it and exited — "the GUI will no longer launch" while
+            // "the process is running" (#589). Tell the user, then leave, like Exit does.
+            var failure = new BootFailureHandler(
+                log: Console.Error.WriteLine,
+                showAsync: error => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                    () => BootFailureView.ShowAsync(error, StartupLog.LogFile)),
+                shutdown: () => global::Avalonia.Threading.Dispatcher.UIThread.BeginInvokeShutdown(
+                    global::Avalonia.Threading.DispatcherPriority.Normal));
+
             task.ContinueWith(
-                t => Console.Error.WriteLine($"Boot failed: {t.Exception?.Flatten().InnerException}"),
+                t => failure.HandleAsync(t.Exception?.Flatten().InnerException ?? t.Exception!),
                 TaskContinuationOptions.OnlyOnFaulted);
 
             try
@@ -299,12 +308,18 @@ internal class Program
                 cts.Cancel();
             }
 
-            try
+            // A faulted boot has been reported and has shut the app down by the time app.Run
+            // returns: waiting on it again would only rethrow into the catch below and put a
+            // crash window on a dispatcher that is gone.
+            if (!task.IsFaulted)
             {
-                task.Wait(cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
+                try
+                {
+                    task.Wait(cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                }
             }
         }
         catch (Exception ex)

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/StartupLog.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/StartupLog.cs
@@ -21,6 +21,12 @@ internal static class StartupLog
 {
     const int STD_ERROR_HANDLE = -12;
 
+    /// <summary>
+    /// Where console output goes while detached; null when a real console or a redirection
+    /// has it. What the boot failure window points the user to.
+    /// </summary>
+    public static string? LogFile { get; private set; }
+
     [DllImport("kernel32.dll")]
     static extern IntPtr GetStdHandle(int nStdHandle);
 
@@ -47,6 +53,7 @@ internal static class StartupLog
 
             Console.SetOut(writer);
             Console.SetError(writer);
+            LogFile = path;
 
             var version = Assembly.GetExecutingAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "?";


### PR DESCRIPTION
Refs #589 — the second half of that report: "the process is running in Task Manager" while "the GUI will no longer launch".

## Problem

`Program.UIMain` starts the bootstrapper, then runs the dispatcher loop; the boot task is only awaited after `app.Run` returns. When a bootloader throws (in #589, the registry key over 255 characters from the first layout load), the failure was logged and nothing else happened:

- no window: `MainBootloader` never reached `ShowControlAsync`;
- no tray icon: `TrayIconController.InitializeAsync` runs after the layout is built;
- the single-instance lock stays held, so every relaunch signals the parked process and exits silently.

The only way out was Task Manager, and the user had no idea why.

## Change

- **`BootFailureHandler`** (`Main/`): the policy, testable without Avalonia. Log the failure, show it, shut the dispatcher down — each step survives the previous one's failure, and shutdown goes through `Dispatcher.UIThread.BeginInvokeShutdown`, the same exit as the tray's Exit. The daemon is deliberately left alone, as on every other way the UI goes away without the user choosing Exit (`DaemonProcessManager`'s documented ownership): whatever it was doing before this failed start is not this run's to undo, and the next successful start reconnects to it.
- **`BootFailureView`** (`Main/`): the exception as selectable text, "Copy details", where the log went (with "Open log folder" when it is a file, i.e. the Windows `ui.log`), Close. Top-level, centered on screen, with a taskbar entry — it is the only sign the app gives at that point.
- **`StartupLog.LogFile`**: the path the detached console output was redirected to, null when a console or a redirection has it.
- **`Program.UIMain`**: composes the handler into the faulted-task continuation, and no longer re-awaits a faulted boot after `app.Run` returns — that rethrew the `AggregateException` into the outer catch and put `ExceptionView` on a dispatcher that was gone.

## Verification

- `BootFailureHandlerTests`: log → show → shutdown order and content; shutdown still happens when the dialog cannot be shown; a shutdown failure is logged, not thrown. UI test suite: 335 passed.
- Live, on Linux (KDE/XWayland), with an isolated instance (own `XDG_RUNTIME_DIR` subdirectory for the lock, own `LBM_HOOK_ENDPOINT`, own `XDG_CONFIG_HOME`/`XDG_DATA_HOME`) and a temporary, uncommitted throw in `UpdateLayout` reproducing the #589 exception: the window came up with the full exception text; closing it through the window manager ended the process in about 500 ms with exit code 0 and released the lock. The log carries the `Boot failed:` trace as before.

## Not in this PR

- `UnixSingleInstanceGuard.TryAcquire` crashes with an unhandled `ArgumentOutOfRangeException` when `XDG_RUNTIME_DIR` is long enough for the socket path to exceed 108 bytes (seen while setting the test up). Unrelated, worth its own guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
