### PR TITLE
fix: keep the logs of the last five runs, not just the last one (#589)

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LogRotationTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LogRotationTests.cs
@@ -105,12 +105,18 @@ public sealed class LogRotationTests : IDisposable
 
         Run("run 1");
         Run("run 2");
-        using var held = new FileStream(Log, FileMode.Open, FileAccess.Write, FileShare.Read);
 
-        Assert.ThrowsAny<IOException>(() => LogRotation.Rotate(Log));
+        using (new FileStream(Log, FileMode.Open, FileAccess.Write, FileShare.Read))
+        {
+            Assert.ThrowsAny<IOException>(() => LogRotation.Rotate(Log));
+
+            // Still in place, and the chain behind it did not move. (ui.log itself is only
+            // readable once the handle is gone: the holder's write access excludes a reader.)
+            Assert.True(File.Exists(Log));
+            Assert.Equal("run 1", Previous(1));
+            Assert.False(File.Exists(LogRotation.PreviousPath(Log, 2)));
+        }
 
         Assert.Equal("run 2", File.ReadAllText(Log));
-        Assert.Equal("run 1", Previous(1));
-        Assert.False(File.Exists(LogRotation.PreviousPath(Log, 2)));
     }
 }

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LogRotationTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/LogRotationTests.cs
@@ -1,0 +1,116 @@
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The startup log keeps the last runs, not just the last one. The run that matters is the
+/// one that failed, and the natural reaction to an app that does not come up is to relaunch
+/// it — twice was enough to lose the log of the hot-plug failure in #589.
+/// </summary>
+public sealed class LogRotationTests : IDisposable
+{
+    readonly string _dir = Path.Combine(Path.GetTempPath(), "lbm-log-rotation-tests", Guid.NewGuid().ToString("N"));
+
+    string Log => Path.Combine(_dir, "ui.log");
+
+    public LogRotationTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { }
+    }
+
+    /// <summary>One run of the app: rotate what is there, then write this run's log.</summary>
+    void Run(string content)
+    {
+        LogRotation.Rotate(Log);
+        File.WriteAllText(Log, content);
+    }
+
+    string Previous(int generation) => File.ReadAllText(LogRotation.PreviousPath(Log, generation));
+
+    [Fact]
+    public void FirstRun_HasNothingToRotate()
+    {
+        LogRotation.Rotate(Log);
+
+        Assert.Empty(Directory.GetFiles(_dir));
+    }
+
+    [Fact]
+    public void GenerationsAreNamedPrevThenNumbered()
+    {
+        // ui.prev.log keeps its historical name: it is what every issue reply asks for.
+        Assert.Equal(Path.Combine(_dir, "ui.prev.log"), LogRotation.PreviousPath(Log, 1));
+        Assert.Equal(Path.Combine(_dir, "ui.prev.2.log"), LogRotation.PreviousPath(Log, 2));
+        Assert.Equal(Path.Combine(_dir, "ui.prev.5.log"), LogRotation.PreviousPath(Log, 5));
+    }
+
+    [Fact]
+    public void TheLastRunBecomesPrev()
+    {
+        Run("run 1");
+        Run("run 2");
+
+        Assert.Equal("run 2", File.ReadAllText(Log));
+        Assert.Equal("run 1", Previous(1));
+        Assert.False(File.Exists(LogRotation.PreviousPath(Log, 2)));
+    }
+
+    [Fact]
+    public void TwoRelaunchesKeepTheRunThatMattered()
+    {
+        // #589: the hot-plug failure, then two boots that failed the same way.
+        Run("hot-plug failure");
+        Run("boot failed");
+        Run("boot failed again");
+
+        Assert.Equal("hot-plug failure", Previous(2));
+    }
+
+    [Fact]
+    public void KeepsFiveRuns_TheOldestFallsOff()
+    {
+        for (var i = 1; i <= 7; i++) Run($"run {i}");
+
+        Assert.Equal("run 7", File.ReadAllText(Log));
+        for (var generation = 1; generation <= LogRotation.Keep; generation++)
+            Assert.Equal($"run {7 - generation}", Previous(generation));
+        Assert.False(File.Exists(LogRotation.PreviousPath(Log, LogRotation.Keep + 1)));
+        Assert.Equal(LogRotation.Keep + 1, Directory.GetFiles(_dir).Length);
+    }
+
+    [Fact]
+    public void AnInterruptedRotationIsFoldedIn()
+    {
+        // A crash between the two moves leaves the last run in the staging file. It must
+        // enter the chain at the next start, not sit there forever.
+        File.WriteAllText(Path.Combine(_dir, "ui.rotating.log"), "interrupted");
+        File.WriteAllText(Log, "current");
+
+        LogRotation.Rotate(Log);
+
+        Assert.Equal("current", Previous(1));
+        Assert.Equal("interrupted", Previous(2));
+        Assert.False(File.Exists(Path.Combine(_dir, "ui.rotating.log")));
+    }
+
+    [Fact]
+    public void ACurrentLogHeldOpen_LeavesTheChainUntouched()
+    {
+        // Windows refuses to move a file another handle holds without FileShare.Delete —
+        // how a second launch finds ui.log, written by the running instance with
+        // FileShare.Read. POSIX renames open files freely: nothing to prove there.
+        if (!OperatingSystem.IsWindows()) return;
+
+        Run("run 1");
+        Run("run 2");
+        using var held = new FileStream(Log, FileMode.Open, FileAccess.Write, FileShare.Read);
+
+        Assert.ThrowsAny<IOException>(() => LogRotation.Rotate(Log));
+
+        Assert.Equal("run 2", File.ReadAllText(Log));
+        Assert.Equal("run 1", Previous(1));
+        Assert.False(File.Exists(LogRotation.PreviousPath(Log, 2)));
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LogRotation.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/LogRotation.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System.IO;
+
+namespace LittleBigMouse.Ui.Avalonia;
+
+/// <summary>
+/// Keeps the logs of the last runs: <c>ui.log</c> is the current run, <c>ui.prev.log</c> the
+/// one before, then <c>ui.prev.2.log</c> … <c>ui.prev.5.log</c>, oldest last.
+/// <para>
+/// One previous generation was not enough. The run that matters is the one that failed,
+/// and relaunching twice is the natural reaction to an app that does not come up: by the
+/// time the reporter of #589 attached the logs, the run with the hot-plug failure had been
+/// overwritten by two failed boots that said the same thing.
+/// </para>
+/// <para>
+/// The current log is taken out of the way <em>first</em>: that is the move that fails while
+/// another instance holds the file open (a second launch, about to exit on the single-instance
+/// guard), and nothing must have shifted by then — the running instance keeps its chain intact.
+/// </para>
+/// </summary>
+internal static class LogRotation
+{
+    /// <summary>How many previous runs are kept.</summary>
+    public const int Keep = 5;
+
+    /// <summary>The file holding the run that ended <paramref name="generation"/> runs ago (1 = the last one).</summary>
+    public static string PreviousPath(string path, int generation)
+    {
+        var dir = Path.GetDirectoryName(path) ?? "";
+        var stem = Path.GetFileNameWithoutExtension(path);
+        var ext = Path.GetExtension(path);
+        return Path.Combine(dir, generation == 1 ? $"{stem}.prev{ext}" : $"{stem}.prev.{generation}{ext}");
+    }
+
+    static string StagingPath(string path)
+        => Path.Combine(Path.GetDirectoryName(path) ?? "", $"{Path.GetFileNameWithoutExtension(path)}.rotating{Path.GetExtension(path)}");
+
+    /// <summary>
+    /// Make room for a new <paramref name="path"/>: the file there becomes the first previous
+    /// generation, every older one moves down, the oldest falls off. Throws when the current
+    /// log cannot be moved (held open by another instance), with the chain untouched.
+    /// </summary>
+    public static void Rotate(string path, int keep = Keep)
+    {
+        var staging = StagingPath(path);
+
+        // A rotation interrupted between the two moves below left the last run in staging:
+        // fold it in rather than leave it orphaned forever.
+        if (File.Exists(staging)) Archive(path, staging, keep);
+
+        if (!File.Exists(path)) return;
+
+        File.Move(path, staging);
+        Archive(path, staging, keep);
+    }
+
+    /// <summary>Shift the chain from the oldest, then file <paramref name="staged"/> as the last run.</summary>
+    static void Archive(string path, string staged, int keep)
+    {
+        for (var generation = keep - 1; generation >= 1; generation--)
+        {
+            var from = PreviousPath(path, generation);
+            if (File.Exists(from)) File.Move(from, PreviousPath(path, generation + 1), overwrite: true);
+        }
+
+        File.Move(staged, PreviousPath(path, 1), overwrite: true);
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/StartupLog.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/StartupLog.cs
@@ -12,8 +12,9 @@ namespace LittleBigMouse.Ui.Avalonia;
 /// (boot failures, unhandled dispatcher exceptions, ViewLocator diagnostics…) is
 /// silently discarded — "the app does nothing and there are no logs anywhere"
 /// (#448, #510). When stderr has no backing handle, console output is routed to
-/// %LOCALAPPDATA%\Mgth\LittleBigMouse\ui.log instead (previous run kept as
-/// ui.prev.log). A real console or an explicit `2&gt; file` redirection provides a
+/// %LOCALAPPDATA%\Mgth\LittleBigMouse\ui.log instead (the previous runs kept as
+/// ui.prev.log, ui.prev.2.log … see <see cref="LogRotation"/>). A real console or an
+/// explicit `2&gt; file` redirection provides a
 /// valid handle and wins over the file. Linux keeps plain stderr (run-lbm.sh and
 /// the desktop session already capture it).
 /// </summary>
@@ -41,11 +42,10 @@ internal static class StartupLog
 
             Directory.CreateDirectory(LbmPaths.DataDir);
             var path = Path.Combine(LbmPaths.DataDir, "ui.log");
-            var prev = Path.Combine(LbmPaths.DataDir, "ui.prev.log");
 
             // Throws while another instance holds ui.log open: that instance owns
             // the log and this one is about to exit on the single-instance guard.
-            if (File.Exists(path)) File.Move(path, prev, overwrite: true);
+            LogRotation.Rotate(path);
 
             var writer = new StreamWriter(
                 new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read))


### PR DESCRIPTION
Refs #589 — the last loose end of that report.

## Problem

`StartupLog` rotated `ui.log` into a single `ui.prev.log`. The run that matters is the one that failed, and relaunching twice is the natural reaction to an app that does not come up: by the time the reporter attached the logs, the run with the hot-plug failure (the `DesktopChanged` at 17:39 in `daemon-events.log`) had been overwritten by two failed boots saying the same thing.

## Change

- **`LogRotation`**: `ui.log` → `ui.prev.log` → `ui.prev.2.log` … `ui.prev.5.log`, the oldest falling off. `ui.prev.log` keeps its historical name, it is what every issue reply asks for.
- The current log is moved out of the way **first**, into a staging name. That is the move that fails while another instance holds the file open (a second launch, about to exit on the single-instance guard), so nothing has shifted by then and the running instance's chain stays intact — the behavior `StartupLog` already relied on, now with the ordering it needs.
- A rotation interrupted between its two moves leaves the last run in the staging file; it is folded into the chain at the next start rather than orphaned.
- `StartupLog` calls the rotation; the rest is unchanged (Windows only, when stderr is detached).

## Tests

`LogRotationTests`: first run, generation names, last run becomes `prev`, the #589 sequence (failure + two relaunches keeps the failure at `ui.prev.2.log`), five kept and the oldest dropped, interrupted rotation folded in, and — on Windows, where an open file cannot be moved — a held `ui.log` throws with the chain untouched. UI suite: 342 passed on Linux; the held-open case runs in CI on `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
