### PR TITLE
fix: the Linux single-instance guard survives a runtime dir too long for a socket

### DIFF
--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UnixInstancePathsTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UnixInstancePathsTests.cs
@@ -1,0 +1,135 @@
+using Xunit;
+
+namespace LittleBigMouse.Ui.Avalonia.Tests;
+
+/// <summary>
+/// The Unix guard's paths. A unix domain socket path is capped at 108 bytes, and an
+/// XDG_RUNTIME_DIR long enough to break that used to crash the app out of Main with an
+/// unhandled ArgumentOutOfRangeException, before any window existed. The lock is the guard
+/// and stays where it is; the socket is the courtesy and may move, or go.
+/// </summary>
+public sealed class UnixInstancePathsTests : IDisposable
+{
+    readonly string _root = Path.Combine(Path.GetTempPath(), "lbm-guard-tests", Guid.NewGuid().ToString("N"));
+
+    public UnixInstancePathsTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, true); } catch { }
+    }
+
+    /// <summary>An existing directory whose path is at least that many characters long.</summary>
+    string DirOfLength(int length)
+    {
+        var dir = Path.Combine(_root, new string('x', Math.Max(1, length - _root.Length - 1)));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void ShortRuntimeDir_HoldsBoth()
+    {
+        var runtime = DirOfLength(60);
+
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, _root, "me");
+
+        Assert.Equal(Path.Combine(runtime, "littlebigmouse.lock"), lockPath);
+        Assert.Equal(Path.Combine(runtime, "littlebigmouse-show.sock"), socketPath);
+    }
+
+    [Fact]
+    public void LongRuntimeDir_KeepsTheLock_MovesTheSocketToAPrivateTempDir()
+    {
+        var runtime = DirOfLength(120);
+
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, _root, "me");
+
+        Assert.Equal(Path.Combine(runtime, "littlebigmouse.lock"), lockPath);
+        Assert.Equal(Path.Combine(_root, "littlebigmouse-me", "littlebigmouse-show.sock"), socketPath);
+        Assert.True(UnixInstancePaths.Fits(socketPath!));
+    }
+
+    [Fact]
+    public void NoDirShortEnough_DropsTheSocket_NotTheLock()
+    {
+        var runtime = DirOfLength(120);
+        var temp = DirOfLength(130);
+
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, temp, "me");
+
+        Assert.Equal(Path.Combine(runtime, "littlebigmouse.lock"), lockPath);
+        Assert.Null(socketPath);
+    }
+
+    [Fact]
+    public void MissingRuntimeDir_FallsBackToTemp()
+    {
+        var expectedLock = Path.Combine(_root, "littlebigmouse.lock");
+
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(null, _root, "me").LockPath);
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve("", _root, "me").LockPath);
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(Path.Combine(_root, "missing"), _root, "me").LockPath);
+        Assert.Equal(Path.Combine(_root, "littlebigmouse-show.sock"), UnixInstancePaths.Resolve(null, _root, "me").SocketPath);
+    }
+
+    [Fact]
+    public void Fits_IsMeasuredInBytes()
+    {
+        Assert.True(UnixInstancePaths.Fits(new string('a', 107)));
+        Assert.False(UnixInstancePaths.Fits(new string('a', 108)));
+        // 60 characters, 120 bytes.
+        Assert.False(UnixInstancePaths.Fits(new string('é', 60)));
+    }
+
+    [Fact]
+    public void LongRuntimeDir_StillAcquiresTheInstance()
+    {
+        // The crash seen while setting up the #589 verification: TryAcquire threw out of Main.
+        // Now: a guard, a lock that refuses a second acquire, a socket in the fallback dir.
+        if (OperatingSystem.IsWindows()) return;
+
+        var runtime = DirOfLength(120);
+        var fallbackSocket = Path.Combine(_root, $"littlebigmouse-{Environment.UserName}", "littlebigmouse-show.sock");
+
+        var guard = SingleInstanceGuard.TryAcquireUnix(runtime, _root);
+        Assert.NotNull(guard);
+        try
+        {
+            Assert.Null(SingleInstanceGuard.TryAcquireUnix(runtime, _root));
+            Assert.True(File.Exists(fallbackSocket));
+        }
+        finally
+        {
+            guard!.Dispose();
+        }
+
+        Assert.False(File.Exists(Path.Combine(runtime, "littlebigmouse.lock")));
+        Assert.False(File.Exists(fallbackSocket));
+    }
+
+    [Fact]
+    public void NoSocketAtAll_StillAcquiresTheInstance()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var runtime = DirOfLength(120);
+        var temp = DirOfLength(130);
+
+        var guard = SingleInstanceGuard.TryAcquireUnix(runtime, temp);
+        Assert.NotNull(guard);
+        try
+        {
+            Assert.Null(SingleInstanceGuard.TryAcquireUnix(runtime, temp));
+        }
+        finally
+        {
+            guard!.Dispose();
+        }
+
+        // After release a fresh acquire succeeds again: the lock really came back.
+        var again = SingleInstanceGuard.TryAcquireUnix(runtime, temp);
+        Assert.NotNull(again);
+        again!.Dispose();
+    }
+}

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UnixInstancePathsTests.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia.Tests/UnixInstancePathsTests.cs
@@ -10,7 +10,13 @@ namespace LittleBigMouse.Ui.Avalonia.Tests;
 /// </summary>
 public sealed class UnixInstancePathsTests : IDisposable
 {
-    readonly string _root = Path.Combine(Path.GetTempPath(), "lbm-guard-tests", Guid.NewGuid().ToString("N"));
+    // Short, so the fallback socket path fits whatever the user name (Linux, where the
+    // end-to-end tests create files here).
+    readonly string _root = Path.Combine(Path.GetTempPath(), "lbm-guard-tests", Guid.NewGuid().ToString("N")[..8]);
+
+    // An existing directory short enough for a socket on every platform. The temp path is
+    // not: on the Windows CI runner it alone is longer than a socket path may be.
+    readonly string _short = Path.GetPathRoot(Path.GetTempPath())!;
 
     public UnixInstancePathsTests() => Directory.CreateDirectory(_root);
 
@@ -30,12 +36,10 @@ public sealed class UnixInstancePathsTests : IDisposable
     [Fact]
     public void ShortRuntimeDir_HoldsBoth()
     {
-        var runtime = DirOfLength(60);
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(_short, _root, "me");
 
-        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, _root, "me");
-
-        Assert.Equal(Path.Combine(runtime, "littlebigmouse.lock"), lockPath);
-        Assert.Equal(Path.Combine(runtime, "littlebigmouse-show.sock"), socketPath);
+        Assert.Equal(Path.Combine(_short, "littlebigmouse.lock"), lockPath);
+        Assert.Equal(Path.Combine(_short, "littlebigmouse-show.sock"), socketPath);
     }
 
     [Fact]
@@ -43,10 +47,10 @@ public sealed class UnixInstancePathsTests : IDisposable
     {
         var runtime = DirOfLength(120);
 
-        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, _root, "me");
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtime, _short, "me");
 
         Assert.Equal(Path.Combine(runtime, "littlebigmouse.lock"), lockPath);
-        Assert.Equal(Path.Combine(_root, "littlebigmouse-me", "littlebigmouse-show.sock"), socketPath);
+        Assert.Equal(Path.Combine(_short, "littlebigmouse-me", "littlebigmouse-show.sock"), socketPath);
         Assert.True(UnixInstancePaths.Fits(socketPath!));
     }
 
@@ -65,12 +69,12 @@ public sealed class UnixInstancePathsTests : IDisposable
     [Fact]
     public void MissingRuntimeDir_FallsBackToTemp()
     {
-        var expectedLock = Path.Combine(_root, "littlebigmouse.lock");
+        var expectedLock = Path.Combine(_short, "littlebigmouse.lock");
 
-        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(null, _root, "me").LockPath);
-        Assert.Equal(expectedLock, UnixInstancePaths.Resolve("", _root, "me").LockPath);
-        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(Path.Combine(_root, "missing"), _root, "me").LockPath);
-        Assert.Equal(Path.Combine(_root, "littlebigmouse-show.sock"), UnixInstancePaths.Resolve(null, _root, "me").SocketPath);
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(null, _short, "me").LockPath);
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve("", _short, "me").LockPath);
+        Assert.Equal(expectedLock, UnixInstancePaths.Resolve(Path.Combine(_root, "missing"), _short, "me").LockPath);
+        Assert.Equal(Path.Combine(_short, "littlebigmouse-show.sock"), UnixInstancePaths.Resolve(null, _short, "me").SocketPath);
     }
 
     [Fact]

--- a/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/SingleInstance.cs
+++ b/LittleBigMouse.Ui/LittleBigMouse.Ui.Avalonia/SingleInstance.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Threading;
 
 namespace LittleBigMouse.Ui.Avalonia;
@@ -13,7 +14,8 @@ namespace LittleBigMouse.Ui.Avalonia;
 /// instance receives that signal through <see cref="ShowRequested"/> (raised on a background
 /// thread; marshal to the UI thread before touching views).
 /// Windows: named Mutex + named EventWaitHandle (unchanged historical behavior).
-/// Linux: exclusive lock file + unix domain socket, both in XDG_RUNTIME_DIR.
+/// Linux: exclusive lock file + unix domain socket in XDG_RUNTIME_DIR — see
+/// <see cref="UnixInstancePaths"/> for where the socket goes when that path is too long for one.
 /// </summary>
 internal abstract class SingleInstanceGuard : IDisposable
 {
@@ -25,6 +27,11 @@ internal abstract class SingleInstanceGuard : IDisposable
         => OperatingSystem.IsWindows()
             ? WindowsSingleInstanceGuard.TryAcquire()
             : UnixSingleInstanceGuard.TryAcquire();
+
+    /// <summary>The Unix guard over explicit directories, for tests: no environment mutation.</summary>
+    [UnsupportedOSPlatform("windows")]
+    internal static SingleInstanceGuard? TryAcquireUnix(string? runtimeDir, string tempDir)
+        => UnixSingleInstanceGuard.TryAcquire(runtimeDir, tempDir);
 
     public abstract void Dispose();
 }
@@ -86,33 +93,71 @@ file sealed class WindowsSingleInstanceGuard : SingleInstanceGuard
     }
 }
 
+/// <summary>
+/// Where the Unix guard puts its two files. The lock file can live anywhere; the socket
+/// cannot: a unix domain socket path is capped at <see cref="MaxSocketPathBytes"/> bytes
+/// (<c>sun_path</c>), and an XDG_RUNTIME_DIR long enough to break that — a sandbox, a test
+/// runner, a nested session — used to take the whole app down with an unhandled
+/// <see cref="ArgumentOutOfRangeException"/> out of Main, before anything was on screen.
+/// <para>
+/// The socket then falls back to a private per-user directory under the temp path, the
+/// classic stand-in for a runtime dir. When even that is too long the guard runs without
+/// it: still single-instance (the lock is the guard), only the "show your window" nudge to
+/// the running instance is lost.
+/// </para>
+/// </summary>
+internal static class UnixInstancePaths
+{
+    /// <summary>
+    /// <c>sizeof(sun_path)</c> is 108 on Linux, terminator included. .NET checks the UTF-8
+    /// length against 108; one less keeps the terminator out of the count everywhere.
+    /// </summary>
+    public const int MaxSocketPathBytes = 107;
+
+    public const string LockFile = "littlebigmouse.lock";
+    public const string SocketFile = "littlebigmouse-show.sock";
+
+    /// <summary>The lock path, and the socket path when a short enough one exists.</summary>
+    public static (string LockPath, string? SocketPath) Resolve(string? runtimeDir, string tempDir, string userName)
+    {
+        var baseDir = runtimeDir is { Length: > 0 } && Directory.Exists(runtimeDir) ? runtimeDir : tempDir;
+        var lockPath = Path.Combine(baseDir, LockFile);
+
+        var socketPath = Path.Combine(baseDir, SocketFile);
+        if (Fits(socketPath)) return (lockPath, socketPath);
+
+        var fallback = Path.Combine(tempDir, $"littlebigmouse-{userName}", SocketFile);
+        return (lockPath, Fits(fallback) ? fallback : null);
+    }
+
+    public static bool Fits(string socketPath) => Encoding.UTF8.GetByteCount(socketPath) <= MaxSocketPathBytes;
+}
+
 [UnsupportedOSPlatform("windows")]
 file sealed class UnixSingleInstanceGuard : SingleInstanceGuard
 {
     readonly FileStream _lock;
-    readonly Socket _listener;
-    readonly string _socketPath;
+    readonly Socket? _listener;
+    readonly string? _socketPath;
     int _disposed;
 
-    UnixSingleInstanceGuard(FileStream fileLock, Socket listener, string socketPath)
+    UnixSingleInstanceGuard(FileStream fileLock, Socket? listener, string? socketPath)
     {
         _lock = fileLock;
         _listener = listener;
         _socketPath = socketPath;
 
+        if (listener is null) return;
         var thread = new Thread(AcceptLoop) { IsBackground = true, Name = "SingleInstance" };
         thread.Start();
     }
 
-    static string RuntimeDir
-        => Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR") is { Length: > 0 } dir && Directory.Exists(dir)
-            ? dir
-            : Path.GetTempPath();
-
     public static new SingleInstanceGuard? TryAcquire()
+        => TryAcquire(Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR"), Path.GetTempPath());
+
+    public static SingleInstanceGuard? TryAcquire(string? runtimeDir, string tempDir)
     {
-        var lockPath = Path.Combine(RuntimeDir, "littlebigmouse.lock");
-        var socketPath = Path.Combine(RuntimeDir, "littlebigmouse-show.sock");
+        var (lockPath, socketPath) = UnixInstancePaths.Resolve(runtimeDir, tempDir, Environment.UserName);
 
         FileStream fileLock;
         try
@@ -122,23 +167,59 @@ file sealed class UnixSingleInstanceGuard : SingleInstanceGuard
         catch (IOException)
         {
             // Another instance holds the lock: ask it to show its window, then exit.
-            try
+            if (socketPath is not null)
             {
-                using var client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-                client.Connect(new UnixDomainSocketEndPoint(socketPath));
+                try
+                {
+                    using var client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                    client.Connect(new UnixDomainSocketEndPoint(socketPath));
+                }
+                catch { }
             }
-            catch { }
             return null;
         }
 
-        // We own the instance: a leftover socket file from a crashed run would fail the bind.
-        File.Delete(socketPath);
+        return new UnixSingleInstanceGuard(fileLock, Listen(socketPath), socketPath);
+    }
 
-        var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-        listener.Bind(new UnixDomainSocketEndPoint(socketPath));
-        listener.Listen(1);
+    /// <summary>
+    /// The "show your window" listener, or null when no socket path is short enough or the
+    /// bind fails. The lock already made this the instance; losing the nudge is not worth
+    /// losing the app, which is what an exception here used to do.
+    /// </summary>
+    static Socket? Listen(string? socketPath)
+    {
+        if (socketPath is null)
+        {
+            Console.Error.WriteLine(
+                "Single instance: no directory short enough for a unix socket; a second launch will not be able to show this window.");
+            return null;
+        }
 
-        return new UnixSingleInstanceGuard(fileLock, listener, socketPath);
+        Socket? listener = null;
+        try
+        {
+            // Only the fallback directory is ours to create. Private: anyone who can connect
+            // can pop the window.
+            var dir = Path.GetDirectoryName(socketPath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            // We own the instance: a leftover socket file from a crashed run would fail the bind.
+            File.Delete(socketPath);
+
+            listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(socketPath));
+            listener.Listen(1);
+            return listener;
+        }
+        catch (Exception error)
+        {
+            listener?.Dispose();
+            Console.Error.WriteLine(
+                $"Single instance: the show-window socket could not be set up at '{socketPath}'; a second launch will not be able to show this window: {error.Message}");
+            return null;
+        }
     }
 
     void AcceptLoop()
@@ -147,7 +228,7 @@ file sealed class UnixSingleInstanceGuard : SingleInstanceGuard
         {
             try
             {
-                using var client = _listener.Accept();
+                using var client = _listener!.Accept();
                 RaiseShowRequested();
             }
             catch (SocketException)
@@ -167,8 +248,11 @@ file sealed class UnixSingleInstanceGuard : SingleInstanceGuard
         // deleting the socket/lock files twice could race a fresh instance that just re-created them.
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
-        _listener.Dispose();
-        try { File.Delete(_socketPath); } catch { }
+        _listener?.Dispose();
+        if (_socketPath is not null)
+        {
+            try { File.Delete(_socketPath); } catch { }
+        }
         _lock.Dispose();
         try { File.Delete(_lock.Name); } catch { }
     }


### PR DESCRIPTION
Noticed while setting up the live verification of #604: the isolated test instance got an `XDG_RUNTIME_DIR` under the session scratchpad, and the app died before `Main` had put anything on screen:

```
Unhandled exception. System.ArgumentOutOfRangeException: The path '…/lbm-test-runtime/littlebigmouse-show.sock' is of an invalid length for use with domain sockets on this platform. The length must be between 1 and 108 characters, inclusive.
   at System.Net.Sockets.UnixDomainSocketEndPoint..ctor(String path, String boundFileName)
   at LittleBigMouse.Ui.Avalonia.<…>UnixSingleInstanceGuard.TryAcquire()
   at LittleBigMouse.Ui.Avalonia.Program.Main(String[] args)
```

A unix domain socket path is capped at 108 bytes (`sun_path`). A runtime dir long enough to pass that is unusual — a sandbox, a test runner, a nested session — but the outcome was a crash with nothing to see, on the one code path that runs before any window or log exists.

## Change

- **`UnixInstancePaths`** (in `SingleInstance.cs`): the lock file stays in the runtime dir — it has no length limit, and it is the guard. The socket, the "show your window" courtesy to a second launch, falls back to a private per-user directory under the temp path (`littlebigmouse-<user>/`, created 0700), and is dropped when even that is too long: still single-instance, only the nudge is lost, and the log says so.
- **`UnixSingleInstanceGuard`**: the socket setup is contained. A failed bind — path, permissions, a squatted fallback dir — logs and leaves a guard without a listener instead of throwing out of `Main`. The second-launch side already swallowed its connect failure; it now also skips the connect when there is no socket path.
- **`SingleInstanceGuard.TryAcquireUnix(runtimeDir, tempDir)`**, internal, so the scenario is provable without mutating the process environment (the existing guard tests run against the real `XDG_RUNTIME_DIR` in parallel).

Nothing changes when the runtime dir is short, i.e. everywhere `/run/user/<uid>` is in use: same lock, same socket, same names.

## Tests

`UnixInstancePathsTests`: short dir holds both; long dir keeps the lock and moves the socket to the private temp dir; no short dir at all drops the socket, not the lock; missing or empty `XDG_RUNTIME_DIR` falls back to temp as before; the cap is measured in UTF-8 bytes; and, on Linux, the two end-to-end cases — a long runtime dir still acquires the instance (second acquire refused, fallback socket present, both files gone after dispose), and a guard with no socket at all still enforces single instance. UI suite: 349 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
